### PR TITLE
Check admin wallet anoncreds upgrade on startup

### DIFF
--- a/acapy_agent/core/conductor.py
+++ b/acapy_agent/core/conductor.py
@@ -857,6 +857,7 @@ class Conductor:
     async def check_for_wallet_upgrades_in_progress(self):
         """Check for upgrade and upgrade if needed."""
         if self.context.settings.get_value("multitenant.enabled"):
+            # Sub-wallets
             subwallet_profiles = await get_subwallet_profiles_from_storage(
                 self.root_profile
             )
@@ -867,5 +868,5 @@ class Conductor:
                 ]
             )
 
-        else:
-            await upgrade_wallet_to_anoncreds_if_requested(self.root_profile)
+        # Stand-alone or admin wallet
+        await upgrade_wallet_to_anoncreds_if_requested(self.root_profile)


### PR DESCRIPTION
I noticed another problem...

The admin wallet in multitenancy mode is allowed to get upgraded through the api endpoint. This is needed because you can only create new sub-wallets which match the base wallet type. However the upgrade check was only checking for sub-wallets. This was a problem if the admin wallet got upgraded because on startup it wouldn't add the wallet to the upgraded singleton and would get 503 on api calls.