### PR TITLE
Follow up from Release 1.2.0 -- including LTS change

### DIFF
--- a/.github/workflows/snyk-lts.yml
+++ b/.github/workflows/snyk-lts.yml
@@ -5,6 +5,7 @@ on:
     # These branches represent the LTS releases
     branches:
       - 0.12.lts
+      - 1.2.lts
     paths:
       - acapy_agent/**
       - docker/**

--- a/.github/workflows/snyk-lts.yml
+++ b/.github/workflows/snyk-lts.yml
@@ -7,6 +7,7 @@ on:
       - 0.12.lts
       - 1.2.lts
     paths:
+      - aries_cloudagent/**
       - acapy_agent/**
       - docker/**
 

--- a/demo/docker-agent/Dockerfile.acapy
+++ b/demo/docker-agent/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.0
 
 USER root
 

--- a/demo/multi-demo/Dockerfile.acapy
+++ b/demo/multi-demo/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.0
 
 USER root
 

--- a/demo/playground/Dockerfile.acapy
+++ b/demo/playground/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.0
 
 USER root
 

--- a/demo/playground/README.md
+++ b/demo/playground/README.md
@@ -26,7 +26,7 @@ These configuration files are provided to the ACA-Py start command via the `AGEN
 
 ### Dockerfile and start.sh
 
-[`Dockerfile.acapy`](./Dockerfile.acapy) assembles the image to run. Currently based on [ACA-Py 1.1.0](ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0), we need [jq](https://stedolan.github.io/jq/) to setup (or not) the ngrok tunnel and execute the Aca-py start command - see [`start.sh`](./start.sh). You may note that the start command is very sparse, additional configuration is done via environment variables in the [docker compose file](./docker-compose.yml).
+[`Dockerfile.acapy`](./Dockerfile.acapy) assembles the image to run. Currently based on [ACA-Py 1.2.0](ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.0), we need [jq](https://stedolan.github.io/jq/) to setup (or not) the ngrok tunnel and execute the Aca-py start command - see [`start.sh`](./start.sh). You may note that the start command is very sparse, additional configuration is done via environment variables in the [docker compose file](./docker-compose.yml).
 
 ### ngrok
 

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,4 +1,4 @@
-ARG from_image=ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
+ARG from_image=ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.0
 FROM ${from_image}
 
 ENV ENABLE_PTVSD 0

--- a/docs/features/DIDResolution.md
+++ b/docs/features/DIDResolution.md
@@ -176,7 +176,7 @@ plugin:
 The following is a fully functional Dockerfile encapsulating this setup:
 
 ```dockerfile=
-FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0   
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.0   
 RUN pip3 install git+https://github.com/dbluhm/acapy-resolver-github
 
 CMD ["aca-py", "start", "-it", "http", "0.0.0.0", "3000", "-ot", "http", "-e", "http://localhost:3000", "--admin", "0.0.0.0", "3001", "--admin-insecure-mode", "--no-ledger", "--plugin", "acapy_resolver_github"]


### PR DESCRIPTION
Update references to the previous release follow the new 1.2.0 Release.

Update the snyk configuration to use the 1.2.lts branch.

@jamshale -- take a look at the snyk config. For the 0.12.lts branch, there is no `aries-agent` path. Should we add the `aries-cloudagent`  path that doesn't existin in main? I assume that is OK, since it has been working fine even though there is no `aries-agent` folder in the 0.12.lts branch.
