### PR TITLE
Fixed handling of base wallet routes in auth decorator

### DIFF
--- a/acapy_agent/admin/tests/test_auth.py
+++ b/acapy_agent/admin/tests/test_auth.py
@@ -134,8 +134,20 @@ class TestTenantAuthentication(IsolatedAsyncioTestCase):
         await decor_func(self.request)
         self.decorated_handler.assert_called_once_with(self.request)
 
-    async def test_base_wallet_additional_route_allowed(self):
+    async def test_base_wallet_additional_route_allowed_string(self):
         self.profile.settings["multitenant.base_wallet_routes"] = "/extra-route"
+        self.request = mock.MagicMock(
+            __getitem__=lambda _, k: self.request_dict[k],
+            headers={"x-api-key": "admin_api_key"},
+            method="POST",
+            path="/extra-route",
+        )
+        decor_func = tenant_authentication(self.decorated_handler)
+        await decor_func(self.request)
+        self.decorated_handler.assert_called_once_with(self.request)
+
+    async def test_base_wallet_additional_route_allowed_list(self):
+        self.profile.settings["multitenant.base_wallet_routes"] = ["/extra-route"]
         self.request = mock.MagicMock(
             __getitem__=lambda _, k: self.request_dict[k],
             headers={"x-api-key": "admin_api_key"},

--- a/acapy_agent/admin/tests/test_auth.py
+++ b/acapy_agent/admin/tests/test_auth.py
@@ -135,7 +135,9 @@ class TestTenantAuthentication(IsolatedAsyncioTestCase):
         self.decorated_handler.assert_called_once_with(self.request)
 
     async def test_base_wallet_additional_route_allowed_string(self):
-        self.profile.settings["multitenant.base_wallet_routes"] = "/extra-route"
+        self.profile.settings["multitenant.base_wallet_routes"] = (
+            "/not-this-route /extra-route"
+        )
         self.request = mock.MagicMock(
             __getitem__=lambda _, k: self.request_dict[k],
             headers={"x-api-key": "admin_api_key"},
@@ -147,7 +149,10 @@ class TestTenantAuthentication(IsolatedAsyncioTestCase):
         self.decorated_handler.assert_called_once_with(self.request)
 
     async def test_base_wallet_additional_route_allowed_list(self):
-        self.profile.settings["multitenant.base_wallet_routes"] = ["/extra-route"]
+        self.profile.settings["multitenant.base_wallet_routes"] = [
+            "/extra-route",
+            "/not-this-route",
+        ]
         self.request = mock.MagicMock(
             __getitem__=lambda _, k: self.request_dict[k],
             headers={"x-api-key": "admin_api_key"},


### PR DESCRIPTION
Resolves #3445 

Note: the handler was updated to accept both an array of strings or a space-separated list of strings, in order to prevent further disruption to existing deployments.