### PR TITLE
1.2.0

### DIFF
--- a/.github/workflows/snyk-lts.yml
+++ b/.github/workflows/snyk-lts.yml
@@ -5,7 +5,6 @@ on:
     # These branches represent the LTS releases
     branches:
       - 0.12.lts
-      - 0.11.lts
     paths:
       - acapy_agent/**
       - docker/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,30 @@
 # Aries Cloud Agent Python Changelog
 
-## 1.2.0rc0
+## 1.2.0
 
-### December 24, 2024
+### January 7, 2025
 
 Release 1.2.0 is a minor update to ACA-Py that contains an update to the AnonCreds implementation to make it easier to deploy on other than Hyperledger Indy, and a lengthy list of adjustments, improvements and fixes, with a focus on removing technical debt. In addition to the AnonCreds updates, the most visible change is the removal of the "in-memory wallet" implementation in favour of using the SQLite in-memory wallet (`sqlite://:memory:`), including removing the logic for handling that extra wallet type. In removing the in-memory wallet, all of the unit and integration tests that used the in-memory wallet have been updated to use SQLite's in-memory wallet.
+
+Release 1.2.x is the new current Long Term Support (LTS) for ACA-Py, as defined in the [LTS Strategy](./LTS-Strategy.md) document. With this release, the "end of life" for the previous "current LTS release" -- [0.12](#0123) -- is set for October 2025.
 
 The first step to full support of [did:webvh](https://identity.foundation/didwebvh/) ("`did:web` + Verifiable History"-- formerly `did:tdw`) has been added to ACA-Py -- a resolver. We're working on improving the new DID Registration mechanism for it, [Cheqd] and other DID Methods, enabling ACA-Py to be used easily with a variety of DID Methods.
 
 [Cheqd]: https://cheqd.io/
 
-The move to the [OpenWallet Foundation](https://openwallet.foundation/) is now complete. For up to date details on what the repo move means for ACA-Py users, including steps for updating deployments, please see latest in [GitHub Issue #3250].
+The move to the [OpenWallet Foundation](https://openwallet.foundation/) is now complete. If you haven't done so already, please update your ACA-Py deployment to use:
+
+- the [ACA-Py OWF repository](https://github.com/openwallet-foundation/acapy),
+- the new [acapy-agent in PyPi](https://pypi.org/project/acapy-agent/), and
+- the container images for ACA-Py hosted by the OpenWallet Foundation GitHub organization within the GitHub Container Repository (GHCR).
 
 A significant testing capability was added in this release -- the ability to run an integration test that includes an ACA-Py upgrade in the middle. This allows us to test, for example starting an agent on one release, doing an upgrade (possibly including running a migration script), and then completing the test on the upgraded release. This is enable by adding a capability to restart Docker containers in the middle of tests. Nice work, @ianco!
 
-[GitHub Issue #3250]: https://github.com/hyperledger/aries-cloudagent-python/issues/3250
-
-### 1.2.0rc0 Deprecation Notices
+### 1.2.0 Deprecation Notices
 
 The same **[deprecation notices](#101-deprecation-notices)** from the [1.1.0](#110) release about AIP 1.0 protocols still apply. The protocols remain in the 1.2.0 release, but will be moved out of the core and into plugins soon. Please review these notifications carefully!
 
-### 1.2.0rc0 Breaking Changes
+### 1.2.0 Breaking Changes
 
 The removal of the "in-memory" wallet implementation might be break some test scripts. Rather than using the in-memory wallet, tests should be updated to use SQLite's special `sqlite://:memory:` database instead. This results in a better alignment between the Askar storage configuration in test environments and what is used in production.
 
@@ -28,7 +32,7 @@ A fix for a multi-tenancy bug in the holding of VC-LD credentials that resulted 
 
 [PR #3391]: https://github.com/openwallet-foundation/acapy/pull/3391
 
-#### 1.2.0rc0 Categorized List of Pull Requests
+#### 1.2.0 Categorized List of Pull Requests
 
 - AnonCreds VC Issuance and Presentation Enhancement / Fixes
   - Fix indy fallback format in presentation from holder [\#3413](https://github.com/openwallet-foundation/acapy/pull/3413) [jamshale](https://github.com/jamshale)
@@ -76,6 +80,8 @@ A fix for a multi-tenancy bug in the holding of VC-LD credentials that resulted 
   - :construction_worker: Fix Nightly Publish to not run on forks [\#3333](https://github.com/openwallet-foundation/acapy/pull/3333) [ff137](https://github.com/ff137)
 
 - Internal Improvements / Cleanups / Tech Debt Updates
+  - Fix devcontainer poetry install [\#3428](https://github.com/openwallet-foundation/acapy/pull/3428) [jamshale](https://github.com/jamshale)
+  - Pin poetry to 1.8.3 in dockerfiles [\#3427](https://github.com/openwallet-foundation/acapy/pull/3427) [jamshale](https://github.com/jamshale)
   - Adds the OpenSSF to the readme [\#3412](https://github.com/openwallet-foundation/acapy/pull/3412) [swcurran](https://github.com/swcurran)
   - The latest tag doesn't exist in git, just github [\#3392](https://github.com/openwallet-foundation/acapy/pull/3392) [ryjones](https://github.com/ryjones)
   - :art: Fix model name for consistency [\#3382](https://github.com/openwallet-foundation/acapy/pull/3382) [ff137](https://github.com/ff137)
@@ -94,15 +100,34 @@ A fix for a multi-tenancy bug in the holding of VC-LD credentials that resulted 
   - :arrow_up: Update lock file [\#3296](https://github.com/openwallet-foundation/acapy/pull/3296) [ff137](https://github.com/ff137)
 
 - Release management pull requests:
+  - 1.2.0 [\#3430](https://github.com/openwallet-foundation/acapy/pull/3430) [swcurran](https://github.com/swcurran)
   - 1.2.0rc0 [\#3420](https://github.com/openwallet-foundation/acapy/pull/3420) [swcurran](https://github.com/swcurran)
   - 1.1.1rc0 [\#3372](https://github.com/openwallet-foundation/acapy/pull/3372) [swcurran](https://github.com/swcurran)
 
 - Dependabot PRs
-  - [Link to list of Dependabot PRs in this release](https://github.com/openwallet-foundation/acapy/pulls?q=is%3Apr+is%3Amerged+merged%3A2024-10-15..2024-12-24+author%3Aapp%2Fdependabot+)
+  - [Link to list of Dependabot PRs in this release](https://github.com/openwallet-foundation/acapy/pulls?q=is%3Apr+is%3Amerged+merged%3A2024-10-15..2025-01-07+author%3Aapp%2Fdependabot+)
 
 ## 1.1.1
 
 ACA-Py Release 1.1.1 was a release candidate for 1.2.0. A mistake in the release PR meant the 1.1.1rc0 was tagged published to PyPi as Release 1.1.1. Since that was not intended to be a final release, the release changelog for 1.2.0 includes the Pull Requests that would have been in 1.1.1.
+
+## 0.12.3
+
+### December 17, 2024
+
+A patch release to add address a bug found in the Linked Data Verifiable Credential handling for multi-tenant holders. The bug was fixed in the main branch, [PR 3391 - BREAKING: VCHolder multitenant binding](https://github.com/openwallet-foundation/acapy/pull/3391), and with this release is backported to 0.12 Long Term Support branch. Prior to this release, holder credentials received into a tenant wallet were actually received into the multi-tenant admin wallet.
+
+### 0.12.3 Breaking Changes
+
+There are no breaking changes in this release.
+
+#### 0.12.3 Categorized List of Pull Requests
+
+- Multitenant LD-VC Holders
+  - Patch PR 3391 - 0.12.lts [\#3396](https://github.com/openwallet-foundation/acapy/pull/3396)
+- Release management pull requests
+  - 0.12.3 [\#3408](https://github.com/hyperledger/aries-cloudagent-python/pull/3408) [swcurran](https://github.com/swcurran)
+  - 0.12.3rc0 [\#3406](https://github.com/hyperledger/aries-cloudagent-python/pull/3406) [swcurran](https://github.com/swcurran)
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-### January 7, 2025
+### January 8, 2025
 
 Release 1.2.0 is a minor update to ACA-Py that contains an update to the AnonCreds implementation to make it easier to deploy on other than Hyperledger Indy, and a lengthy list of adjustments, improvements and fixes, with a focus on removing technical debt. In addition to the AnonCreds updates, the most visible change is the removal of the "in-memory wallet" implementation in favour of using the SQLite in-memory wallet (`sqlite://:memory:`), including removing the logic for handling that extra wallet type. In removing the in-memory wallet, all of the unit and integration tests that used the in-memory wallet have been updated to use SQLite's in-memory wallet.
 
@@ -105,7 +105,7 @@ A fix for a multi-tenancy bug in the holding of VC-LD credentials that resulted 
   - 1.1.1rc0 [\#3372](https://github.com/openwallet-foundation/acapy/pull/3372) [swcurran](https://github.com/swcurran)
 
 - Dependabot PRs
-  - [Link to list of Dependabot PRs in this release](https://github.com/openwallet-foundation/acapy/pulls?q=is%3Apr+is%3Amerged+merged%3A2024-10-15..2025-01-07+author%3Aapp%2Fdependabot+)
+  - [Link to list of Dependabot PRs in this release](https://github.com/openwallet-foundation/acapy/pulls?q=is%3Apr+is%3Amerged+merged%3A2024-10-15..2025-01-08+author%3Aapp%2Fdependabot+)
 
 ## 1.1.1
 

--- a/Managing-ACA-Py-Doc-Site.md
+++ b/Managing-ACA-Py-Doc-Site.md
@@ -20,7 +20,7 @@ and mkdocs configuration.
 
 When the GitHub Action fires, it runs a container that carries out the following steps:
 
-- Checks out the triggering branch, either `main` or `docs-v<version>` (e.g `docs-v1.2.0rc0`).
+- Checks out the triggering branch, either `main` or `docs-v<version>` (e.g `docs-v1.2.0`).
 - Runs the script [scripts/prepmkdocs.sh], which moves and updates some of the
   markdown files so that they fit into the generated site. See the comments in
   the scripts for details about the copying and editing done via the script. In
@@ -97,39 +97,10 @@ To delete the documentation version, do the following:
 - Check your `git status` and make sure there are no changes in the branch --
   e.g., new files that shouldn't be added to the `gh-pages` branch. If there are
   any -- delete the files so they are not added.
-- Remove the folder for the RC.  For example `rm -rf 1.2.0rc0`
+- Remove the folder for the RC.  For example `rm -rf 1.2.0`
 - Edit the `versions.json` file and remove the reference to the RC release in
   the file.
 - Push the changes via a PR to the ACA-Py `gh-pages` branch (don't PR them into
   `main`!!).
 - Merge the PR and verify (after a few minutes) that the drop down no longer has
   the RC in it.
-
-## Adding new 0.11.x Releases
-
-The automatic generation process from ACA-Py started with release 0.12.0.
-Unfortunately, we declared release 0.11.x to be an Long Term Support version and
-so we still need to add 0.11.x version documentation to the generated site.
-Here's the (lousy) process to do this. Typically, [swcurran] will do this and no
-one else needs to worry about it. But for completeness, here is the process:
-
-- Follow the instructions in the [aries-acapy-docs] repository to generate and
-  publish the documentation site for the new 0.11.x version.
-- Have a local copy of the [aries-acapy-docs] repository. In that repo, run `git
-  checkout -b gh-pages --track upstream/gh-pages` to checkout a local copy of
-  the generated pages from that repo.
-- In ACA-Py, run `git checkout -b gh-pages --track upstream/gh-pages` to create
-  a local branch from which you will push a PR.
-- Copy the v0.11.x folder from [aries-acapy-docs] local to a new 0.11.x folder
-  in the ACA-Py local. Note the "v" that is on the folder in [aries-acapy-docs],
-  but not in ACA-Py.
-- Edit the `versions.json` file to add the 0.11.x reference into the file.
-- Push the changes via a PR to the ACA-Py `gh-pages` branch (don't PR them into
-  `main`!!).
-- Merge the PR and verify (after a few minutes) that the drop down includes the
-  0.11.x version.
-
-Ugly! The LTS for 0.11 ends in January 2025 and this process can be dropped.
-
-[swcurran]: https://github.com/swcurran
-[aries-acapy-docs]: https://github.com/hyperledger/aries-acapy-docs

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -6,7 +6,7 @@ a major, minor or patch release, per [semver](https://semver.org/) rules.
 
 Once ready to do a release, create a local branch that includes the following updates:
 
-1. Create a local PR branch from an updated `main` branch, e.g. "1.2.0rc0".
+1. Create a local PR branch from an updated `main` branch, e.g. "1.2.0".
 
 2. See if there are any Document Site `mkdocs` changes needed. Run the script
    `./scripts/prepmkdocs.sh; mkdocs`. Watch the log, noting particularly if

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ACA-Py -- A Cloud Agent - Python  <!-- omit in toc -->
 
-🚨 **ACA-Py is transitioning to the [OpenWallet Foundation] (OWF)!** 🚨
+🚨 **ACA-Py is part of the [OpenWallet Foundation] (OWF)!** 🚨
 
 [OpenWallet Foundation]: https://openwallet.foundation/
 
-We’re excited to announce that the ACA-Py project has moved to the OWF's GitHub organization as the [new "acapy" project](https://github.com/openwallet-foundation/project-proposals/blob/main/projects/aca-py.md).
+The move of ACA-Py to the OWF is now complete. If you haven't done so already, please update your ACA-Py deployment to use:
 
-For details on what this means for ACA-Py users, including steps for updating deployments, please follow the updates in [GitHub Issue #3250]. We'll keep you informed about how to update your deployment to reflect this change. Stay tuned!
-
-[GitHub Issue #3250]: https://github.com/openwallet-foundation/acapy/issues/3250
+- the [ACA-Py OWF repository](https://github.com/openwallet-foundation/acapy),
+- the new [acapy-agent in PyPi](https://pypi.org/project/acapy-agent/), and
+- the container images for ACA-Py hosted by the OpenWallet Foundation GitHub organization within the GitHub Container Repository (GHCR).
 
 <p float="left">
   <a href="https://scorecard.dev/viewer/?uri=github.com/openwallet-foundation/acapy"><img src="https://api.scorecard.dev/projects/github.com/openwallet-foundation/acapy/badge" />
@@ -51,10 +51,14 @@ the active LTS releases. Each LTS release will be supported with patches for **9
 months** following the designation of the **next** LTS Release. For more details see
 the [LTS strategy](./LTS-Strategy.md).
 
-Current LTS releases are:
+Current LTS releases:
 
-- [0.12](https://github.com/openwallet-foundation/acapy/releases/tag/0.12.1) **Current LTS Release**
-- [0.11](https://github.com/openwallet-foundation/acapy/releases/tag/0.11.1) **End of Life: January 2025**
+- Release [1.2](https://github.com/openwallet-foundation/acapy/releases/tag/1.2.0) **Current LTS Release**
+- Release [0.12](https://github.com/openwallet-foundation/acapy/releases/tag/0.12.3) **End of Life: October 2025**
+
+Past LTS releases:
+
+- Release [0.11](https://github.com/openwallet-foundation/acapy/releases/tag/0.11.3) **End of Life: January 2025**
 
 Unless specified in the **Breaking Changes** section of the ACA-Py
 [CHANGELOG](./CHANGELOG.md), all LTS patch releases will be able to be deployed

--- a/demo/docker-agent/Dockerfile.acapy
+++ b/demo/docker-agent/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.12.3
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
 
 USER root
 

--- a/demo/multi-demo/Dockerfile.acapy
+++ b/demo/multi-demo/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.12.3
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
 
 USER root
 

--- a/demo/playground/Dockerfile.acapy
+++ b/demo/playground/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.12.3
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
 
 USER root
 

--- a/demo/playground/README.md
+++ b/demo/playground/README.md
@@ -26,7 +26,7 @@ These configuration files are provided to the ACA-Py start command via the `AGEN
 
 ### Dockerfile and start.sh
 
-[`Dockerfile.acapy`](./Dockerfile.acapy) assembles the image to run. Currently based on [Aries Cloudagent Python 0.21.1](ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.12.1), we need [jq](https://stedolan.github.io/jq/) to setup (or not) the ngrok tunnel and execute the Aca-py start command - see [`start.sh`](./start.sh). You may note that the start command is very sparse, additional configuration is done via environment variables in the [docker compose file](./docker-compose.yml).
+[`Dockerfile.acapy`](./Dockerfile.acapy) assembles the image to run. Currently based on [ACA-Py 1.1.0](ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0), we need [jq](https://stedolan.github.io/jq/) to setup (or not) the ngrok tunnel and execute the Aca-py start command - see [`start.sh`](./start.sh). You may note that the start command is very sparse, additional configuration is done via environment variables in the [docker compose file](./docker-compose.yml).
 
 ### ngrok
 

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,4 +1,4 @@
-ARG from_image=ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.12.1
+ARG from_image=ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
 FROM ${from_image}
 
 ENV ENABLE_PTVSD 0

--- a/docs/features/DIDResolution.md
+++ b/docs/features/DIDResolution.md
@@ -176,7 +176,7 @@ plugin:
 The following is a fully functional Dockerfile encapsulating this setup:
 
 ```dockerfile=
-FROM ghcr.io/openwallet-foundation/acapy:py3.9-0.12.1
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0cd ../demo   
 RUN pip3 install git+https://github.com/dbluhm/acapy-resolver-github
 
 CMD ["aca-py", "start", "-it", "http", "0.0.0.0", "3000", "-ot", "http", "-e", "http://localhost:3000", "--admin", "0.0.0.0", "3001", "--admin-insecure-mode", "--no-ledger", "--plugin", "acapy_resolver_github"]

--- a/docs/features/DIDResolution.md
+++ b/docs/features/DIDResolution.md
@@ -176,7 +176,7 @@ plugin:
 The following is a fully functional Dockerfile encapsulating this setup:
 
 ```dockerfile=
-FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0cd ../demo   
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0   
 RUN pip3 install git+https://github.com/dbluhm/acapy-resolver-github
 
 CMD ["aca-py", "start", "-it", "http", "0.0.0.0", "3000", "-ot", "http", "-e", "http://localhost:3000", "--admin", "0.0.0.0", "3001", "--admin-insecure-mode", "--no-ledger", "--plugin", "acapy_resolver_github"]

--- a/docs/features/SupportedRFCs.md
+++ b/docs/features/SupportedRFCs.md
@@ -8,7 +8,7 @@ ACA-Py or the repository `main` branch. Reminders (and PRs!) to update this page
 welcome! If you have any questions, please contact us on the #aries channel on
 [OpenWallet Foundation Discord](https://discord.gg/openwallet-foundation) or through an issue in this repo.
 
-**Last Update**: 2024-12-24, Release 1.2.0rc0
+**Last Update**: 2025-01-07, Release 1.2.0
 
 > The checklist version of this document was created as a joint effort
 > between [Northern Block](https://northernblock.io/), [Animo Solutions](https://animo.id/) and the Ontario government, on behalf of the Ontario government.

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -2,7 +2,7 @@
   "openapi" : "3.0.1",
   "info" : {
     "title" : "Aries Cloud Agent",
-    "version" : "v1.2.0rc0"
+    "version" : "v1.2.0"
   },
   "servers" : [ {
     "url" : "/"

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger" : "2.0",
   "info" : {
-    "version" : "v1.2.0rc0",
+    "version" : "v1.2.0",
     "title" : "Aries Cloud Agent"
   },
   "tags" : [ {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "acapy_agent"
-version = "1.2.0rc0"
+version = "1.2.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 authors = []
 license = "Apache-2.0"


### PR DESCRIPTION
In addition to the usual Release changes, updates a number of Dockerfiles to use the most recent previous release (Release 1.1.0).

One question for OpenAPI experiments. Where do we change, and what is the ramification of changing, the "Title" in the `openapi.json` and `swagger.json` files from the current `"title" : "Aries Cloud Agent"` to a post OWF-move name like `ACA-Py Agent`. Given it is just "info", does it affect those using the OpenAPI generators?

Thanks!

