### PR TITLE
Fix tails upload for anoncreds multitenancy

### DIFF
--- a/acapy_agent/anoncreds/revocation.py
+++ b/acapy_agent/anoncreds/revocation.py
@@ -32,6 +32,8 @@ from ..askar.profile_anon import AskarAnoncredsProfile, AskarAnoncredsProfileSes
 from ..core.error import BaseError
 from ..core.event_bus import Event, EventBus
 from ..core.profile import Profile, ProfileSession
+from ..multitenant.base import BaseMultitenantManager
+from ..tails.anoncreds_tails_server import AnonCredsTailsServer
 from ..tails.base import BaseTailsServer
 from .error_messages import ANONCREDS_PROFILE_REQUIRED_MSG
 from .events import RevListFinishedEvent, RevRegDefFinishedEvent
@@ -694,7 +696,12 @@ class AnonCredsRevocation:
 
     async def upload_tails_file(self, rev_reg_def: RevRegDef):
         """Upload the local tails file to the tails server."""
-        tails_server = self.profile.inject_or(BaseTailsServer)
+        multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            tails_server = AnonCredsTailsServer()
+        else:
+            tails_server = self.profile.inject_or(BaseTailsServer)
+
         if not tails_server:
             raise AnonCredsRevocationError("Tails server not configured")
         if not Path(self.get_local_tails_path(rev_reg_def)).is_file():

--- a/acapy_agent/anoncreds/tests/test_revocation.py
+++ b/acapy_agent/anoncreds/tests/test_revocation.py
@@ -48,7 +48,7 @@ rev_reg_def = RevRegDef(
             "accum_key": {"z": "1 0BB...386"},
         },
         tails_hash="58NNWYnVxVFzAfUztwGSNBL4551XNq6nXk56pCiKJxxt",
-        tails_location="http://tails-server.com",
+        tails_location="https://tails-server.com",
     ),
     issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
     type="CL_ACCUM",
@@ -840,7 +840,7 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
                 None,
                 mock.MagicMock(
                     upload_tails_file=mock.CoroutineMock(
-                        return_value=(True, "http://tails-server.com")
+                        return_value=(True, "https://tails-server.com")
                     )
                 ),
             ]
@@ -853,7 +853,7 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
                 None,
                 mock.MagicMock(
                     upload_tails_file=mock.CoroutineMock(
-                        return_value=(None, "http://tails-server.com"),
+                        return_value=(None, "https://tails-server.com"),
                     )
                 ),
             ]


### PR DESCRIPTION
During some detailed testing I found that the tails file wasn't uploading for anoncreds tenants in multitenancy mode. It ended up injectecting the IndyTailsServer class.

This will be covered in a integration test in another PR.