### PR TITLE
Anoncreds post api object handling

### DIFF
--- a/acapy_agent/anoncreds/models/schema.py
+++ b/acapy_agent/anoncreds/models/schema.py
@@ -64,6 +64,7 @@ class AnonCredsSchemaSchema(BaseModelSchema):
             "example": ANONCREDS_DID_EXAMPLE,
         },
         data_key="issuerId",
+        required=True,
     )
     attr_names = fields.List(
         fields.Str(
@@ -74,11 +75,15 @@ class AnonCredsSchemaSchema(BaseModelSchema):
         ),
         metadata={"description": "Schema attribute names"},
         data_key="attrNames",
+        required=True,
     )
     name = fields.Str(
-        metadata={"description": "Schema name", "example": "Example schema"}
+        metadata={"description": "Schema name", "example": "Example schema"},
+        required=True,
     )
-    version = fields.Str(metadata={"description": "Schema version", "example": "1.0"})
+    version = fields.Str(
+        metadata={"description": "Schema version", "example": "1.0"}, required=True
+    )
 
 
 class GetSchemaResult(BaseModel):

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -192,6 +192,11 @@ async def schemas_post(request: web.BaseRequest):
     name = schema_data.get("name")
     version = schema_data.get("version")
 
+    if not issuer_id or not attr_names or not name or not version:
+        raise web.HTTPBadRequest(
+            reason="issuerId, attrNames, name, and version are required"
+        )
+
     try:
         issuer = AnonCredsIssuer(profile)
         result = await issuer.create_and_register_schema(
@@ -524,6 +529,7 @@ class InnerRevRegDefSchema(OpenAPISchema):
             "example": ANONCREDS_DID_EXAMPLE,
         },
         data_key="issuerId",
+        required=True,
     )
     cred_def_id = fields.Str(
         metadata={
@@ -531,9 +537,11 @@ class InnerRevRegDefSchema(OpenAPISchema):
             "example": ANONCREDS_SCHEMA_ID_EXAMPLE,
         },
         data_key="credDefId",
+        required=True,
     )
     tag = fields.Str(
-        metadata={"description": "tag for revocation registry", "example": "default"}
+        metadata={"description": "tag for revocation registry", "example": "default"},
+        required=True,
     )
     max_cred_num = fields.Int(
         metadata={
@@ -541,6 +549,7 @@ class InnerRevRegDefSchema(OpenAPISchema):
             "example": 777,
         },
         data_key="maxCredNum",
+        required=True,
     )
 
 
@@ -649,7 +658,8 @@ class RevListCreateRequestSchema(OpenAPISchema):
         metadata={
             "description": "Revocation registry definition identifier",
             "example": ANONCREDS_REV_REG_ID_EXAMPLE,
-        }
+        },
+        required=True,
     )
     options = fields.Nested(RevListOptionsSchema)
 

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -192,11 +192,6 @@ async def schemas_post(request: web.BaseRequest):
     name = schema_data.get("name")
     version = schema_data.get("version")
 
-    if not issuer_id or not attr_names or not name or not version:
-        raise web.HTTPBadRequest(
-            reason="issuerId, attrNames, name, and version are required"
-        )
-
     try:
         issuer = AnonCredsIssuer(profile)
         result = await issuer.create_and_register_schema(

--- a/acapy_agent/anoncreds/tests/test_routes.py
+++ b/acapy_agent/anoncreds/tests/test_routes.py
@@ -97,6 +97,13 @@ class TestAnoncredsRoutes(IsolatedAsyncioTestCase):
                 },
                 {},
                 {"schema": {}},
+                {
+                    "schema": {
+                        "attrNames": ["score"],
+                        "name": "Example Schema",
+                        "version": "0.0.1",
+                    }
+                },
             ]
         )
         result = await test_module.schemas_post(self.request)
@@ -105,9 +112,12 @@ class TestAnoncredsRoutes(IsolatedAsyncioTestCase):
         assert mock_create_and_register_schema.call_count == 1
 
         with self.assertRaises(web.HTTPBadRequest):
+            # Empty body
             await test_module.schemas_post(self.request)
-
-        await test_module.schemas_post(self.request)
+            # Empty schema
+            await test_module.schemas_post(self.request)
+            # Missing issuerId
+            await test_module.schemas_post(self.request)
 
     async def test_get_schema(self):
         self.request.match_info = {"schema_id": "schema_id"}


### PR DESCRIPTION
The required values in the anoncreds POST object need to declare them as required explicitly to get the desired response.

```json
{
  "json": {
    "schema": {
      "issuerId": [
        "Missing data for required field."
      ]
    }
  }
}
```