### PR TITLE
:art: Fix model name for consistency

### DIFF
--- a/acapy_agent/anoncreds/models/presentation_request.py
+++ b/acapy_agent/anoncreds/models/presentation_request.py
@@ -299,7 +299,7 @@ class AnoncredsPresentationRequestSchema(BaseModelSchema):
                     },
                 ),
             },
-            name="AnoncredPresentationRequestNonRevokedSchema",
+            name="AnoncredsPresentationRequestNonRevokedSchema",
         ),
         allow_none=True,
         required=False,

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -7763,7 +7763,7 @@
         },
         "type" : "object"
       },
-      "AnoncredPresentationRequestNonRevoked" : {
+      "AnoncredsPresentationRequestNonRevoked" : {
         "properties" : {
           "from" : {
             "description" : "Earliest time of interest in non-revocation interval",
@@ -7895,7 +7895,7 @@
             "type" : "string"
           },
           "non_revoked" : {
-            "$ref" : "#/components/schemas/AnoncredPresentationRequestNonRevoked"
+            "$ref" : "#/components/schemas/AnoncredsPresentationRequestNonRevoked"
           },
           "nonce" : {
             "description" : "Nonce",

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -6396,7 +6396,7 @@
         }
       }
     },
-    "AnoncredPresentationRequestNonRevoked" : {
+    "AnoncredsPresentationRequestNonRevoked" : {
       "type" : "object",
       "properties" : {
         "from" : {
@@ -6530,7 +6530,7 @@
           "description" : "Proof request name"
         },
         "non_revoked" : {
-          "$ref" : "#/definitions/AnoncredPresentationRequestNonRevoked"
+          "$ref" : "#/definitions/AnoncredsPresentationRequestNonRevoked"
         },
         "nonce" : {
           "type" : "string",


### PR DESCRIPTION
Noticed a very minor naming inconsistency. 

Just renaming an openapi schema from Anoncred.. to Anoncreds..