### PR TITLE
:bug: Rearrange connection record deletion after hangup

### DIFF
--- a/acapy_agent/protocols/did_rotate/v1_0/manager.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/manager.py
@@ -79,11 +79,11 @@ class DIDRotateManager:
 
         hangup = Hangup()
 
-        async with self.profile.session() as session:
-            await conn.delete_record(session)
-
         responder = self.profile.inject(BaseResponder)
         await responder.send(hangup, connection_id=conn.connection_id)
+
+        async with self.profile.session() as session:
+            await conn.delete_record(session)
 
         return hangup
 


### PR DESCRIPTION
Resolves #3306

Originally, the `hangup` method would delete the associated connection record before posting the hangup request. This is evidently a mistake, since the hangup depends on the connection record.

Mostly it would work, since there is a delay in the deletion of the connection record reflecting in storage, but rearranging the delete after hangup is a simple fix to avoid the race condition.

___

Before:
Sample 500 error from our tests (in "Wait for pytest and print logs" step): https://github.com/didx-xyz/aries-cloudapi-python/actions/runs/11387403475/job/31682203816

After:
Our tests now pass when testing this fix: https://github.com/didx-xyz/aries-cloudapi-python/pull/1138


