### PR TITLE
Fix interop test fork location replacement

### DIFF
--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -67,7 +67,7 @@ jobs:
           if [ ${{ github.event_name }} == 'pull_request' ]; then
             echo ${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}
             echo ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-            sed -i 's|@git+https://github.com/openwallet-foundation/acapy@main|@git+${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}@${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}|g' ./aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
+            sed -i 's|aries-cloudagent\[indy, bbs, askar\]@git+https://github.com/hyperledger/aries-cloudagent-python@main|acapy-agent[indy, bbs, askar]@git+${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}@${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}|g' ./aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
           fi
           cat aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
 


### PR DESCRIPTION
This fixes the interop integration tests. I had changed a reference that shouldn't have been changed.

This workflow replaces the remote agent location with the forked repo location doing a sed text replacement. It needed to have the package name updated as well.