### PR TITLE
fix: ensure profile names are unique

### DIFF
--- a/acapy_agent/askar/profile.py
+++ b/acapy_agent/askar/profile.py
@@ -42,7 +42,9 @@ class AskarProfile(Profile):
         profile_id: Optional[str] = None,
     ):
         """Create a new AskarProfile instance."""
-        super().__init__(context=context, name=opened.name, created=opened.created)
+        super().__init__(
+            context=context, name=profile_id or opened.name, created=opened.created
+        )
         self.opened = opened
         self.ledger_pool: Optional[IndyVdrLedgerPool] = None
         self.profile_id = profile_id
@@ -52,7 +54,7 @@ class AskarProfile(Profile):
     @property
     def name(self) -> str:
         """Accessor for the profile name."""
-        return self.opened.name
+        return self.profile_id or self.opened.name
 
     @property
     def store(self) -> Store:

--- a/acapy_agent/askar/profile_anon.py
+++ b/acapy_agent/askar/profile_anon.py
@@ -44,7 +44,9 @@ class AskarAnoncredsProfile(Profile):
         profile_id: Optional[str] = None,
     ):
         """Create a new AskarProfile instance."""
-        super().__init__(context=context, name=opened.name, created=opened.created)
+        super().__init__(
+            context=context, name=profile_id or opened.name, created=opened.created
+        )
         self.opened = opened
         self.ledger_pool: Optional[IndyVdrLedgerPool] = None
         self.profile_id = profile_id
@@ -54,7 +56,7 @@ class AskarAnoncredsProfile(Profile):
     @property
     def name(self) -> str:
         """Accessor for the profile name."""
-        return self.opened.name
+        return self.profile_id or self.opened.name
 
     @property
     def store(self) -> Store:


### PR DESCRIPTION
The `profile.name` property is expected to be unique. When using single-wallet-askar, it is not unique and is always `multitenant_sub_wallet` or whatever the wallet for all the profiles is called. This causes problems in a few key areas. This fix uses the profile_id (when present, i.e. when using single-wallet-askar) to make sure profile.name is unique. I will open an issue to further detail the extent of this problem so we can discuss how far back we need to go.