### PR TITLE
:art: Refactor string concatenation in model descriptions

### DIFF
--- a/acapy_agent/protocols/connections/v1_0/tests/test_manager.py
+++ b/acapy_agent/protocols/connections/v1_0/tests/test_manager.py
@@ -446,7 +446,7 @@ class TestConnectionManager(IsolatedAsyncioTestCase):
 
     async def test_create_request_mediation_id(self):
         mediation_record = MediationRecord(
-            mediation_id="test_medation_id",
+            mediation_id="test_mediation_id",
             role=MediationRecord.ROLE_CLIENT,
             state=MediationRecord.STATE_GRANTED,
             connection_id=self.test_mediator_conn_id,
@@ -856,7 +856,7 @@ class TestConnectionManager(IsolatedAsyncioTestCase):
         )
 
         mediation_record = MediationRecord(
-            mediation_id="test_medation_id",
+            mediation_id="test_mediation_id",
             role=MediationRecord.ROLE_CLIENT,
             state=MediationRecord.STATE_GRANTED,
             connection_id=self.test_mediator_conn_id,
@@ -916,7 +916,7 @@ class TestConnectionManager(IsolatedAsyncioTestCase):
 
     async def test_create_response_mediation(self):
         mediation_record = MediationRecord(
-            mediation_id="test_medation_id",
+            mediation_id="test_mediation_id",
             role=MediationRecord.ROLE_CLIENT,
             state=MediationRecord.STATE_GRANTED,
             connection_id=self.test_mediator_conn_id,

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/models/tests/test_mediation_record.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/models/tests/test_mediation_record.py
@@ -44,8 +44,8 @@ async def test_backwards_compat_terms(session: ProfileSession):
 
 @pytest.mark.asyncio
 async def test_mediation_record_eq():
-    record_0 = MediationRecord(mediation_id="test_medation_id_0", endpoint="zero")
-    record_1 = MediationRecord(mediation_id="test_medation_id_1", endpoint="one")
+    record_0 = MediationRecord(mediation_id="test_mediation_id_0", endpoint="zero")
+    record_1 = MediationRecord(mediation_id="test_mediation_id_1", endpoint="one")
     assert record_0 != record_1
 
     with pytest.raises(ValueError):

--- a/acapy_agent/resolver/default/peer4.py
+++ b/acapy_agent/resolver/default/peer4.py
@@ -66,8 +66,8 @@ class PeerDID4Resolver(BaseDIDResolver):
                     record = await storage.get_record(self.RECORD_TYPE, did)
                 except StorageNotFoundError:
                     raise DIDNotFound(
-                        f"short did:peer:4 does not correspond to a \
-                          known long did:peer:4 {did}"
+                        "short did:peer:4 does not correspond to a known long did:peer:4"
+                        f"{did}"
                     )
             document = resolve_short(record.value)
         else:

--- a/acapy_agent/vc/data_integrity/models/options.py
+++ b/acapy_agent/vc/data_integrity/models/options.py
@@ -70,8 +70,8 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "An optional identifier for the proof, which MUST be a URL [URL], \
-                    such as a UUID as a URN"
+                "An optional identifier for the proof, which MUST be a URL [URL], "
+                "such as a UUID as a URN"
             ),
             "example": "urn:uuid:6a1676b8-b51f-11ed-937b-d76685a20ff5",
         },
@@ -81,8 +81,8 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=True,
         metadata={
             "description": (
-                "The specific type of proof MUST be specified as a string that maps \
-                    to a URL [URL]."
+                "The specific type of proof MUST be specified as a string that maps "
+                "to a URL [URL]."
             ),
             "example": "DataIntegrityProof",
         },
@@ -92,9 +92,11 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         data_key="proofPurpose",
         required=True,
         metadata={
-            "description": "The proof purpose acts as a safeguard to prevent the \
-                proof from being misused by being applied to a purpose other than \
-                    the one that was intended.",
+            "description": (
+                "The proof purpose acts as a safeguard to prevent the "
+                "proof from being misused by being applied to a purpose other than "
+                "the one that was intended."
+            ),
             "example": "assertionMethod",
         },
     )
@@ -104,8 +106,10 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=True,
         validate=Uri(),
         metadata={
-            "description": "A verification method is the means and information \
-                needed to verify the proof. ",
+            "description": (
+                "A verification method is the means and information "
+                "needed to verify the proof."
+            ),
             "example": (
                 "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg34"
                 "2Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
@@ -117,8 +121,8 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=True,
         metadata={
             "description": (
-                "An identifier for the cryptographic suite that can be used to \
-                    verify the proof."
+                "An identifier for the cryptographic suite that can be used to "
+                "verify the proof."
             ),
             "example": "eddsa-jcs-2022",
         },
@@ -128,9 +132,9 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "The date and time the proof was created is OPTIONAL and, if \
-                    included, MUST be specified as an [XMLSCHEMA11-2] \
-                        dateTimeStamp string"
+                "The date and time the proof was created is OPTIONAL and, if "
+                "included, MUST be specified as an [XMLSCHEMA11-2] "
+                "dateTimeStamp string"
             ),
             "example": RFC3339_DATETIME_EXAMPLE,
         },
@@ -140,9 +144,9 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "The expires property is OPTIONAL and, if present, specifies when \
-                    the proof expires. If present, it MUST be an [XMLSCHEMA11-2] \
-                        dateTimeStamp string"
+                "The expires property is OPTIONAL and, if present, specifies when "
+                "the proof expires. If present, it MUST be an [XMLSCHEMA11-2] "
+                "dateTimeStamp string"
             ),
             "example": RFC3339_DATETIME_EXAMPLE,
         },
@@ -152,8 +156,8 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "It conveys one or more security domains in which the proof is \
-                    meant to be used."
+                "It conveys one or more security domains in which the proof is "
+                "meant to be used."
             ),
             "example": "example.com",
         },
@@ -163,8 +167,8 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "The value is used once for a particular domain and window of time. \
-                    This value is used to mitigate replay attacks."
+                "The value is used once for a particular domain and window of time. "
+                "This value is used to mitigate replay attacks."
             ),
             "example": UUID4_EXAMPLE,
         },
@@ -174,8 +178,10 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
         required=False,
         data_key="previousProof",
         metadata={
-            "description": "Each value identifies another data integrity proof that \
-                MUST verify before the current proof is processed.",
+            "description": (
+                "Each value identifies another data integrity proof that "
+                "MUST verify before the current proof is processed."
+            ),
             "example": ("urn:uuid:6a1676b8-b51f-11ed-937b-d76685a20ff5"),
         },
     )
@@ -195,9 +201,10 @@ class DataIntegrityProofOptionsSchema(BaseModelSchema):
     nonce = fields.Str(
         required=False,
         metadata={
-            "description": "One use of this field is to increase privacy by decreasing \
-                linkability that is the result of deterministically \
-                    generated signatures.",
+            "description": (
+                "One use of this field is to increase privacy by decreasing linkability "
+                "that is the result of deterministically generated signatures."
+            ),
             "example": (
                 "CF69iO3nfvqRsRBNElE8b4wO39SyJHPM7Gg1nExltW5vSfQA1lvDCR/zXX1To0/4NLo=="
             ),

--- a/acapy_agent/vc/data_integrity/models/proof.py
+++ b/acapy_agent/vc/data_integrity/models/proof.py
@@ -94,8 +94,8 @@ class DataIntegrityProofSchema(BaseModelSchema):
         metadata={
             "description": (
                 "The proof purpose acts as a safeguard to prevent the proof "
-                "from being misused by being applied to a purpose other than the one that "
-                "was intended."
+                "from being misused by being applied to a purpose other than the one "
+                "that was intended."
             ),
             "example": "assertionMethod",
         },

--- a/acapy_agent/vc/data_integrity/models/proof.py
+++ b/acapy_agent/vc/data_integrity/models/proof.py
@@ -70,8 +70,8 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "An optional identifier for the proof, which MUST be a URL [URL], \
-                    such as a UUID as a URN"
+                "An optional identifier for the proof, which MUST be a URL [URL], "
+                "such as a UUID as a URN"
             ),
             "example": "urn:uuid:6a1676b8-b51f-11ed-937b-d76685a20ff5",
         },
@@ -81,8 +81,8 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=True,
         metadata={
             "description": (
-                "The specific type of proof MUST be specified as a string that maps \
-                    to a URL [URL]."
+                "The specific type of proof MUST be specified as a string that maps "
+                "to a URL [URL]."
             ),
             "example": "DataIntegrityProof",
         },
@@ -92,9 +92,11 @@ class DataIntegrityProofSchema(BaseModelSchema):
         data_key="proofPurpose",
         required=True,
         metadata={
-            "description": "The proof purpose acts as a safeguard to prevent the proof \
-                from being misused by being applied to a purpose other than the one that \
-                    was intended.",
+            "description": (
+                "The proof purpose acts as a safeguard to prevent the proof "
+                "from being misused by being applied to a purpose other than the one that "
+                "was intended."
+            ),
             "example": "assertionMethod",
         },
     )
@@ -104,8 +106,10 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=True,
         validate=Uri(),
         metadata={
-            "description": "A verification method is the means and information needed \
-                to verify the proof. ",
+            "description": (
+                "A verification method is the means and information needed "
+                "to verify the proof."
+            ),
             "example": (
                 "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg34"
                 "2Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
@@ -117,8 +121,8 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=True,
         metadata={
             "description": (
-                "An identifier for the cryptographic suite that can be used to verify \
-                    the proof."
+                "An identifier for the cryptographic suite that can be used to verify "
+                "the proof."
             ),
             "example": "eddsa-jcs-2022",
         },
@@ -128,8 +132,8 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "The date and time the proof was created is OPTIONAL and, if included, \
-                    MUST be specified as an [XMLSCHEMA11-2] dateTimeStamp string"
+                "The date and time the proof was created is OPTIONAL and, if included, "
+                "MUST be specified as an [XMLSCHEMA11-2] dateTimeStamp string"
             ),
             "example": RFC3339_DATETIME_EXAMPLE,
         },
@@ -139,9 +143,9 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "The expires property is OPTIONAL and, if present, specifies when the \
-                    proof expires. If present, it MUST be an [XMLSCHEMA11-2] \
-                        dateTimeStamp string"
+                "The expires property is OPTIONAL and, if present, specifies when the "
+                "proof expires. If present, it MUST be an [XMLSCHEMA11-2] "
+                "dateTimeStamp string"
             ),
             "example": RFC3339_DATETIME_EXAMPLE,
         },
@@ -151,8 +155,8 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "It conveys one or more security domains in which the proof is \
-                    meant to be used."
+                "It conveys one or more security domains in which the proof is "
+                "meant to be used."
             ),
             "example": "example.com",
         },
@@ -162,8 +166,8 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=False,
         metadata={
             "description": (
-                "The value is used once for a particular domain and window of time. \
-                    This value is used to mitigate replay attacks."
+                "The value is used once for a particular domain and window of time. "
+                "This value is used to mitigate replay attacks."
             ),
             "example": UUID4_EXAMPLE,
         },
@@ -173,9 +177,10 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=False,
         data_key="proofValue",
         metadata={
-            "description": "A string value that expresses base-encoded binary data \
-                necessary to verify the digital proof using the verificationMethod \
-                    specified.",
+            "description": (
+                "A string value that expresses base-encoded binary data necessary "
+                "to verify the digital proof using the verificationMethod specified."
+            ),
             "example": (
                 "zsy1AahqbzJQ63n9RtekmwzqZeVj494VppdAVJBnMYrTwft6cLJJGeTSSxCCJ6HKnR"
                 "twE7jjDh6sB2z2AAiZY9BBnCD8wUVgwqH3qchGRCuC2RugA4eQ9fUrR4Yuycac3caiaaay"
@@ -187,8 +192,10 @@ class DataIntegrityProofSchema(BaseModelSchema):
         required=False,
         data_key="previousProof",
         metadata={
-            "description": "Each value identifies another data integrity proof that \
-                MUST verify before the current proof is processed.",
+            "description": (
+                "Each value identifies another data integrity proof that "
+                "MUST verify before the current proof is processed."
+            ),
             "example": ("urn:uuid:6a1676b8-b51f-11ed-937b-d76685a20ff5"),
         },
     )
@@ -196,9 +203,10 @@ class DataIntegrityProofSchema(BaseModelSchema):
     nonce = fields.Str(
         required=False,
         metadata={
-            "description": "One use of this field is to increase privacy by decreasing \
-                linkability that is the result of deterministically generated \
-                    signatures.",
+            "description": (
+                "One use of this field is to increase privacy by decreasing linkability "
+                "that is the result of deterministically generated signatures."
+            ),
             "example": (
                 "CF69iO3nfvqRsRBNElE8b4wO39SyJHPM7Gg1nExltW5vSfQA1lvDCR/zXX1To0/4NLo=="
             ),

--- a/acapy_agent/wallet/keys/routes.py
+++ b/acapy_agent/wallet/keys/routes.py
@@ -29,8 +29,10 @@ class CreateKeyRequestSchema(OpenAPISchema):
     seed = fields.Str(
         required=False,
         metadata={
-            "description": "Optional seed to generate the key pair. \
-                Must enable insecure wallet mode.",
+            "description": (
+                "Optional seed to generate the key pair. "
+                "Must enable insecure wallet mode."
+            ),
             "example": "00000000000000000000000000000000",
         },
     )
@@ -38,8 +40,9 @@ class CreateKeyRequestSchema(OpenAPISchema):
     kid = fields.Str(
         required=False,
         metadata={
-            "description": "Optional kid to bind to the keypair, \
-                such as a verificationMethod.",
+            "description": (
+                "Optional kid to bind to the keypair, such as a verificationMethod."
+            ),
             "example": "did:web:example.com#key-01",
         },
     )
@@ -77,8 +80,9 @@ class UpdateKeyRequestSchema(OpenAPISchema):
     kid = fields.Str(
         required=True,
         metadata={
-            "description": "New kid to bind to the key pair, \
-                such as a verificationMethod.",
+            "description": (
+                "New kid to bind to the key pair, such as a verificationMethod."
+            ),
             "example": "did:web:example.com#key-02",
         },
     )

--- a/acapy_agent/wallet/routes.py
+++ b/acapy_agent/wallet/routes.py
@@ -178,7 +178,7 @@ class DIDEndpointWithTypeSchema(OpenAPISchema):
         required=False,
         validate=UUID4_VALIDATE,
         metadata={
-            "description": "Medation ID to use for endpoint information.",
+            "description": "Mediation ID to use for endpoint information.",
             "example": UUID4_EXAMPLE,
         },
     )


### PR DESCRIPTION
Just some minor artsy cleanup --

I noticed that using the backslash for line continuation includes all the whitespace of the code indentation in the final string. So, the openapi docs would generate a description as:

```
The value is used once for a particular domain and window of time.                     This value is ...
```

So, quick fix: replace \ for line continuation with string concatenation

edit: also fixes mediation typo, while I'm at it