### PR TITLE
:sparkles: Add ordering options to askar scan and fetch_all methods

### DIFF
--- a/acapy_agent/connections/routes.py
+++ b/acapy_agent/connections/routes.py
@@ -250,20 +250,6 @@ class EndpointsResultSchema(OpenAPISchema):
     )
 
 
-def connection_sort_key(conn):
-    """Get the sorting key for a particular connection."""
-
-    conn_rec_state = ConnRecord.State.get(conn["state"])
-    if conn_rec_state is ConnRecord.State.ABANDONED:
-        pfx = "2"
-    elif conn_rec_state is ConnRecord.State.INVITATION:
-        pfx = "1"
-    else:
-        pfx = "0"
-
-    return pfx + conn["created_at"]
-
-
 @docs(
     tags=["connection"],
     summary="Query agent-to-agent connections",
@@ -324,7 +310,6 @@ async def connections_list(request: web.BaseRequest):
                 alt=True,
             )
         results = [record.serialize() for record in records]
-        results.sort(key=connection_sort_key)
     except (StorageError, BaseModelError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 

--- a/acapy_agent/connections/routes.py
+++ b/acapy_agent/connections/routes.py
@@ -16,7 +16,10 @@ from ..cache.base import BaseCache
 from ..connections.models.conn_record import ConnRecord, ConnRecordSchema
 from ..messaging.models.base import BaseModelError
 from ..messaging.models.openapi import OpenAPISchema
-from ..messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
+from ..messaging.models.paginated_query import (
+    PaginatedQuerySchema,
+    get_paginated_query_params,
+)
 from ..messaging.valid import (
     ENDPOINT_EXAMPLE,
     ENDPOINT_VALIDATE,
@@ -305,7 +308,7 @@ async def connections_list(request: web.BaseRequest):
     if request.query.get("connection_protocol"):
         post_filter["connection_protocol"] = request.query["connection_protocol"]
 
-    limit, offset = get_limit_offset(request)
+    limit, offset, order_by, descending = get_paginated_query_params(request)
 
     profile = context.profile
     try:
@@ -315,6 +318,8 @@ async def connections_list(request: web.BaseRequest):
                 tag_filter,
                 limit=limit,
                 offset=offset,
+                order_by=order_by,
+                descending=descending,
                 post_filter_positive=post_filter,
                 alt=True,
             )

--- a/acapy_agent/connections/tests/test_routes.py
+++ b/acapy_agent/connections/tests/test_routes.py
@@ -100,6 +100,8 @@ class TestConnectionRoutes(IsolatedAsyncioTestCase):
                     },
                     limit=100,
                     offset=0,
+                    order_by="id",
+                    descending=False,
                     post_filter_positive={
                         "their_role": list(ConnRecord.Role.REQUESTER.value),
                         "connection_protocol": "connections/1.0",

--- a/acapy_agent/connections/tests/test_routes.py
+++ b/acapy_agent/connections/tests/test_routes.py
@@ -86,7 +86,7 @@ class TestConnectionRoutes(IsolatedAsyncioTestCase):
                     )
                 ),
             ]
-            mock_conn_rec.query.return_value = [conns[2], conns[0], conns[1]]  # jumbled
+            mock_conn_rec.query.return_value = conns
 
             with mock.patch.object(test_module.web, "json_response") as mock_response:
                 await test_module.connections_list(self.request)

--- a/acapy_agent/messaging/models/base_record.py
+++ b/acapy_agent/messaging/models/base_record.py
@@ -293,6 +293,8 @@ class BaseRecord(BaseModel):
         *,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        order_by: Optional[str] = None,
+        descending: bool = False,
         post_filter_positive: Optional[dict] = None,
         post_filter_negative: Optional[dict] = None,
         alt: bool = False,
@@ -304,6 +306,8 @@ class BaseRecord(BaseModel):
             tag_filter: An optional dictionary of tag filter clauses
             limit: The maximum number of records to retrieve
             offset: The offset to start retrieving records from
+            order_by: An optional field by which to order the records.
+            descending: Whether to order the records in descending order.
             post_filter_positive: Additional value filters to apply matching positively
             post_filter_negative: Additional value filters to apply matching negatively
             alt: set to match any (positive=True) value or miss all (positive=False)
@@ -327,11 +331,15 @@ class BaseRecord(BaseModel):
                 tag_query=tag_query,
                 limit=limit,
                 offset=offset,
+                order_by=order_by,
+                descending=descending,
             )
         else:
             rows = await storage.find_all_records(
                 type_filter=cls.RECORD_TYPE,
                 tag_query=tag_query,
+                order_by=order_by,
+                descending=descending,
             )
 
         num_results_post_filter = 0  # used if applying pagination post-filter

--- a/acapy_agent/messaging/models/paginated_query.py
+++ b/acapy_agent/messaging/models/paginated_query.py
@@ -27,12 +27,14 @@ class PaginatedQuerySchema(OpenAPISchema):
     )
     order_by = fields.Str(
         required=False,
-        load_default=None,
-        dump_only=True,  # Hide from schema by making it dump-only
-        load_only=True,  # Ensure it can still be loaded/validated
-        validate=OneOf(["id"]),  # Example of possible fields
-        metadata={"description": "Order results in descending order if true"},
-        error_messages={"validator_failed": "Ordering only support for column `id`"},
+        load_default="id",
+        validate=OneOf(["id"]),  # only one possible column supported in askar
+        metadata={
+            "description": (
+                'The column to order results by. Only "id" is currently supported.'
+            )
+        },
+        error_messages={"validator_failed": '`order_by` only supports column "id"'},
     )
     descending = fields.Bool(
         required=False,

--- a/acapy_agent/messaging/models/paginated_query.py
+++ b/acapy_agent/messaging/models/paginated_query.py
@@ -41,16 +41,22 @@ class PaginatedQuerySchema(OpenAPISchema):
     )
 
 
-def get_limit_offset(request: BaseRequest) -> Tuple[int, int]:
-    """Read the limit and offset query parameters from a request as ints, with defaults.
+def get_paginated_query_params(request: BaseRequest) -> Tuple[int, int, str, bool]:
+    """Read the limit, offset, order_by, and descending query parameters from a request.
 
     Args:
-        request: aiohttp request object
+        request: aiohttp request object.
 
     Returns:
-        A tuple of the limit and offset values
+        A tuple containing:
+        - limit (int): The number of results to return, defaulting to DEFAULT_PAGE_SIZE.
+        - offset (int): The offset for pagination, defaulting to 0.
+        - order_by (str): The field by which to order results, defaulting to "id".
+        - descending (bool): Whether to order results in descending order, defaulting to False.
     """
 
     limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
     offset = int(request.query.get("offset", 0))
-    return limit, offset
+    order_by = request.query.get("order_by", "id")
+    descending = bool(request.query.get("descending", False))
+    return limit, offset, order_by, descending

--- a/acapy_agent/messaging/models/paginated_query.py
+++ b/acapy_agent/messaging/models/paginated_query.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 from aiohttp.web import BaseRequest
 from marshmallow import fields
-from marshmallow.validate import Range
+from marshmallow.validate import OneOf, Range
 
 from ...messaging.models.openapi import OpenAPISchema
 from ...storage.base import DEFAULT_PAGE_SIZE, MAXIMUM_PAGE_SIZE
@@ -24,6 +24,20 @@ class PaginatedQuerySchema(OpenAPISchema):
         load_default=0,
         validate=Range(min=0),
         metadata={"description": "Offset for pagination", "example": 0},
+    )
+    order_by = fields.Str(
+        required=False,
+        load_default=None,
+        dump_only=True,  # Hide from schema by making it dump-only
+        load_only=True,  # Ensure it can still be loaded/validated
+        validate=OneOf(["id"]),  # Example of possible fields
+        metadata={"description": "Order results in descending order if true"},
+        error_messages={"validator_failed": "Ordering only support for column `id`"},
+    )
+    descending = fields.Bool(
+        required=False,
+        load_default=False,
+        metadata={"description": "Order results in descending order if true"},
     )
 
 

--- a/acapy_agent/messaging/models/paginated_query.py
+++ b/acapy_agent/messaging/models/paginated_query.py
@@ -52,7 +52,7 @@ def get_paginated_query_params(request: BaseRequest) -> Tuple[int, int, str, boo
         - limit (int): The number of results to return, defaulting to DEFAULT_PAGE_SIZE.
         - offset (int): The offset for pagination, defaulting to 0.
         - order_by (str): The field by which to order results, defaulting to "id".
-        - descending (bool): Whether to order results in descending order, defaulting to False.
+        - descending (bool): Order results in descending order; defaults to False.
     """
 
     limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))

--- a/acapy_agent/messaging/models/paginated_query.py
+++ b/acapy_agent/messaging/models/paginated_query.py
@@ -39,7 +39,10 @@ class PaginatedQuerySchema(OpenAPISchema):
     descending = fields.Bool(
         required=False,
         load_default=False,
+        truthy={"true", "1", "yes"},
+        falsy={"false", "0", "no"},
         metadata={"description": "Order results in descending order if true"},
+        error_messages={"invalid": "Not a valid boolean."},
     )
 
 
@@ -60,5 +63,9 @@ def get_paginated_query_params(request: BaseRequest) -> Tuple[int, int, str, boo
     limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
     offset = int(request.query.get("offset", 0))
     order_by = request.query.get("order_by", "id")
-    descending = bool(request.query.get("descending", False))
+
+    # Convert the 'descending' parameter to a boolean
+    descending_str = request.query.get("descending", "False").lower()
+    descending = descending_str in {"true", "1", "yes"}
+
     return limit, offset, order_by, descending

--- a/acapy_agent/messaging/models/tests/test_base_record.py
+++ b/acapy_agent/messaging/models/tests/test_base_record.py
@@ -164,6 +164,8 @@ class TestBaseRecord(IsolatedAsyncioTestCase):
             result = await BaseRecordImpl.query(session, tag_filter)
             mock_storage.find_all_records.assert_awaited_once_with(
                 type_filter=BaseRecordImpl.RECORD_TYPE,
+                order_by=None,
+                descending=False,
                 tag_query=tag_filter,
             )
             assert result and isinstance(result[0], BaseRecordImpl)
@@ -215,6 +217,8 @@ class TestBaseRecord(IsolatedAsyncioTestCase):
             )
             mock_storage.find_all_records.assert_awaited_once_with(
                 type_filter=ARecordImpl.RECORD_TYPE,
+                order_by=None,
+                descending=False,
                 tag_query=tag_filter,
             )
             assert result and isinstance(result[0], ARecordImpl)
@@ -339,6 +343,8 @@ class TestBaseRecord(IsolatedAsyncioTestCase):
                 tag_query=tag_filter,
                 limit=10,
                 offset=0,
+                order_by=None,
+                descending=False,
             )
             assert result and isinstance(result[0], ARecordImpl)
             assert result[0]._id == record_id
@@ -369,6 +375,8 @@ class TestBaseRecord(IsolatedAsyncioTestCase):
                 tag_query=tag_filter,
                 limit=DEFAULT_PAGE_SIZE,
                 offset=10,
+                order_by=None,
+                descending=False,
             )
             assert result and isinstance(result[0], ARecordImpl)
             assert result[0]._id == record_id
@@ -399,6 +407,8 @@ class TestBaseRecord(IsolatedAsyncioTestCase):
                 tag_query=tag_filter,
                 limit=10,
                 offset=5,
+                order_by=None,
+                descending=False,
             )
             assert result and isinstance(result[0], ARecordImpl)
             assert result[0]._id == record_id
@@ -433,7 +443,10 @@ class TestBaseRecord(IsolatedAsyncioTestCase):
                 post_filter_positive={"a": "one"},
             )
             mock_storage.find_all_records.assert_awaited_once_with(
-                type_filter=ARecordImpl.RECORD_TYPE, tag_query=tag_filter
+                type_filter=ARecordImpl.RECORD_TYPE,
+                order_by=None,
+                descending=False,
+                tag_query=tag_filter,
             )
             assert len(result) == 10
             assert result and isinstance(result[0], ARecordImpl)

--- a/acapy_agent/multitenant/admin/routes.py
+++ b/acapy_agent/multitenant/admin/routes.py
@@ -397,7 +397,6 @@ async def wallets_list(request: web.BaseRequest):
                 descending=descending,
             )
         results = [format_wallet_record(record) for record in records]
-        results.sort(key=lambda w: w["created_at"])
     except (StorageError, BaseModelError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 

--- a/acapy_agent/multitenant/admin/routes.py
+++ b/acapy_agent/multitenant/admin/routes.py
@@ -16,7 +16,10 @@ from ...core.error import BaseError
 from ...core.profile import ProfileManagerProvider
 from ...messaging.models.base import BaseModelError
 from ...messaging.models.openapi import OpenAPISchema
-from ...messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
+from ...messaging.models.paginated_query import (
+    PaginatedQuerySchema,
+    get_paginated_query_params,
+)
 from ...messaging.valid import UUID4_EXAMPLE, JSONWebToken
 from ...multitenant.base import BaseMultitenantManager
 from ...storage.error import StorageError, StorageNotFoundError
@@ -381,7 +384,7 @@ async def wallets_list(request: web.BaseRequest):
     if wallet_name:
         query["wallet_name"] = wallet_name
 
-    limit, offset = get_limit_offset(request)
+    limit, offset, order_by, descending = get_paginated_query_params(request)
 
     try:
         async with profile.session() as session:
@@ -390,6 +393,8 @@ async def wallets_list(request: web.BaseRequest):
                 tag_filter=query,
                 limit=limit,
                 offset=offset,
+                order_by=order_by,
+                descending=descending,
             )
         results = [format_wallet_record(record) for record in records]
         results.sort(key=lambda w: w["created_at"])

--- a/acapy_agent/multitenant/admin/tests/test_routes.py
+++ b/acapy_agent/multitenant/admin/tests/test_routes.py
@@ -87,7 +87,7 @@ class TestMultitenantRoutes(IsolatedAsyncioTestCase):
                 ),
             ]
             mock_wallet_record.query = mock.CoroutineMock()
-            mock_wallet_record.query.return_value = [wallets[2], wallets[0], wallets[1]]
+            mock_wallet_record.query.return_value = wallets
 
             await test_module.wallets_list(self.request)
             mock_response.assert_called_once_with(

--- a/acapy_agent/protocols/issue_credential/v1_0/routes.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/routes.py
@@ -23,7 +23,10 @@ from ....ledger.error import LedgerError
 from ....messaging.credential_definitions.util import CRED_DEF_TAGS
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
+from ....messaging.models.paginated_query import (
+    PaginatedQuerySchema,
+    get_paginated_query_params,
+)
 from ....messaging.valid import (
     INDY_CRED_DEF_ID_EXAMPLE,
     INDY_CRED_DEF_ID_VALIDATE,
@@ -411,7 +414,7 @@ async def credential_exchange_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit, offset = get_limit_offset(request)
+    limit, offset, order_by, descending = get_paginated_query_params(request)
 
     try:
         async with context.profile.session() as session:
@@ -420,6 +423,8 @@ async def credential_exchange_list(request: web.BaseRequest):
                 tag_filter=tag_filter,
                 limit=limit,
                 offset=offset,
+                order_by=order_by,
+                descending=descending,
                 post_filter_positive=post_filter,
             )
         results = [record.serialize() for record in records]

--- a/acapy_agent/protocols/issue_credential/v2_0/routes.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/routes.py
@@ -26,7 +26,10 @@ from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
+from ....messaging.models.paginated_query import (
+    PaginatedQuerySchema,
+    get_paginated_query_params,
+)
 from ....messaging.valid import (
     ANONCREDS_CRED_DEF_ID_EXAMPLE,
     ANONCREDS_DID_EXAMPLE,
@@ -626,7 +629,7 @@ async def credential_exchange_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit, offset = get_limit_offset(request)
+    limit, offset, order_by, descending = get_paginated_query_params(request)
 
     try:
         async with profile.session() as session:
@@ -635,6 +638,8 @@ async def credential_exchange_list(request: web.BaseRequest):
                 tag_filter=tag_filter,
                 limit=limit,
                 offset=offset,
+                order_by=order_by,
+                descending=descending,
                 post_filter_positive=post_filter,
             )
 

--- a/acapy_agent/protocols/present_proof/v1_0/routes.py
+++ b/acapy_agent/protocols/present_proof/v1_0/routes.py
@@ -25,7 +25,10 @@ from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
+from ....messaging.models.paginated_query import (
+    PaginatedQuerySchema,
+    get_paginated_query_params,
+)
 from ....messaging.valid import (
     INDY_EXTRA_WQL_EXAMPLE,
     INDY_EXTRA_WQL_VALIDATE,
@@ -309,7 +312,7 @@ async def presentation_exchange_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit, offset = get_limit_offset(request)
+    limit, offset, order_by, descending = get_paginated_query_params(request)
 
     try:
         async with context.profile.session() as session:
@@ -318,6 +321,8 @@ async def presentation_exchange_list(request: web.BaseRequest):
                 tag_filter=tag_filter,
                 limit=limit,
                 offset=offset,
+                order_by=order_by,
+                descending=descending,
                 post_filter_positive=post_filter,
             )
         results = [record.serialize() for record in records]

--- a/acapy_agent/protocols/present_proof/v2_0/routes.py
+++ b/acapy_agent/protocols/present_proof/v2_0/routes.py
@@ -27,7 +27,10 @@ from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
+from ....messaging.models.paginated_query import (
+    PaginatedQuerySchema,
+    get_paginated_query_params,
+)
 from ....messaging.valid import (
     INDY_EXTRA_WQL_EXAMPLE,
     INDY_EXTRA_WQL_VALIDATE,
@@ -468,7 +471,7 @@ async def present_proof_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit, offset = get_limit_offset(request)
+    limit, offset, order_by, descending = get_paginated_query_params(request)
 
     try:
         async with profile.session() as session:
@@ -477,6 +480,8 @@ async def present_proof_list(request: web.BaseRequest):
                 tag_filter=tag_filter,
                 limit=limit,
                 offset=offset,
+                order_by=order_by,
+                descending=descending,
                 post_filter_positive=post_filter,
             )
         results = [record.serialize() for record in records]

--- a/acapy_agent/storage/askar.py
+++ b/acapy_agent/storage/askar.py
@@ -174,6 +174,8 @@ class AskarStorage(BaseStorage):
         tag_query: Optional[Mapping] = None,
         limit: int = DEFAULT_PAGE_SIZE,
         offset: int = 0,
+        order_by: Optional[str] = None,
+        descending: bool = False,
     ) -> Sequence[StorageRecord]:
         """Retrieve a page of records matching a particular type filter and tag query.
 
@@ -182,6 +184,11 @@ class AskarStorage(BaseStorage):
             tag_query: An optional dictionary of tag filter clauses
             limit: The maximum number of records to retrieve
             offset: The offset to start retrieving records from
+            order_by: An optional field by which to order the records.
+            descending: Whether to order the records in descending order.
+
+        Returns:
+            A sequence of StorageRecord matching the filter and query parameters.
         """
         results = []
 
@@ -190,6 +197,8 @@ class AskarStorage(BaseStorage):
             tag_filter=tag_query,
             limit=limit,
             offset=offset,
+            order_by=order_by,
+            descending=descending,
             profile=self._session.profile.settings.get("wallet.askar_profile"),
         ):
             results += (
@@ -206,13 +215,19 @@ class AskarStorage(BaseStorage):
         self,
         type_filter: str,
         tag_query: Optional[Mapping] = None,
+        order_by: Optional[str] = None,
+        descending: bool = False,
         options: Optional[Mapping] = None,
     ):
         """Retrieve all records matching a particular type filter and tag query."""
         for_update = bool(options and options.get("forUpdate"))
         results = []
         for row in await self._session.handle.fetch_all(
-            type_filter, tag_query, for_update=for_update
+            category=type_filter,
+            tag_filter=tag_query,
+            order_by=order_by,
+            descending=descending,
+            for_update=for_update,
         ):
             results.append(
                 StorageRecord(

--- a/acapy_agent/storage/base.py
+++ b/acapy_agent/storage/base.py
@@ -99,6 +99,8 @@ class BaseStorage(ABC):
         tag_query: Optional[Mapping] = None,
         limit: int = DEFAULT_PAGE_SIZE,
         offset: int = 0,
+        order_by: Optional[str] = None,
+        descending: bool = False,
     ) -> Sequence[StorageRecord]:
         """Retrieve a page of records matching a particular type filter and tag query.
 
@@ -107,6 +109,11 @@ class BaseStorage(ABC):
             tag_query: An optional dictionary of tag filter clauses
             limit: The maximum number of records to retrieve
             offset: The offset to start retrieving records from
+            order_by: An optional field by which to order the records.
+            descending: Whether to order the records in descending order.
+
+        Returns:
+            A sequence of StorageRecord matching the filter and query parameters.
         """
 
     @abstractmethod
@@ -114,6 +121,8 @@ class BaseStorage(ABC):
         self,
         type_filter: str,
         tag_query: Optional[Mapping] = None,
+        order_by: Optional[str] = None,
+        descending: bool = False,
         options: Optional[Mapping] = None,
     ) -> Sequence[StorageRecord]:
         """Retrieve all records matching a particular type filter and tag query.
@@ -121,6 +130,8 @@ class BaseStorage(ABC):
         Args:
             type_filter: The type of records to filter by.
             tag_query: An optional dictionary of tag filter clauses.
+            order_by: An optional field by which to order the records.
+            descending: Whether to order the records in descending order.
             options: Additional options for the query.
         """
 


### PR DESCRIPTION
:sparkles: Adds `order_by` and `descending` options to paginated scan or fetch_all methods

❗ This PR is waiting for next official Askar release

:construction: At present, uses TestPyPI package to test ordering functionality introduced in Askar: https://github.com/hyperledger/aries-askar/pull/291

To-do: test coverage, and point to next aries-askar release that includes this change.

Notes: currently it only appears to ever make sense to order by the "id" column, since record field values are encrypted.
So, it does feel a bit weird allowing users to select an "order_by" column when there's only one valid choice. But, I still believe it's better than nothing. We at least add the functionality for control over ordering, and it can be disabled (for whatever reason) by requesting None. Ordering by id is effectively the same as ordering by time created (AFAICT), so the newest records can be received at the top by selecting descending=True. Perhaps this can be made default behavior.

At present (before this Askar PR is merged), there is no guaranteed ordering when fetching records, for the scan (paginated queries) or fetch all methods. This means there's no solid guarantee that all records will be retrieved while scanning (with increasing offsets), and ordering of records may be inconsistent across many fetch_all calls. So, resolving that is the motive for this contribution.

Will close #3001 