### PR TITLE
Anoncreds Issuance - Extra options.

### DIFF
--- a/acapy_agent/anoncreds/models/credential_proposal.py
+++ b/acapy_agent/anoncreds/models/credential_proposal.py
@@ -23,7 +23,7 @@ class AnoncredsCredentialDefinitionProposal(OpenAPISchema):
     """Query string parameters for credential definition searches."""
 
     cred_def_id = fields.Str(
-        required=True,
+        required=False,
         validate=ANONCREDS_CRED_DEF_ID_VALIDATE,
         metadata={
             "description": "Credential definition id. This is the only required field.",

--- a/acapy_agent/anoncreds/models/credential_proposal.py
+++ b/acapy_agent/anoncreds/models/credential_proposal.py
@@ -2,7 +2,7 @@
 
 import re
 
-from marshmallow import fields
+from marshmallow import fields, validate
 
 from ...core.profile import Profile
 from ...messaging.models.openapi import OpenAPISchema
@@ -13,12 +13,30 @@ from ...messaging.valid import (
     ANONCREDS_DID_VALIDATE,
     ANONCREDS_SCHEMA_ID_EXAMPLE,
     ANONCREDS_SCHEMA_ID_VALIDATE,
+    INDY_DID_VALIDATE,
+    MAJOR_MINOR_VERSION_EXAMPLE,
+    MAJOR_MINOR_VERSION_VALIDATE,
 )
 
 
 class AnoncredsCredentialDefinitionProposal(OpenAPISchema):
     """Query string parameters for credential definition searches."""
 
+    cred_def_id = fields.Str(
+        required=True,
+        validate=ANONCREDS_CRED_DEF_ID_VALIDATE,
+        metadata={
+            "description": "Credential definition id. This is the only required field.",
+            "example": ANONCREDS_CRED_DEF_ID_EXAMPLE,
+        },
+    )
+    issuer_id = fields.Str(
+        required=False,
+        # TODO: INDY_DID_VALIDATE should be removed when indy sov did's
+        # are represented by did:sov:{nym} in acapy
+        validate=validate.NoneOf([ANONCREDS_DID_VALIDATE, INDY_DID_VALIDATE]),
+        metadata={"description": "Issuer DID", "example": ANONCREDS_DID_EXAMPLE},
+    )
     schema_id = fields.Str(
         required=False,
         validate=ANONCREDS_SCHEMA_ID_VALIDATE,
@@ -27,17 +45,25 @@ class AnoncredsCredentialDefinitionProposal(OpenAPISchema):
             "example": ANONCREDS_SCHEMA_ID_EXAMPLE,
         },
     )
-    issuer_id = fields.Str(
+    schema_issuer_id = fields.Str(
         required=False,
-        validate=ANONCREDS_DID_VALIDATE,
-        metadata={"description": "Issuer DID", "example": ANONCREDS_DID_EXAMPLE},
-    )
-    cred_def_id = fields.Str(
-        required=False,
-        validate=ANONCREDS_CRED_DEF_ID_VALIDATE,
+        # TODO: INDY_DID_VALIDATE should be removed when indy sov did's
+        # are represented by did:sov:{nym} in acapy
+        validate=validate.NoneOf([ANONCREDS_DID_VALIDATE, INDY_DID_VALIDATE]),
         metadata={
-            "description": "Credential definition id",
-            "example": ANONCREDS_CRED_DEF_ID_EXAMPLE,
+            "description": "Schema identifier",
+            "example": ANONCREDS_SCHEMA_ID_EXAMPLE,
+        },
+    )
+    schema_name = fields.Str(
+        required=False, metadata={"description": "Schema name", "example": "simple"}
+    )
+    schema_version = fields.Str(
+        required=False,
+        validate=MAJOR_MINOR_VERSION_VALIDATE,
+        metadata={
+            "description": "Schema version",
+            "example": MAJOR_MINOR_VERSION_EXAMPLE,
         },
     )
 

--- a/scenarios/examples/anoncreds_issuance_and_revocation/example.py
+++ b/scenarios/examples/anoncreds_issuance_and_revocation/example.py
@@ -97,10 +97,14 @@ async def main():
 
             await issuer.post("/wallet/did/public", params=params(did=public_did.did))
 
-        _, cred_def = await indy_anoncred_credential_artifacts(
+        schema_name = "anoncreds-test-" + token_hex(8)
+        schema_version = "1.0"
+        schema, cred_def = await indy_anoncred_credential_artifacts(
             issuer,
             ["firstname", "lastname"],
             support_revocation=True,
+            schema_name=schema_name,
+            schema_version=schema_version,
         )
 
         # Issue a credential
@@ -111,6 +115,10 @@ async def main():
             holder_anoncreds_conn.connection_id,
             cred_def.credential_definition_id,
             {"firstname": "Anoncreds", "lastname": "Holder"},
+            issuer_id=public_did.did,
+            schema_id=schema.schema_id,
+            schema_issuer_id=public_did.did,
+            schema_name=schema_name,
         )
 
         # Present the the credential's attributes
@@ -156,6 +164,10 @@ async def main():
             holder_indy_conn.connection_id,
             cred_def.credential_definition_id,
             {"firstname": "Indy", "lastname": "Holder"},
+            issuer_id=public_did.did,
+            schema_id=schema.schema_id,
+            schema_issuer_id=public_did.did,
+            schema_name=schema_name,
         )
 
         # Present the the credential's attributes
@@ -230,12 +242,14 @@ async def main():
 
         # Create a new schema and cred def with different attributes on new
         # anoncreds endpoints
+        schema_name = "anoncreds-test-" + token_hex(8)
+        schema_version = "1.0"
         schema = await issuer.post(
             "/anoncreds/schema",
             json={
                 "schema": {
-                    "name": "anoncreds-test-" + token_hex(8),
-                    "version": "1.0",
+                    "name": schema_name,
+                    "version": schema_version,
                     "attrNames": ["middlename"],
                     "issuerId": public_did.did,
                 }
@@ -263,6 +277,10 @@ async def main():
             holder_anoncreds_conn.connection_id,
             cred_def.credential_definition_state["credential_definition_id"],
             {"middlename": "Anoncreds"},
+            issuer_id=public_did.did,
+            schema_id=schema.schema_state["schema_id"],
+            schema_issuer_id=public_did.did,
+            schema_name=schema_name,
         )
         # Presentation for anoncreds capable holder
         await anoncreds_present_proof_v2(
@@ -294,6 +312,10 @@ async def main():
             holder_indy_conn.connection_id,
             cred_def.credential_definition_state["credential_definition_id"],
             {"middlename": "Indy"},
+            issuer_id=public_did.did,
+            schema_id=schema.schema_state["schema_id"],
+            schema_issuer_id=public_did.did,
+            schema_name=schema_name,
         )
         # Presentation for indy holder
         await anoncreds_present_proof_v2(

--- a/scenarios/examples/util.py
+++ b/scenarios/examples/util.py
@@ -202,6 +202,11 @@ async def anoncreds_issue_credential_v2(
     holder_connection_id: str,
     cred_def_id: str,
     attributes: Mapping[str, str],
+    issuer_id: Optional[str] = None,
+    schema_id: Optional[str] = None,
+    schema_issuer_id: Optional[str] = None,
+    schema_name: Optional[str] = None,
+    schema_version: Optional[str] = None,
 ) -> Tuple[V20CredExRecordDetail, V20CredExRecordDetail]:
     """Issue an credential using issue-credential/2.0.
 
@@ -217,8 +222,30 @@ async def anoncreds_issue_credential_v2(
 
     if is_issuer_anoncreds:
         _filter = {"anoncreds": {"cred_def_id": cred_def_id}}
+        if issuer_id:
+            _filter["anoncreds"]["issuer_id"] = issuer_id
+        if schema_id:
+            _filter["anoncreds"]["schema_id"] = schema_id
+        if schema_issuer_id:
+            _filter["anoncreds"]["schema_issuer_id"] = schema_issuer_id
+        if schema_name:
+            _filter["anoncreds"]["schema_name"] = schema_name
+        if schema_version:
+            _filter["anoncreds"]["schema_version"] = schema_version
+
     else:
         _filter = {"indy": {"cred_def_id": cred_def_id}}
+        if issuer_id:
+            _filter["indy"]["issuer_did"] = issuer_id
+        if schema_id:
+            _filter["indy"]["schema_id"] = schema_id
+        if schema_issuer_id:
+            _filter["indy"]["schema_issuer_did"] = schema_issuer_id
+        if schema_name:
+            _filter["indy"]["schema_name"] = schema_name
+        if schema_version:
+            _filter["indy"]["schema_version"] = schema_version
+
     issuer_cred_ex = await issuer.post(
         "/issue-credential-2.0/send-offer",
         json={
@@ -311,9 +338,7 @@ async def anoncreds_issue_credential_v2(
     )
 
     return (
-        V20CredExRecordDetail(
-            cred_ex_record=issuer_cred_ex, details=issuer_indy_record
-        ),
+        V20CredExRecordDetail(cred_ex_record=issuer_cred_ex, details=issuer_indy_record),
         V20CredExRecordDetail(
             cred_ex_record=holder_cred_ex,
             details=holder_indy_record,


### PR DESCRIPTION
This make the rest of the options in the anoncreds RFC available and prevents the issuance from failing when they are provided.

Notice how indy and anoncreds have slightly different options. schema_id vs schema_did and issuer_id vs issuer_did.

https://github.com/hyperledger/aries-rfcs/blob/main/features/0771-anoncreds-attachments/README.md#credential-filter-format
https://github.com/hyperledger/aries-rfcs/blob/main/features/0592-indy-attachments/README.md#cred-filter-format

However, I am still a bit confused about this. In the old indy filter handler the extra options don't really seem to be used and currently with the anoncreds filter handler the only field used is `cred_def_id`. I don't think the other options really do anything.

`
The potential holder may not know, and need not specify, all of these criteria. For example, the holder might only know the schema name and the (credential) issuer i
`

I don't think this feature is currently available. I could possibly implement it in this PR or could do it as a separate task...
