### PR TITLE
Adjust coverage location for sonarcloud

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -64,5 +64,5 @@ jobs:
             -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
             -Dsonar.coverage.exclusions=**/tests/**,**/demo/**,**/docs/**,**/docker/**,**/scripts/**,**/scenarios/**
             -Dsonar.cpd.exclusions=**/tests/**,**/demo/**,**/docs/**,**/docker/**,**/scripts/**,**/scenarios/**
-            -Dsonar.python.coverage.reportPaths=test-reports/coverage.xml
+            -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.sources=./


### PR DESCRIPTION
Ok. This should actually fix the sonar coverage reporting. 

Github actions did change so that last PR was needed. However, the coverage report gets saved at the current location now. It no longer needs to be moved into a test-reports folder. 

It actually probably didn't need to do this before. Just needed to move from the runner location to the workspace location. That's what changed.