### PR TITLE
:sparkles: Handle NotFound and UnprocessableEntity errors in middleware

### DIFF
--- a/acapy_agent/admin/server.py
+++ b/acapy_agent/admin/server.py
@@ -179,12 +179,7 @@ async def ready_middleware(request: web.BaseRequest, handler: Coroutine):
             LOGGER.debug("Task cancelled")
             raise
         except Exception as e:
-            # some other error?
-            LOGGER.error("Handler error with exception: %s", str(e))
-            import traceback
-
-            print("\n=================")
-            traceback.print_exc()
+            LOGGER.exception("Handler error with exception:", exc_info=e)
             raise
 
     raise web.HTTPServiceUnavailable(reason="Shutdown in progress")

--- a/acapy_agent/admin/server.py
+++ b/acapy_agent/admin/server.py
@@ -13,8 +13,6 @@ from aiohttp import web
 from aiohttp_apispec import setup_aiohttp_apispec, validation_middleware
 from uuid_utils import uuid4
 
-from acapy_agent.wallet import singletons
-
 from ..config.injection_context import InjectionContext
 from ..config.logging import context_wallet_id
 from ..core.event_bus import Event, EventBus
@@ -35,6 +33,7 @@ from ..utils.extract_validation_error import extract_validation_error_message
 from ..utils.stats import Collector
 from ..utils.task_queue import TaskQueue
 from ..version import __version__
+from ..wallet import singletons
 from ..wallet.anoncreds_upgrade import check_upgrade_completion_loop
 from .base_server import BaseAdminServer
 from .error import AdminSetupError

--- a/acapy_agent/admin/server.py
+++ b/acapy_agent/admin/server.py
@@ -179,7 +179,7 @@ async def ready_middleware(request: web.BaseRequest, handler: Coroutine):
         raise
     except (LedgerConfigError, LedgerTransactionError) as e:
         # fatal, signal server shutdown
-        LOGGER.error("Shutdown with %s", str(e))
+        LOGGER.critical("Shutdown with %s", str(e))
         request.app._state["ready"] = False
         request.app._state["alive"] = False
         raise

--- a/acapy_agent/admin/server.py
+++ b/acapy_agent/admin/server.py
@@ -158,6 +158,22 @@ async def ready_middleware(request: web.BaseRequest, handler: Coroutine):
         except (web.HTTPBadRequest, MultitenantManagerError) as e:
             LOGGER.info("Bad request during %s %s: %s", request.method, request.path, e)
             raise web.HTTPBadRequest(reason=str(e)) from e
+        except (web.HTTPNotFound, StorageNotFoundError) as e:
+            LOGGER.info(
+                "Not Found error occurred during %s %s: %s",
+                request.method,
+                request.path,
+                e,
+            )
+            raise web.HTTPNotFound(reason=str(e)) from e
+        except web.HTTPUnprocessableEntity as e:
+            LOGGER.info(
+                "Unprocessable Entity occurred during %s %s: %s",
+                request.method,
+                request.path,
+                e.reason,
+            )
+            raise
         except asyncio.CancelledError:
             # redirection spawns new task and cancels old
             LOGGER.debug("Task cancelled")

--- a/acapy_agent/admin/server.py
+++ b/acapy_agent/admin/server.py
@@ -31,6 +31,7 @@ from ..transport.outbound.message import OutboundMessage
 from ..transport.outbound.status import OutboundSendStatus
 from ..transport.queue.basic import BasicMessageQueue
 from ..utils import general as general_utils
+from ..utils.extract_validation_error import extract_validation_error_message
 from ..utils.stats import Collector
 from ..utils.task_queue import TaskQueue
 from ..version import __version__
@@ -167,11 +168,12 @@ async def ready_middleware(request: web.BaseRequest, handler: Coroutine):
             )
             raise web.HTTPNotFound(reason=str(e)) from e
         except web.HTTPUnprocessableEntity as e:
+            validation_error_message = extract_validation_error_message(e)
             LOGGER.info(
                 "Unprocessable Entity occurred during %s %s: %s",
                 request.method,
                 request.path,
-                e.reason,
+                validation_error_message,
             )
             raise
         except asyncio.CancelledError:

--- a/acapy_agent/admin/tests/test_admin_server.py
+++ b/acapy_agent/admin/tests/test_admin_server.py
@@ -149,7 +149,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
                 handler.side_effect,
             )
 
-            # Test InvalidTokenError (assuming custom exception)
+            # Test InvalidTokenError
             handler = mock.CoroutineMock(
                 side_effect=test_module.InvalidTokenError("Token error")
             )

--- a/acapy_agent/admin/tests/test_admin_server.py
+++ b/acapy_agent/admin/tests/test_admin_server.py
@@ -3,9 +3,11 @@ import json
 from typing import Optional
 from unittest import IsolatedAsyncioTestCase
 
+import jwt
 import pytest
 from aiohttp import ClientSession, DummyCookieJar, TCPConnector, web
 from aiohttp.test_utils import unused_port
+from marshmallow import ValidationError
 
 from acapy_agent.tests import mock
 from acapy_agent.wallet import singletons
@@ -16,7 +18,9 @@ from ...core.event_bus import Event
 from ...core.goal_code_registry import GoalCodeRegistry
 from ...core.in_memory import InMemoryProfile
 from ...core.protocol_registry import ProtocolRegistry
+from ...multitenant.error import MultitenantManagerError
 from ...storage.base import BaseStorage
+from ...storage.error import StorageNotFoundError
 from ...storage.record import StorageRecord
 from ...storage.type import RECORD_TYPE_ACAPY_UPGRADING
 from ...utils.stats import Collector
@@ -107,6 +111,160 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             handler = mock.CoroutineMock(side_effect=KeyError("No such thing"))
             with self.assertRaises(KeyError):
                 await test_module.ready_middleware(request, handler)
+
+    async def test_ready_middleware_http_unauthorized(self):
+        """Test handling of web.HTTPUnauthorized and related exceptions."""
+        with mock.patch.object(test_module, "LOGGER", mock.MagicMock()) as mock_logger:
+            mock_logger.info = mock.MagicMock()
+
+            request = mock.MagicMock(
+                method="GET",
+                path="/unauthorized",
+                app=mock.MagicMock(_state={"ready": True}),
+            )
+
+            # Test web.HTTPUnauthorized
+            handler = mock.CoroutineMock(
+                side_effect=web.HTTPUnauthorized(reason="Unauthorized")
+            )
+            with self.assertRaises(web.HTTPUnauthorized):
+                await test_module.ready_middleware(request, handler)
+            mock_logger.info.assert_called_with(
+                "Unauthorized access during %s %s: %s",
+                request.method,
+                request.path,
+                handler.side_effect,
+            )
+
+            # Test jwt.InvalidTokenError
+            handler = mock.CoroutineMock(
+                side_effect=jwt.InvalidTokenError("Invalid token")
+            )
+            with self.assertRaises(web.HTTPUnauthorized):
+                await test_module.ready_middleware(request, handler)
+            mock_logger.info.assert_called_with(
+                "Unauthorized access during %s %s: %s",
+                request.method,
+                request.path,
+                handler.side_effect,
+            )
+
+            # Test InvalidTokenError (assuming custom exception)
+            handler = mock.CoroutineMock(
+                side_effect=test_module.InvalidTokenError("Token error")
+            )
+            with self.assertRaises(web.HTTPUnauthorized):
+                await test_module.ready_middleware(request, handler)
+            mock_logger.info.assert_called_with(
+                "Unauthorized access during %s %s: %s",
+                request.method,
+                request.path,
+                handler.side_effect,
+            )
+
+    async def test_ready_middleware_http_bad_request(self):
+        """Test handling of web.HTTPBadRequest and MultitenantManagerError."""
+        with mock.patch.object(test_module, "LOGGER", mock.MagicMock()) as mock_logger:
+            mock_logger.info = mock.MagicMock()
+
+            request = mock.MagicMock(
+                method="POST",
+                path="/bad-request",
+                app=mock.MagicMock(_state={"ready": True}),
+            )
+
+            # Test web.HTTPBadRequest
+            handler = mock.CoroutineMock(
+                side_effect=web.HTTPBadRequest(reason="Bad request")
+            )
+            with self.assertRaises(web.HTTPBadRequest):
+                await test_module.ready_middleware(request, handler)
+            mock_logger.info.assert_called_with(
+                "Bad request during %s %s: %s",
+                request.method,
+                request.path,
+                handler.side_effect,
+            )
+
+            # Test MultitenantManagerError
+            handler = mock.CoroutineMock(
+                side_effect=MultitenantManagerError("Multitenant error")
+            )
+            with self.assertRaises(web.HTTPBadRequest):
+                await test_module.ready_middleware(request, handler)
+            mock_logger.info.assert_called_with(
+                "Bad request during %s %s: %s",
+                request.method,
+                request.path,
+                handler.side_effect,
+            )
+
+    async def test_ready_middleware_http_not_found(self):
+        """Test handling of web.HTTPNotFound and StorageNotFoundError."""
+        with mock.patch.object(test_module, "LOGGER", mock.MagicMock()) as mock_logger:
+            mock_logger.info = mock.MagicMock()
+
+            request = mock.MagicMock(
+                method="GET",
+                path="/not-found",
+                app=mock.MagicMock(_state={"ready": True}),
+            )
+
+            # Test web.HTTPNotFound
+            handler = mock.CoroutineMock(side_effect=web.HTTPNotFound(reason="Not found"))
+            with self.assertRaises(web.HTTPNotFound):
+                await test_module.ready_middleware(request, handler)
+            mock_logger.info.assert_called_with(
+                "Not Found error occurred during %s %s: %s",
+                request.method,
+                request.path,
+                handler.side_effect,
+            )
+
+            # Test StorageNotFoundError
+            handler = mock.CoroutineMock(
+                side_effect=StorageNotFoundError("Item not found")
+            )
+            with self.assertRaises(web.HTTPNotFound):
+                await test_module.ready_middleware(request, handler)
+            mock_logger.info.assert_called_with(
+                "Not Found error occurred during %s %s: %s",
+                request.method,
+                request.path,
+                handler.side_effect,
+            )
+
+    async def test_ready_middleware_http_unprocessable_entity(self):
+        """Test handling of web.HTTPUnprocessableEntity with nested ValidationError."""
+        with mock.patch.object(test_module, "LOGGER", mock.MagicMock()) as mock_logger:
+            mock_logger.info = mock.MagicMock()
+            # Mock the extract_validation_error_message function
+            with mock.patch.object(
+                test_module, "extract_validation_error_message"
+            ) as mock_extract:
+                mock_extract.return_value = {"field": ["Invalid input"]}
+
+                request = mock.MagicMock(
+                    method="POST",
+                    path="/unprocessable",
+                    app=mock.MagicMock(_state={"ready": True}),
+                )
+
+                # Create a HTTPUnprocessableEntity exception with a nested ValidationError
+                validation_error = ValidationError({"field": ["Invalid input"]})
+                http_error = web.HTTPUnprocessableEntity(reason="Unprocessable Entity")
+                http_error.__cause__ = validation_error
+
+                handler = mock.CoroutineMock(side_effect=http_error)
+                with self.assertRaises(web.HTTPUnprocessableEntity):
+                    await test_module.ready_middleware(request, handler)
+                mock_extract.assert_called_once_with(http_error)
+                mock_logger.info.assert_called_with(
+                    "Unprocessable Entity occurred during %s %s: %s",
+                    request.method,
+                    request.path,
+                    mock_extract.return_value,
+                )
 
     def get_admin_server(
         self, settings: Optional[dict] = None, context: Optional[InjectionContext] = None

--- a/acapy_agent/askar/profile.py
+++ b/acapy_agent/askar/profile.py
@@ -75,7 +75,7 @@ class AskarProfile(Profile):
             read_only = bool(self.settings.get("ledger.read_only", False))
             socks_proxy = self.settings.get("ledger.socks_proxy")
             if read_only:
-                LOGGER.error("Note: setting ledger to read-only mode")
+                LOGGER.warning("Note: setting ledger to read-only mode")
             genesis_transactions = self.settings.get("ledger.genesis_transactions")
             cache = self.context.injector.inject_or(BaseCache)
             self.ledger_pool = IndyVdrLedgerPool(

--- a/acapy_agent/askar/profile_anon.py
+++ b/acapy_agent/askar/profile_anon.py
@@ -77,7 +77,7 @@ class AskarAnoncredsProfile(Profile):
             read_only = bool(self.settings.get("ledger.read_only", False))
             socks_proxy = self.settings.get("ledger.socks_proxy")
             if read_only:
-                LOGGER.error("Note: setting ledger to read-only mode")
+                LOGGER.warning("Note: setting ledger to read-only mode")
             genesis_transactions = self.settings.get("ledger.genesis_transactions")
             cache = self.context.injector.inject_or(BaseCache)
             self.ledger_pool = IndyVdrLedgerPool(

--- a/acapy_agent/protocols/out_of_band/v1_0/manager.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/manager.py
@@ -461,7 +461,7 @@ class InvitationCreator:
             did_method = PEER4 if did_peer_4 else PEER2
             my_info = await self.oob.fetch_invitation_reuse_did(did_method)
             if not my_info:
-                LOGGER.warn("No invitation DID found, creating new DID")
+                LOGGER.warning("No invitation DID found, creating new DID")
 
         if not my_info:
             did_metadata = (

--- a/acapy_agent/utils/extract_validation_error.py
+++ b/acapy_agent/utils/extract_validation_error.py
@@ -1,0 +1,16 @@
+"""Extract validation error messages from nested exceptions."""
+
+from aiohttp.web import HTTPUnprocessableEntity
+from marshmallow.exceptions import ValidationError
+
+
+def extract_validation_error_message(exc: HTTPUnprocessableEntity) -> str:
+    """Extract marshmallow error message from a nested UnprocessableEntity exception."""
+    visited = set()
+    current_exc = exc
+    while current_exc and current_exc not in visited:
+        visited.add(current_exc)
+        if isinstance(current_exc, ValidationError):
+            return current_exc.messages
+        current_exc = current_exc.__cause__ or current_exc.__context__
+    return exc.reason

--- a/acapy_agent/utils/tests/test_extract_validation_error.py
+++ b/acapy_agent/utils/tests/test_extract_validation_error.py
@@ -1,0 +1,77 @@
+import unittest
+
+from aiohttp.web import HTTPUnprocessableEntity
+from marshmallow.exceptions import ValidationError
+
+from ...utils.extract_validation_error import extract_validation_error_message
+
+
+class TestExtractValidationErrorMessage(unittest.TestCase):
+    def test_validation_error_extracted(self):
+        """Test that the validation error message is extracted when present."""
+        validation_error = ValidationError({"field": ["Invalid input"]})
+        http_error = HTTPUnprocessableEntity(reason="Unprocessable Entity")
+        http_error.__cause__ = validation_error
+
+        result = extract_validation_error_message(http_error)
+        self.assertEqual(result, {"field": ["Invalid input"]})
+
+    def test_no_validation_error_returns_reason(self):
+        """Test that the reason is returned when no ValidationError is found."""
+        http_error = HTTPUnprocessableEntity(reason="Unprocessable Entity")
+
+        result = extract_validation_error_message(http_error)
+        self.assertEqual(result, "Unprocessable Entity")
+
+    def test_deeply_nested_validation_error(self):
+        """Test extraction when ValidationError is nested deeply."""
+        validation_error = ValidationError({"field": ["Invalid input"]})
+        level_3 = Exception("Level 3")
+        level_3.__cause__ = validation_error
+        level_2 = Exception("Level 2")
+        level_2.__cause__ = level_3
+        http_error = HTTPUnprocessableEntity(reason="Unprocessable Entity")
+        http_error.__cause__ = level_2
+
+        result = extract_validation_error_message(http_error)
+        self.assertEqual(result, {"field": ["Invalid input"]})
+
+    def test_multiple_exceptions_no_validation_error(self):
+        """Test that reason is returned when no ValidationError is in the chain."""
+        level_2 = Exception("Level 2")
+        level_1 = Exception("Level 1")
+        level_1.__cause__ = level_2
+        http_error = HTTPUnprocessableEntity(reason="Unprocessable Entity")
+        http_error.__cause__ = level_1
+
+        result = extract_validation_error_message(http_error)
+        self.assertEqual(result, "Unprocessable Entity")
+
+    def test_validation_error_in_context(self):
+        """Test extraction when ValidationError is in __context__ instead of __cause__."""
+        validation_error = ValidationError({"field": ["Invalid input"]})
+        level_1 = Exception("Level 1")
+        level_1.__context__ = validation_error
+        http_error = HTTPUnprocessableEntity(reason="Unprocessable Entity")
+        http_error.__context__ = level_1
+
+        result = extract_validation_error_message(http_error)
+        self.assertEqual(result, {"field": ["Invalid input"]})
+
+    def test_exception_already_visited(self):
+        """Test that visited set prevents infinite loops."""
+        validation_error = ValidationError({"field": ["Invalid input"]})
+        http_error = HTTPUnprocessableEntity(reason="Unprocessable Entity")
+        # Create a loop in the exception chain
+        validation_error.__cause__ = http_error
+        http_error.__cause__ = validation_error
+
+        result = extract_validation_error_message(http_error)
+        self.assertEqual(result, {"field": ["Invalid input"]})
+
+    def test_validation_error_as_initial_exception(self):
+        """Test when the initial exception is a ValidationError."""
+        validation_error = ValidationError({"field": ["Invalid input"]})
+
+        result = extract_validation_error_message(validation_error)
+        self.assertEqual(result, {"field": ["Invalid input"]})


### PR DESCRIPTION
Closes #3322

Currently, NotFound and UnprocessableEntity errors would print stack traces in the logs. It is more sensible to record these as info logs, since they typically represent bad requests / client errors.

This PR contributes changes so that the new behaviour will print messages like:
```sh
Not Found error occurred during GET /connections/abe80270-051c-415b-9bb1-b74a86846276: Record not found: connection/abe80270-051c-415b-9bb1-b74a86846276
```

```sh
Unprocessable Entity occurred during GET /connections: {'querystring': {'their_public_did': ['Value None is not a valid DID']}}
```

A util method `extract_validation_error_message` was added to help print this marshmallow validation error, so that the logs still provide the error context previously contained in the stack trace.

___
:art: Other minor amendments included as well:
- logger.warn is deprecated in favour of logger.warning, so replaced one instance
- there were 2 error logs (`"Note: setting ledger to read-only mode"`). I opted to set these to warning level
- refactored `ready_middleware` to reduce complexity
- modified a fatal log to critical instead of error level