### PR TITLE
Pin poetry to 1.8.3 in dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 
 COPY . .
 
-RUN pip install --no-cache-dir poetry
+RUN pip install --no-cache-dir poetry==1.8.3
 RUN poetry build
 
 FROM python:${python_version}-slim-bullseye AS main

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -10,7 +10,7 @@ RUN mkdir -p bin && curl -L -o bin/jq \
 	chmod ug+x bin/jq
 
 # Copy and install Aries Agent code
-RUN pip install --no-cache-dir poetry
+RUN pip install --no-cache-dir poetry==1.8.3
 
 COPY README.md pyproject.toml poetry.lock ./
 

--- a/docker/Dockerfile.run
+++ b/docker/Dockerfile.run
@@ -12,7 +12,7 @@ WORKDIR /usr/src/app
 # For consistency with base images, include curl for healthchecks
 RUN apt-get update && apt-get install -y curl && apt-get clean
 
-RUN pip install --no-cache-dir poetry
+RUN pip install --no-cache-dir poetry==1.8.3
 
 RUN mkdir -p acapy_agent && touch acapy_agent/__init__.py
 COPY pyproject.toml poetry.lock README.md ./

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -9,7 +9,7 @@ RUN apt-get update -y && \
 
 WORKDIR /usr/src/app
 
-RUN pip install --no-cache-dir poetry
+RUN pip install --no-cache-dir poetry==1.8.3
 
 COPY ./README.md pyproject.toml ./poetry.lock ./
 RUN mkdir acapy_agent && touch acapy_agent/__init__.py


### PR DESCRIPTION
Yesterday, poetry released a major breaking change version `2.0.0`. https://python-poetry.org/history/#200---2025-01-05

Our dockerfiles weren't pinned to a version and this caused the project to not install properly. Causing scenario tests which use the Dockerfile.run image to fail.