### PR TITLE
Update anoncreds format names

### DIFF
--- a/acapy_agent/protocols/issue_credential/v2_0/message_types.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/message_types.py
@@ -37,25 +37,25 @@ CRED_20_PREVIEW = "issue-credential/2.0/credential-preview"
 # Format specifications
 ATTACHMENT_FORMAT = {
     CRED_20_PROPOSAL: {
-        V20CredFormat.Format.ANONCREDS.api: "anoncreds/cred-filter@v2.0",
+        V20CredFormat.Format.ANONCREDS.api: "anoncreds/credential-filter@v1.0",
         V20CredFormat.Format.INDY.api: "hlindy/cred-filter@v2.0",
         V20CredFormat.Format.LD_PROOF.api: "aries/ld-proof-vc-detail@v1.0",
         V20CredFormat.Format.VC_DI.api: "didcomm/w3c-di-vc@v0.1",
     },
     CRED_20_OFFER: {
-        V20CredFormat.Format.ANONCREDS.api: "anoncreds/cred-abstract@v2.0",
+        V20CredFormat.Format.ANONCREDS.api: "anoncreds/credential-offer@v1.0",
         V20CredFormat.Format.INDY.api: "hlindy/cred-abstract@v2.0",
         V20CredFormat.Format.LD_PROOF.api: "aries/ld-proof-vc-detail@v1.0",
         V20CredFormat.Format.VC_DI.api: "didcomm/w3c-di-vc-offer@v0.1",
     },
     CRED_20_REQUEST: {
-        V20CredFormat.Format.ANONCREDS.api: "anoncreds/cred-req@v2.0",
+        V20CredFormat.Format.ANONCREDS.api: "anoncreds/credential-request@v1.0",
         V20CredFormat.Format.INDY.api: "hlindy/cred-req@v2.0",
         V20CredFormat.Format.LD_PROOF.api: "aries/ld-proof-vc-detail@v1.0",
         V20CredFormat.Format.VC_DI.api: "didcomm/w3c-di-vc-request@v0.1",
     },
     CRED_20_ISSUE: {
-        V20CredFormat.Format.ANONCREDS.api: "anoncreds/cred@v2.0",
+        V20CredFormat.Format.ANONCREDS.api: "anoncreds/credential@v1.0",
         V20CredFormat.Format.INDY.api: "hlindy/cred@v2.0",
         V20CredFormat.Format.LD_PROOF.api: "aries/ld-proof-vc@v1.0",
         V20CredFormat.Format.VC_DI.api: "didcomm/w3c-di-vc@v0.1",

--- a/acapy_agent/protocols/issue_credential/v2_0/routes.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/routes.py
@@ -28,6 +28,7 @@ from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
 from ....messaging.valid import (
+    ANONCREDS_CRED_DEF_ID_EXAMPLE,
     ANONCREDS_DID_EXAMPLE,
     ANONCREDS_SCHEMA_ID_EXAMPLE,
     INDY_CRED_DEF_ID_EXAMPLE,
@@ -137,11 +138,22 @@ class V20CredStoreRequestSchema(OpenAPISchema):
 class V20CredFilterAnoncredsSchema(OpenAPISchema):
     """Anoncreds credential filtration criteria."""
 
-    cred_def_id = fields.Str(
+    schema_issuer_id = fields.Str(
         required=False,
         metadata={
-            "description": "Credential definition identifier",
+            "description": "Schema issuer ID",
             "example": ANONCREDS_DID_EXAMPLE,
+        },
+    )
+    schema_name = fields.Str(
+        required=False,
+        metadata={"description": "Schema name", "example": "preferences"},
+    )
+    schema_version = fields.Str(
+        required=False,
+        metadata={
+            "description": "Schema version",
+            "example": MAJOR_MINOR_VERSION_EXAMPLE,
         },
     )
     schema_id = fields.Str(
@@ -154,13 +166,16 @@ class V20CredFilterAnoncredsSchema(OpenAPISchema):
     issuer_id = fields.Str(
         required=False,
         metadata={
-            "description": "Credential issuer DID",
+            "description": "Credential issuer ID",
             "example": ANONCREDS_DID_EXAMPLE,
         },
     )
-    epoch = fields.Str(
+    cred_def_id = fields.Str(
         required=False,
-        metadata={"description": "Credential epoch time", "example": "2021-08-24"},
+        metadata={
+            "description": "Credential definition identifier",
+            "example": ANONCREDS_CRED_DEF_ID_EXAMPLE,
+        },
     )
 
 

--- a/acapy_agent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -61,6 +61,29 @@ class TestV20CredRoutes(IsolatedAsyncioTestCase):
         with self.assertRaises(test_module.ValidationError):
             schema.validate_fields({"veres-one": {"no": "support"}})
 
+    async def test_validate_cred_filter_anoncreds_schema(self):
+        schema = test_module.V20CredFilterSchema()
+        schema.validate_fields({"anoncreds": {"issuer_id": TEST_DID}})
+        schema.validate_fields(
+            {"anoncreds": {"issuer_id": TEST_DID, "schema_version": "1.0"}}
+        )
+        schema.validate_fields(
+            {
+                "anoncreds": {"issuer_id": TEST_DID},
+            }
+        )
+        schema.validate_fields(
+            {
+                "anoncreds": {},
+            }
+        )
+        with self.assertRaises(test_module.ValidationError):
+            schema.validate_fields({})
+        with self.assertRaises(test_module.ValidationError):
+            schema.validate_fields(["hopeless", "stop"])
+        with self.assertRaises(test_module.ValidationError):
+            schema.validate_fields({"veres-one": {"no": "support"}})
+
     async def test_validate_create_schema(self):
         schema = test_module.V20IssueCredSchemaCore()
         schema.validate(

--- a/acapy_agent/protocols/present_proof/v2_0/message_types.py
+++ b/acapy_agent/protocols/present_proof/v2_0/message_types.py
@@ -32,17 +32,17 @@ MESSAGE_TYPES = DIDCommPrefix.qualify_all(
 # Format specifications
 ATTACHMENT_FORMAT = {
     PRES_20_PROPOSAL: {
-        V20PresFormat.Format.ANONCREDS.api: "anoncreds/proof-req@v2.0",
+        V20PresFormat.Format.ANONCREDS.api: "anoncreds/proof-proposal@v1.0",
         V20PresFormat.Format.INDY.api: "hlindy/proof-req@v2.0",
         V20PresFormat.Format.DIF.api: "dif/presentation-exchange/definitions@v1.0",
     },
     PRES_20_REQUEST: {
-        V20PresFormat.Format.ANONCREDS.api: "anoncreds/proof-req@v2.0",
+        V20PresFormat.Format.ANONCREDS.api: "anoncreds/proof-request@v1.0",
         V20PresFormat.Format.INDY.api: "hlindy/proof-req@v2.0",
         V20PresFormat.Format.DIF.api: "dif/presentation-exchange/definitions@v1.0",
     },
     PRES_20: {
-        V20PresFormat.Format.ANONCREDS.api: "anoncreds/proof@v2.0",
+        V20PresFormat.Format.ANONCREDS.api: "anoncreds/proof@v1.0",
         V20PresFormat.Format.INDY.api: "hlindy/proof@v2.0",
         V20PresFormat.Format.DIF.api: "dif/presentation-exchange/submission@v1.0",
     },


### PR DESCRIPTION
These format names need to match the RFC. Also the extra credential request params that I didn't include are needed as per the RFC.

See:
 - https://github.com/hyperledger/aries-rfcs/blob/main/features/0771-anoncreds-attachments/README.md#credential-filter-format
 - https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md