### PR TITLE
Fix sonar coverage on merge main

### DIFF
--- a/.github/workflows/sonar-merge-main.yml
+++ b/.github/workflows/sonar-merge-main.yml
@@ -19,10 +19,6 @@ jobs:
             python-version: "3.12"
             os: "ubuntu-latest"
             is_pr: "false" 
-      - name: Adjust Test Coverage Source
-        run: |
-            # Need to change source in coverage report because it was generated from another context
-            sed -i 's/\/home\/runner\/work\/acapy\/acapy\//\/github\/workspace\//g' test-reports/coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
The coverage report when merging to main used to need to be adjusted from the github actions runner location to the workspace. This doesn't seem to be the case anymore. I did this adjustment for my forked branch and got the report to sonarcloud.

![image](https://github.com/user-attachments/assets/a2e062c1-4400-4728-9f85-324fcfbc051d)

I'm not 100% this will work, but it won't cause any problems.