### PR TITLE
Don't pass rekey to sub_wallet_profile

### DIFF
--- a/acapy_agent/multitenant/single_wallet_askar_manager.py
+++ b/acapy_agent/multitenant/single_wallet_askar_manager.py
@@ -74,6 +74,7 @@ class SingleWalletAskarMultitenantManager(BaseMultitenantManager):
             sub_wallet_settings = {
                 "wallet.recreate": False,
                 "wallet.seed": None,
+                "wallet.key": "",
                 "wallet.rekey": None,
                 "wallet.id": None,
                 "wallet.name": multitenant_wallet_name,


### PR DESCRIPTION
This should be all that is needed to allow multitenancy single wallet mode to work with the rekey feature. In single wallet mode the multitenant_sub_wallet is always created without a key. I guess this is ok because the subwallets should have a key.

When the rekey feature was applied it would send the new key to try and use to open the multitenant_sub_wallet, resulting in a failure to open the wallet.


There is other work to be done here. Right now in single wallet mode it is possible to make subwallets without a key and there is no rekey feature for subwallets. See https://github.com/openwallet-foundation/acapy/issues/3307