### PR TITLE
:art: Replace deprecated ABC decorators

### DIFF
--- a/acapy_agent/messaging/base_message.py
+++ b/acapy_agent/messaging/base_message.py
@@ -1,6 +1,6 @@
 """Base message."""
 
-from abc import ABC, abstractclassmethod, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Optional, Type
 
@@ -23,15 +23,18 @@ class BaseMessage(ABC):
     the context of the plugin.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _type(self) -> str:
         """Return message type."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _id(self) -> str:
         """Return message id."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _thread_id(self) -> Optional[str]:
         """Return message thread id."""
 
@@ -39,10 +42,12 @@ class BaseMessage(ABC):
     def serialize(self, msg_format: DIDCommVersion = DIDCommVersion.v1) -> dict:
         """Return serialized message in format specified."""
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def deserialize(cls, value: dict, msg_format: DIDCommVersion = DIDCommVersion.v1):
         """Return message object deserialized from value in format specified."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def Handler(self) -> Type["BaseHandler"]:
         """Return reference to handler class."""

--- a/acapy_agent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/formats/handler.py
@@ -1,7 +1,7 @@
 """V2.0 issue-credential base credential format handler."""
 
 import logging
-from abc import ABC, abstractclassmethod, abstractmethod
+from abc import ABC, abstractmethod
 from typing import Mapping, Optional, Tuple
 
 from .....core.error import BaseError
@@ -60,7 +60,8 @@ class V20CredFormatHandler(ABC):
     def get_format_data(self, message_type: str, data: dict) -> CredFormatAttachment:
         """Get credential format and attachment objects for use in cred ex messages."""
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def validate_fields(cls, message_type: str, attachment_data: dict) -> None:
         """Validate attachment data for specific message type and format."""
 

--- a/acapy_agent/protocols/present_proof/v2_0/formats/handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/handler.py
@@ -1,7 +1,7 @@
 """present-proof-v2 format handler - supports ANONCREDS, DIF and INDY."""
 
 import logging
-from abc import ABC, abstractclassmethod, abstractmethod
+from abc import ABC, abstractmethod
 from typing import Optional, Tuple
 
 from .....core.error import BaseError
@@ -56,7 +56,8 @@ class V20PresFormatHandler(ABC):
     def get_format_data(self, message_type: str, data: dict) -> PresFormatAttachment:
         """Get presentation format and attach objects for use in pres_ex messages."""
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def validate_fields(cls, message_type: str, attachment_data: dict) -> None:
         """Validate attachment data for specific message type and format."""
 

--- a/acapy_agent/vc/ld_proofs/crypto/key_pair.py
+++ b/acapy_agent/vc/ld_proofs/crypto/key_pair.py
@@ -1,6 +1,6 @@
 """Base key pair class."""
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import List, Optional, Union
 
 
@@ -15,7 +15,8 @@ class KeyPair(ABC):
     async def verify(self, message: Union[List[bytes], bytes], signature: bytes) -> bool:
         """Verify message(s) against signature using key pair."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def has_public_key(self) -> bool:
         """Whether key pair has a public key.
 
@@ -23,7 +24,8 @@ class KeyPair(ABC):
         in the verification process.
         """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def public_key(self) -> Optional[bytes]:
         """Getter for the public key bytes.
 


### PR DESCRIPTION
`@abstractclassmethod` and `@abstractproperty` are deprecated.
Replaced with `@classmethod @abstractmethod` and `@property @abstractmethod`