### PR TITLE
Add explicit token for publishing

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -27,3 +27,5 @@ jobs:
           poetry build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_HYPERLEDGER }}


### PR DESCRIPTION
[Based on this](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#advanced-release-management)