### PR TITLE
Remove sonar cov report move step

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -51,12 +51,6 @@ jobs:
           echo base branch = ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
 
           git checkout -B temp-branch-for-scanning upstream/${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-      - name: Move Coverage Report And Adjust Source
-        run: |
-          mkdir test-reports
-          mv coverage.xml test-reports
-          # Need to change source in coverage report because it was generated from another context
-          sed -i 's/\/home\/runner\/work\/acapy\/acapy\//\/github\/workspace\//g' test-reports/coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@master
         env:


### PR DESCRIPTION
Something changed with github actions and this step to move the coverage report is no longer needed. It was done already for merge to main, but it affected the PR workflow as well. 

It needs to be merged to main before taking effect.