### PR TITLE
Patch PR 3391 - 0.12.lts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,12 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || '' }}
-
-      - name: Gather image info
-        id: info
-        run: |
-          echo "repo-owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
-
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -72,15 +66,15 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: hyperledger
+          password: ${{ secrets.HYPERLEDGER_GHCR_PAT }}
 
       - name: Setup Image Metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ steps.info.outputs.repo-owner }}/aries-cloudagent-python
+            ghcr.io/hyperledger/aries-cloudagent-python
           tags: |
             type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
 

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,20 +7,23 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aries-cloudagent
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-      - name: Install dependencies
+          python-version: "3.9"
+      - name: Install build and publish dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine poetry
       - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           poetry build
-          twine upload dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -118,7 +118,7 @@ class AskarProfile(Profile):
             VCHolder,
             ClassProvider(
                 "aries_cloudagent.storage.vc_holder.askar.AskarVCHolder",
-                ref(self),
+                ClassProvider.Inject(Profile),
             ),
         )
         if (


### PR DESCRIPTION
We need someone from hyperledger to set the new HYPERLEDGER_GHCR_PAT token in the openwallet-foundation repo. See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic

> secrets.HYPERLEDGER_GHCR_PAT 
