### PR TITLE
Revert "[#1895] Stopping the aca-py shell process keeps python process running"

### DIFF
--- a/bin/aca-py
+++ b/bin/aca-py
@@ -7,4 +7,4 @@ if [ -z "$PYTHON" ]; then
     fi
 fi
 
-exec $PYTHON -m aries_cloudagent "$@"
+$PYTHON -m aries_cloudagent "$@"


### PR DESCRIPTION
This reverts commit 67db5de43770933efd8cbc816ffb5d3850fa5785.