### PR TITLE
Switch to COPY commands in dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:${python_version}-slim-bullseye AS build
 
 WORKDIR /src
 
-ADD . .
+COPY . .
 
 RUN pip install --no-cache-dir poetry
 RUN poetry build

--- a/docker/Dockerfile.bdd
+++ b/docker/Dockerfile.bdd
@@ -4,6 +4,6 @@ FROM faber-alice-demo
 RUN pip3 install --no-cache-dir -r demo/requirements.behave.txt
 
 WORKDIR ./demo
-ADD demo/multi_ledger_config_bdd.yml ./demo/multi_ledger_config.yml
+COPY demo/multi_ledger_config_bdd.yml ./demo/multi_ledger_config.yml
 RUN chmod a+w .
 ENTRYPOINT ["behave"]

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -9,25 +9,25 @@ RUN mkdir -p bin && curl -L -o bin/jq \
 	https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
 	chmod ug+x bin/jq
 
-# Add and install Aries Agent code
+# Copy and install Aries Agent code
 RUN pip install --no-cache-dir poetry
 
-ADD README.md pyproject.toml poetry.lock ./
+COPY README.md pyproject.toml poetry.lock ./
 
 ARG all_extras=0
 RUN if ! [ -z ${all_extras} ]; then poetry install --no-root --no-directory --all-extras; else poetry install --no-root --no-directory -E "didcommv2"; fi
 
-ADD acapy_agent ./acapy_agent
-ADD scripts ./scripts
+COPY acapy_agent ./acapy_agent
+COPY scripts ./scripts
 
 RUN pip3 install --no-cache-dir -e .
 
 RUN mkdir demo && chown -R aries:aries demo && chmod -R ug+rw demo
 
-# Add and install demo code
-ADD demo/requirements.txt ./demo/requirements.txt
+# Copy and install demo code
+COPY demo/requirements.txt ./demo/requirements.txt
 RUN pip3 install --no-cache-dir -r demo/requirements.txt
 
-ADD demo ./demo
+COPY demo ./demo
 
 ENTRYPOINT ["bash", "-c", "demo/ngrok-wait.sh \"$@\"", "--"]

--- a/docker/Dockerfile.run
+++ b/docker/Dockerfile.run
@@ -15,12 +15,12 @@ RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN pip install --no-cache-dir poetry
 
 RUN mkdir -p acapy_agent && touch acapy_agent/__init__.py
-ADD pyproject.toml poetry.lock README.md ./
+COPY pyproject.toml poetry.lock README.md ./
 RUN mkdir -p log && chmod -R ug+rw log
 
 ARG all_extras=0
 RUN if ! [ -z ${all_extras} ]; then poetry install --all-extras; else poetry install -E "didcommv2"; fi
 
-ADD . .
+COPY . .
 
 ENTRYPOINT ["/bin/bash", "-c", "poetry run aca-py \"$@\"", "--"]

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -11,12 +11,12 @@ WORKDIR /usr/src/app
 
 RUN pip install --no-cache-dir poetry
 
-ADD ./README.md pyproject.toml ./poetry.lock ./
+COPY ./README.md pyproject.toml ./poetry.lock ./
 RUN mkdir acapy_agent && touch acapy_agent/__init__.py
 
 ARG all_extras=0
 RUN if ! [ -z ${all_extras} ]; then poetry install --no-directory --all-extras --with=dev; else poetry install --no-directory -E "didcommv2" --with=dev; fi
 
-ADD . .
+COPY . .
 
 ENTRYPOINT ["/bin/bash", "-c", "poetry run pytest \"$@\"", "--"]


### PR DESCRIPTION
> Using the ADD instruction instead of COPY for local resources in Dockerfiles can lead to several issues, including unexpected behavior, increased complexity, and security risks. The ADD instruction has additional features that can introduce unintended side effects, such as automatically extracting compressed files and fetching remote resources. This can make the behavior of the instruction less predictable and harder to understand or even lead to security issues, if, for example, due to a typo in the source path, the ADD instruction could fetch a remote resource instead of copying a local file.
> 
> If you only need to copy local files or directories into your Docker image, it is recommended to use the COPY instruction instead. Only use the ADD instruction when you need its additional features, such as fetching remote resources or extracting compressed files. See also the rule [S7026](https://sonarcloud.io/organizations/openwallet-foundation/rules?open=docker%3AS7026&rule_key=docker%3AS7026) for more information on using the ADD instruction to fetch remote resources.

Easy fix for the low rated security issues in Sonarcloud.