### PR TITLE
fix: handle range proofs in presentation

### DIFF
--- a/acapy_agent/protocols/present_proof/v2_0/formats/indy/handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/indy/handler.py
@@ -287,12 +287,12 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
                     "primary_proof"
                 ]["ge_proofs"]:
                     proof_pred_spec = ge_proof["predicate"]
-                    if proof_pred_spec["attr_name"] != canon(req_name):
-                        continue
                     if not (
-                        Predicate.get(proof_pred_spec["p_type"]) is req_pred
-                        and proof_pred_spec["value"] == req_value
+                        proof_pred_spec["attr_name"] == canon(req_name)
+                        and Predicate.get(proof_pred_spec["p_type"]) is req_pred
                     ):
+                        continue
+                    if proof_pred_spec["value"] != req_value:
                         raise V20PresFormatHandlerError(
                             f"Presentation predicate on {req_name} "
                             "mismatches proposal request"


### PR DESCRIPTION
## Problem

If I specify multiple predicates on the same attribute when çreating a presentation request, like this:
```
requested_predicates: {
  age_gte: {
    name: "age",
    p_type: ">=",
    p_value: 20
  },
  age_lt: {
    name: "age",
    p_type: "<",
    p_value: 30
  }
}
```

The agent crashes due to this:
https://github.com/openwallet-foundation/acapy/blob/3d1682cd2cf6a485122d8e36ec47d1f5f37c1709/acapy_agent/protocols/present_proof/v2_0/formats/indy/handler.py#L295-L302

It happens when `reft` is `age_lt`(the second one) and `ge_proof["predicate"]` is `{ "attr_name": "age", "p_type": "GE", "value": 20 }`(the first one).
It should just skip the first `ge_proof` but the current implementation raises an exception instead.

## Solution

By checking both `"attr_name"` and `"p_type"` of `proof_pred_spec`, it is now possible to specify more than one predicate on a single attribute, enabling doing a range proof on an attribute.