### PR TITLE
More robust verification method selection by did

### DIFF
--- a/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
@@ -118,20 +118,13 @@ class DIFPresExchHandler:
     ):
         """Get signature suite for signing presentation."""
         did_info = await self._did_info_for_did(issuer_id)
-        verkey_id_strategy = self.profile.context.inject(BaseVerificationKeyStrategy)
-        verification_method = (
-            await verkey_id_strategy.get_verification_method_id_for_did(
-                issuer_id,
-                self.profile,
-                proof_type=self.proof_type,
-                proof_purpose="assertionMethod",
-            )
+        vm_id_strategy = self.profile.context.inject(BaseVerificationKeyStrategy)
+        verification_method = await vm_id_strategy.get_verification_method_id_for_did(
+            issuer_id,
+            self.profile,
+            proof_type=self.proof_type,
+            proof_purpose="assertionMethod",
         )
-
-        if verification_method is None:
-            raise DIFPresExchError(
-                f"Unable to get retrieve verification method for did {issuer_id}"
-            )
 
         # Get signature class based on proof type
         SignatureClass = self.PROOF_TYPE_SIGNATURE_SUITE_MAPPING[self.proof_type]

--- a/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
@@ -40,7 +40,10 @@ from ....vc.ld_proofs.constants import (
 from ....vc.vc_di.prove import create_signed_anoncreds_presentation
 from ....vc.vc_ld.prove import create_presentation, derive_credential, sign_presentation
 from ....wallet.base import BaseWallet, DIDInfo
-from ....wallet.default_verification_key_strategy import BaseVerificationKeyStrategy
+from ....wallet.default_verification_key_strategy import (
+    BaseVerificationKeyStrategy,
+    ProofPurposeStr,
+)
 from ....wallet.error import WalletError, WalletNotFoundError
 from ....wallet.key_type import BLS12381G2, ED25519
 from .pres_exch import (
@@ -115,15 +118,17 @@ class DIFPresExchHandler:
         self,
         *,
         issuer_id: str,
+        proof_purpose: Optional[ProofPurposeStr] = None,
     ):
         """Get signature suite for signing presentation."""
+        proof_purpose = proof_purpose or "assertionMethod"
         did_info = await self._did_info_for_did(issuer_id)
         vm_id_strategy = self.profile.context.inject(BaseVerificationKeyStrategy)
         verification_method = await vm_id_strategy.get_verification_method_id_for_did(
             issuer_id,
             self.profile,
             proof_type=self.proof_type,
-            proof_purpose="assertionMethod",
+            proof_purpose=proof_purpose,
         )
 
         # Get signature class based on proof type
@@ -1300,8 +1305,9 @@ class DIFPresExchHandler:
                 )
             else:
                 vp = self.__add_dif_fields_to_vp(vp, submission_property)
+                assert issuer_id
                 issue_suite = await self._get_issue_suite(
-                    issuer_id=issuer_id,
+                    issuer_id=issuer_id, proof_purpose="authentication"
                 )
                 signed_vp = await sign_presentation(
                     presentation=vp,

--- a/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
@@ -119,8 +119,13 @@ class DIFPresExchHandler:
         """Get signature suite for signing presentation."""
         did_info = await self._did_info_for_did(issuer_id)
         verkey_id_strategy = self.profile.context.inject(BaseVerificationKeyStrategy)
-        verification_method = await verkey_id_strategy.get_verification_method_id_for_did(
-            issuer_id, self.profile, proof_purpose="assertionMethod"
+        verification_method = (
+            await verkey_id_strategy.get_verification_method_id_for_did(
+                issuer_id,
+                self.profile,
+                proof_type=self.proof_type,
+                proof_purpose="assertionMethod",
+            )
         )
 
         if verification_method is None:

--- a/acapy_agent/vc/vc_ld/manager.py
+++ b/acapy_agent/vc/vc_ld/manager.py
@@ -344,14 +344,12 @@ class VcLdpManager:
         verification_method = (
             options.verification_method
             or await verkey_id_strategy.get_verification_method_id_for_did(
-                issuer_id, self.profile, proof_type, proof_purpose="assertionMethod"
+                issuer_id,
+                self.profile,
+                proof_type=proof_type,
+                proof_purpose="assertionMethod",
             )
         )
-
-        if verification_method is None:
-            raise VcLdpManagerError(
-                f"Unable to get retrieve verification method for did {issuer_id}"
-            )
 
         suite = await self._get_suite(
             proof_type=proof_type,

--- a/acapy_agent/vc/vc_ld/manager.py
+++ b/acapy_agent/vc/vc_ld/manager.py
@@ -344,7 +344,7 @@ class VcLdpManager:
         verification_method = (
             options.verification_method
             or await verkey_id_strategy.get_verification_method_id_for_did(
-                issuer_id, self.profile, proof_purpose="assertionMethod"
+                issuer_id, self.profile, proof_type, proof_purpose="assertionMethod"
             )
         )
 

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -7,6 +7,8 @@ from acapy_agent.core.profile import Profile
 from acapy_agent.did.did_key import DIDKey
 from acapy_agent.wallet.key_type import KeyType
 
+from acapy_agent.resolver.did_resolver import DIDResolver
+
 
 class BaseVerificationKeyStrategy(ABC):
     """Base class for defining which verification method is in use."""
@@ -60,5 +62,11 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         elif did.startswith("did:sov:"):
             # key-1 is what uniresolver uses for key id
             return did + "#key-1"
-
+        elif did.startswith("did:web:"):
+            did_resolver = profile.inject(DIDResolver)
+            did_document = await did_resolver.resolve(profile=profile, did=did)
+            verification_method_list = did_document.get("verificationMethod", {})
+            # taking the first verification method from did document
+            verification_method_id = verification_method_list[0].get("id")
+            return verification_method_id
         return None

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -77,7 +77,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
                 verification_method_types = self.key_types_mapping[proof_type]
                 verification_method_list = did_document.get("verificationMethod", None)
                 for method in verification_method_list:
-                    if method.get("type") == verification_method_type:
+                    if method.get("type") in verification_method_types:
                         return method.get("id")
             else:
                 # taking the first verification method from did document

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -43,7 +43,7 @@ class BaseVerificationKeyStrategy(ABC):
         *,
         proof_type: Optional[str] = None,
         proof_purpose: Optional[ProofPurposeStr] = None,
-    ) -> Optional[str]:
+    ) -> str:
         """Given a DID, returns the verification key ID in use.
 
         Returns None if no strategy is specified for this DID.
@@ -54,7 +54,7 @@ class BaseVerificationKeyStrategy(ABC):
         :params proof_purpose: the verkey relationship (assertionMethod, keyAgreement, ..)
         :returns Optional[str]: the current verkey ID
         """
-        pass
+        ...
 
 
 class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
@@ -77,7 +77,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         *,
         proof_type: Optional[str] = None,
         proof_purpose: Optional[ProofPurposeStr] = None,
-    ) -> Optional[str]:
+    ) -> str:
         """Given a did:key or did:sov, returns the verification key ID in use.
 
         Returns None if no strategy is specified for this DID.
@@ -113,7 +113,12 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
             for method in methods_or_refs
         ]
 
-        method_types = self.key_types_mapping[proof_type]
+        method_types = self.key_types_mapping.get(proof_type)
+        if not method_types:
+            raise VerificationKeyStrategyError(
+                f"proof type {proof_type} is not supported"
+            )
+
         # Filter methods by type expected for proof_type
         methods = [vm for vm in methods if vm.type in method_types]
         if not methods:

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -18,6 +18,7 @@ class BaseVerificationKeyStrategy(ABC):
         self,
         did: str,
         profile: Optional[Profile],
+        proof_type: Optional[str] = None,
         allowed_verification_method_types: Optional[List[KeyType]] = None,
         proof_purpose: Optional[str] = None,
     ) -> Optional[str]:
@@ -39,11 +40,18 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
 
     Supports did:key: and did:sov only.
     """
+    def __init__(self):
+        """Initialize the key types mapping."""
+        self.key_types_mapping = {
+            "Ed25519Signature2018": "Ed25519VerificationKey2018",
+            "Ed25519Signature2020": "Ed25519VerificationKey2020",
+        }
 
     async def get_verification_method_id_for_did(
         self,
         did: str,
         profile: Optional[Profile],
+        proof_type: Optional[str] = None,
         allowed_verification_method_types: Optional[List[KeyType]] = None,
         proof_purpose: Optional[str] = None,
     ) -> Optional[str]:
@@ -65,8 +73,14 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         elif did.startswith("did:web:"):
             did_resolver = profile.inject(DIDResolver)
             did_document = await did_resolver.resolve(profile=profile, did=did)
-            verification_method_list = did_document.get("verificationMethod", {})
-            # taking the first verification method from did document
-            verification_method_id = verification_method_list[0].get("id")
-            return verification_method_id
+            if proof_type:
+                verification_method_type = self.key_types_mapping[proof_type]
+                verification_method_list = did_document.get("verificationMethod", None)
+                for method in verification_method_list:
+                    if method.get("type") == verification_method_type:
+                        return method.get("id")
+            else:
+                # taking the first verification method from did document
+                verification_method_id = verification_method_list[0].get("id")
+                return verification_method_id
         return None

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -74,7 +74,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
             did_resolver = profile.inject(DIDResolver)
             did_document = await did_resolver.resolve(profile=profile, did=did)
             if proof_type:
-                verification_method_type = self.key_types_mapping[proof_type]
+                verification_method_types = self.key_types_mapping[proof_type]
                 verification_method_list = did_document.get("verificationMethod", None)
                 for method in verification_method_list:
                     if method.get("type") == verification_method_type:

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -43,8 +43,8 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
     def __init__(self):
         """Initialize the key types mapping."""
         self.key_types_mapping = {
-            "Ed25519Signature2018": "Ed25519VerificationKey2018",
-            "Ed25519Signature2020": "Ed25519VerificationKey2020",
+            "Ed25519Signature2018": ["Ed25519VerificationKey2018"],
+            "Ed25519Signature2020": ["Ed25519VerificationKey2020", "Multikey"],
         }
 
     async def get_verification_method_id_for_did(

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 import logging
-from typing import Optional
+from typing import Literal, Optional
 
 from pydid import DIDDocument
 
@@ -12,6 +12,20 @@ from ..did.did_key import DIDKey
 from ..resolver.did_resolver import DIDResolver
 
 LOGGER = logging.getLogger(__name__)
+
+
+ProofPurposeStr = Literal[
+    "assertionMethod",
+    "authentication",
+    "capabilityDelegation",
+    "capabilityInvocation",
+]
+PROOF_PURPOSES = (
+    "authentication",
+    "assertionMethod",
+    "capabilityInvocation",
+    "capabilityDelegation",
+)
 
 
 class VerificationKeyStrategyError(BaseError):
@@ -28,7 +42,7 @@ class BaseVerificationKeyStrategy(ABC):
         profile: Profile,
         *,
         proof_type: Optional[str] = None,
-        proof_purpose: Optional[str] = None,
+        proof_purpose: Optional[ProofPurposeStr] = None,
     ) -> Optional[str]:
         """Given a DID, returns the verification key ID in use.
 
@@ -62,7 +76,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         profile: Profile,
         *,
         proof_type: Optional[str] = None,
-        proof_purpose: Optional[str] = None,
+        proof_purpose: Optional[ProofPurposeStr] = None,
     ) -> Optional[str]:
         """Given a did:key or did:sov, returns the verification key ID in use.
 
@@ -77,12 +91,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         proof_type = proof_type or "Ed25519Signature2018"
         proof_purpose = proof_purpose or "assertionMethod"
 
-        if proof_purpose not in (
-            "authentication",
-            "assertionMethod",
-            "capabilityInvocation",
-            "capabilityDelegation",
-        ):
+        if proof_purpose not in PROOF_PURPOSES:
             raise ValueError("Invalid proof purpose")
 
         if did.startswith("did:key:"):

--- a/acapy_agent/wallet/jwt.py
+++ b/acapy_agent/wallet/jwt.py
@@ -61,8 +61,6 @@ async def jwt_sign(
         verification_method = await verkey_strat.get_verification_method_id_for_did(
             did, profile
         )
-        if not verification_method:
-            raise ValueError("Could not determine verification method from DID")
     else:
         # We look up keys by did for now
         did = DIDUrl.parse(verification_method).did

--- a/acapy_agent/wallet/tests/test_default_verification_key_strategy.py
+++ b/acapy_agent/wallet/tests/test_default_verification_key_strategy.py
@@ -1,4 +1,7 @@
 from unittest import IsolatedAsyncioTestCase
+import pytest
+
+from acapy_agent.resolver.did_resolver import DIDResolver
 
 from ...did.did_key import DIDKey
 from ...utils.testing import create_test_profile
@@ -13,6 +16,8 @@ TEST_DID_KEY = "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
 class TestDefaultVerificationKeyStrategy(IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.profile = await create_test_profile()
+        resolver = DIDResolver()
+        self.profile.context.injector.bind_instance(DIDResolver, resolver)
 
     async def test_with_did_sov(self):
         strategy = DefaultVerificationKeyStrategy()
@@ -30,9 +35,7 @@ class TestDefaultVerificationKeyStrategy(IsolatedAsyncioTestCase):
 
     async def test_unsupported_did_method(self):
         strategy = DefaultVerificationKeyStrategy()
-        assert (
+        with pytest.raises(Exception):
             await strategy.get_verification_method_id_for_did(
                 "did:test:test", self.profile
             )
-            is None
-        )


### PR DESCRIPTION
This PR is intended to supersede #3138 by adding a default verification method selection strategy for all DID methods.

This strategy relies on proof type and proof purpose to select the most appropriate verification method. For example, if proof type is `Ed25519Signature2020` and purpose is `assertionMethod`, the changes in this PR will select the first matching method in the `assertionMethod` relationship that can produce a `Ed25519Signature2020`.

This places more expectations on the DID -- specifically that it is well formatted (which many aren't). By well formatted I mean that verification methods used for issuance are properly referenced in `assertionMethod`, methods used to authenticate the DID owner are in `authentication`, etc. In practice, this may cause challenges but it is possible for users who depend on a DID method/document that isn't well formatted to create their own strategy and plug it in. So I'm comfortable making the assertion that we can expect the DIDs we're working with to be well formatted.

This PR does adjust the interface for the VerificationKeyStrategy to better account for this. This might be painful to some plugin users who've added DID Methods by plugin and added a strategy to match. However, my hope is that those same users won't need to plug in their own strategy anymore with these changes since they should be robust enough to cover most use cases.

Shout out to @aritroCoder for his original work on #3138!