### PR TITLE
Fix/universal resolver

### DIFF
--- a/acapy_agent/resolver/default/tests/test_universal.py
+++ b/acapy_agent/resolver/default/tests/test_universal.py
@@ -119,14 +119,28 @@ async def test_fetch_resolver_props(mock_client_session: MockClientSession):
 
 @pytest.mark.asyncio
 async def test_get_supported_did_regex():
-    props = {"example": {"http": {"pattern": "match a test string"}}}
+    # Example response from dev universal resolver 1.0
+    props = {
+        "^(did:sov:(?:(?:\\w[-\\w]*(?::\\w[-\\w]*)*):)?(?:[1-9A-HJ-NP-Za-km-z]{21,22}))$": {
+            "libIndyPath": "",
+            "openParallel": "false",
+            "poolVersions": "_;2;test;2;builder;2;danube;2;idunion;2;idunion:test;2;indicio;2;indicio:test;2;indicio:demo;2;nxd;2;findy:test;2;bcovrin;2;bcovrin:test;2;bcovrin:dev;2;candy;2;candy:test;2;candy:dev;2",
+            "submitterDidSeeds": "_;_;test;_;builder;_;danube;_;idunion;_;idunion:test;_;indicio;_;indicio:test;_;indicio:demo;_;nxd;_;findy:test;_;bcovrin;_;bcovrin:test;_;bcovrin:dev;_;candy;_;candy:test;_;candy:dev;_",
+            "http": {
+                "resolveUri": "http://driver-did-sov:8080/1.0/identifiers/",
+                "propertiesUri": "http://driver-did-sov:8080/1.0/properties",
+            },
+            "walletNames": "_;w1;test;w2;builder;w3;danube;w4;idunion;w5;idunion:test;w6;indicio;w7;indicio:test;w8;indicio:demo;w9;nxd;w11;findy:test;w12;bcovrin;w13;bcovrin:test;w14;bcovrin:dev;w15;candy;w16;candy:test;w17;candy:dev;w18",
+            "poolConfigs": "_;./sovrin/_.txn;test;./sovrin/test.txn;builder;./sovrin/builder.txn;danube;./sovrin/danube.txn;idunion;./sovrin/idunion.txn;idunion:test;./sovrin/idunion-test.txn;indicio;./sovrin/indicio.txn;indicio:test;./sovrin/indicio-test.txn;indicio:demo;./sovrin/indicio-demo.txn;nxd;./sovrin/nxd.txn;bcovrin:test;./sovrin/bcovrin-test.txn;candy;./sovrin/candy.txn;candy:test;./sovrin/candy-test.txn;candy:dev;./sovrin/candy-dev.txn",
+        }
+    }
     with mock.patch.object(
         UniversalResolver,
         "_fetch_resolver_props",
         mock.CoroutineMock(return_value=props),
     ):
         pattern = await UniversalResolver()._get_supported_did_regex()
-        assert pattern.fullmatch("match a test string")
+        assert pattern.match("did:sov:WRfXPg8dantKVubE3HX8pw")
 
 
 def test_compile_supported_did_regex():

--- a/acapy_agent/resolver/default/tests/test_universal.py
+++ b/acapy_agent/resolver/default/tests/test_universal.py
@@ -119,6 +119,16 @@ async def test_fetch_resolver_props(mock_client_session: MockClientSession):
 
 @pytest.mark.asyncio
 async def test_get_supported_did_regex():
+    # Old response format
+    props = {"example": {"http": {"pattern": "match a test string"}}}
+    with mock.patch.object(
+        UniversalResolver,
+        "_fetch_resolver_props",
+        mock.CoroutineMock(return_value=props),
+    ):
+        pattern = await UniversalResolver()._get_supported_did_regex()
+        assert pattern.fullmatch("match a test string")
+
     # Example response from dev universal resolver 1.0
     props = {
         "^(did:sov:(?:(?:\\w[-\\w]*(?::\\w[-\\w]*)*):)?(?:[1-9A-HJ-NP-Za-km-z]{21,22}))$": {

--- a/acapy_agent/resolver/default/universal.py
+++ b/acapy_agent/resolver/default/universal.py
@@ -112,6 +112,4 @@ class UniversalResolver(BaseDIDResolver):
 
     async def _get_supported_did_regex(self) -> Pattern:
         props = await self._fetch_resolver_props()
-        return _compile_supported_did_regex(
-            driver["http"]["pattern"] for driver in props.values()
-        )
+        return _compile_supported_did_regex(driver for driver in props.keys())

--- a/acapy_agent/resolver/default/universal.py
+++ b/acapy_agent/resolver/default/universal.py
@@ -110,6 +110,16 @@ class UniversalResolver(BaseDIDResolver):
                     "Failed to retrieve resolver properties: " + await resp.text()
                 )
 
-    async def _get_supported_did_regex(self) -> Pattern:
+    async def _get_supported_did_regex(self):
         props = await self._fetch_resolver_props()
-        return _compile_supported_did_regex(driver for driver in props.keys())
+
+        def _get_patterns():
+            """Handle both old and new properties responses."""
+            patterns = list(props.values())[0].get("http", {}).get("pattern")
+            if not patterns:
+                return props.keys()
+            else:
+                return [driver["http"]["pattern"] for driver in props.values()]
+
+        patterns = _get_patterns()
+        return _compile_supported_did_regex(patterns)


### PR DESCRIPTION
The `https://dev.uniresolver.io/1.0/properties` endpoint which is the default url for the universal resolver changed recently and acapy failed to handle the response.

The patterns are now the keys of the json payload.