### PR TITLE
Fix devcontainer poetry install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.12"
 FROM mcr.microsoft.com/devcontainers/python:${VARIANT}
 
-ARG POETRY_VERSION="1.4"
+ARG POETRY_VERSION="1.8.3"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 
@@ -17,5 +17,5 @@ RUN curl -sSL https://install.python-poetry.org | python3 - \
 
 COPY pyproject.toml poetry.lock ./
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-root --no-interaction -E "askar didcommv2" \
+    && poetry install --no-root --no-interaction -E "didcommv2" \
     && rm -rf /root/.cache/pypoetry


### PR DESCRIPTION
The devcontainer poetry install needed to be updated for the changed extras. `askar` is a direct dependency now and can't be installed as an extra.