### PR TITLE
Add legacy pypi token

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -27,3 +27,5 @@ jobs:
           poetry build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_HYPERLEDGER }}


### PR DESCRIPTION
Adds the legacy pypi token to the 0.12.lts branch for publishing to hyperledger aries-cloudagent package.