### PR TITLE
Patch PR 3391 - 0.11.lts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,12 +51,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref || '' }}
-
-      - name: Gather image info
-        id: info
-        run: |
-          echo "repo-owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
-
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
@@ -72,15 +66,15 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: hyperledger
+          password: ${{ secrets.HYPERLEDGER_GHCR_PAT }}
 
       - name: Setup Image Metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/${{ steps.info.outputs.repo-owner }}/aries-cloudagent-python
+            ghcr.io/hyperledger/aries-cloudagent-python
           tags: |
             type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
 

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,20 +7,23 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aries-cloudagent
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-      - name: Install dependencies
+          python-version: "3.9"
+      - name: Install build and publish dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine poetry
       - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           poetry build
-          twine upload dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -5,7 +5,6 @@ import logging
 import time
 
 # import traceback
-
 from typing import Any, Mapping
 from weakref import ref
 
@@ -26,8 +25,7 @@ from ..storage.vc_holder.base import VCHolder
 from ..utils.multi_ledger import get_write_ledger_config_for_profile
 from ..wallet.base import BaseWallet
 from ..wallet.crypto import validate_seed
-
-from .store import AskarStoreConfig, AskarOpenStore
+from .store import AskarOpenStore, AskarStoreConfig
 
 LOGGER = logging.getLogger(__name__)
 
@@ -118,7 +116,7 @@ class AskarProfile(Profile):
             VCHolder,
             ClassProvider(
                 "aries_cloudagent.storage.vc_holder.askar.AskarVCHolder",
-                ref(self),
+                ClassProvider.Inject(Profile),
             ),
         )
         if (

--- a/aries_cloudagent/storage/vc_holder/tests/test_askar_vc_holder.py
+++ b/aries_cloudagent/storage/vc_holder/tests/test_askar_vc_holder.py
@@ -1,12 +1,10 @@
 import pytest
 
-
 from ....askar.profile import AskarProfileManager
 from ....config.injection_context import InjectionContext
-
+from ..askar import AskarVCHolder
 from ..base import VCHolder
 from ..vc_record import VCRecord
-
 from . import test_in_memory_vc_holder as in_memory
 
 
@@ -22,6 +20,7 @@ async def make_profile():
             "key_derivation_method": "RAW",  # much faster than using argon-hashed keys
         },
     )
+    profile.context.injector.bind_instance(VCHolder, AskarVCHolder(profile))
     return profile
 
 


### PR DESCRIPTION
For this to work someone with access to https://pypi.org/project/aries-cloudagent/ needs to set a new publisher.

Then we also need someone from hyperledger to set the new HYPERLEDGER_GHCR_PAT token in the openwallet-foundation repo. See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic.

> secrets.HYPERLEDGER_GHCR_PAT 
