### PR TITLE
Fix endorsement setup with existing connection

### DIFF
--- a/acapy_agent/utils/endorsement_setup.py
+++ b/acapy_agent/utils/endorsement_setup.py
@@ -20,15 +20,14 @@ from ..protocols.out_of_band.v1_0.messages.invitation import InvitationMessage
 LOGGER = logging.getLogger(__name__)
 
 
+class EndorsementSetupError(Exception):
+    """Endorsement setup error."""
+
+
 async def attempt_auto_author_with_endorser_setup(profile: Profile):
     """Automatically setup the author's endorser connection if possible."""
 
     if not is_author_role(profile):
-        return
-
-    endorser_invitation = profile.settings.get_value("endorser.endorser_invitation")
-    if not endorser_invitation:
-        LOGGER.info("No endorser invitation, can't connect automatically.")
         return
 
     endorser_alias = profile.settings.get_value("endorser.endorser_alias")
@@ -44,6 +43,11 @@ async def attempt_auto_author_with_endorser_setup(profile: Profile):
     endorser_did = profile.settings.get_value("endorser.endorser_public_did")
     if not endorser_did:
         LOGGER.info("No endorser DID, can connect, but can't setup connection metadata.")
+        return
+
+    endorser_invitation = profile.settings.get_value("endorser.endorser_invitation")
+    if not endorser_invitation:
+        LOGGER.info("No endorser invitation, can't create connection automatically.")
         return
 
     try:
@@ -71,7 +75,7 @@ async def attempt_auto_author_with_endorser_setup(profile: Profile):
                     alias=endorser_alias,
                 )
             else:
-                raise Exception(
+                raise EndorsementSetupError(
                     "Failed to establish endorser connection, invalid "
                     "invitation format."
                 )

--- a/acapy_agent/utils/tests/test_endorsement_setup.py
+++ b/acapy_agent/utils/tests/test_endorsement_setup.py
@@ -82,3 +82,22 @@ class TestEndorsementSetupUtil(IsolatedAsyncioTestCase):
             mock_logger.call_args_list[0][0][0]
             == "Connected to endorser from previous connection."
         )
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_alias",
+        side_effect=Exception("No connection"),
+    )
+    @mock.patch.object(endorsement_setup.LOGGER, "info", return_value=mock.MagicMock())
+    async def test_does_not_have_previous_connection_with_did_but_no_invitation(
+        self, mock_logger, *_
+    ):
+        await endorsement_setup.attempt_auto_author_with_endorser_setup(self.profile)
+
+        # No invitation
+        self.profile.settings.set_value("endorser.author", True)
+        self.profile.settings.set_value("endorser.endorser_alias", "test-alias")
+        self.profile.settings.set_value(
+            "endorser.endorser_public_did", "WuE7ndRJgAGbJYnwDXV7Pz"
+        )
+        await endorsement_setup.attempt_auto_author_with_endorser_setup(self.profile)

--- a/acapy_agent/utils/tests/test_endorsement_setup.py
+++ b/acapy_agent/utils/tests/test_endorsement_setup.py
@@ -62,3 +62,23 @@ class TestEndorsementSetupUtil(IsolatedAsyncioTestCase):
             assert "Error accepting endorser invitation" not in call[0][0]
 
         assert mock_conn_record.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_alias",
+        return_value=[ConnRecord(connection_id="test-connection-id")],
+    )
+    @mock.patch.object(endorsement_setup.LOGGER, "info", return_value=mock.MagicMock())
+    async def test_has_previous_connection(self, mock_logger, *_):
+        await endorsement_setup.attempt_auto_author_with_endorser_setup(self.profile)
+
+        # No invitation
+        self.profile.settings.set_value("endorser.author", True)
+        self.profile.settings.set_value("endorser.endorser_alias", "test-alias")
+        await endorsement_setup.attempt_auto_author_with_endorser_setup(self.profile)
+
+        assert mock_logger.call_count == 1
+        assert (
+            mock_logger.call_args_list[0][0][0]
+            == "Connected to endorser from previous connection."
+        )


### PR DESCRIPTION
Moves the invitation url check until after checking for a previous endorser connection.