### PR TITLE
:wrench: set default fixture scope for pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ markers = [
 ]
 junit_family = "xunit1"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "module"
 
 [tool.coverage.run]
 


### PR DESCRIPTION
Resolves `PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset`
