### PR TITLE
Fixing BaseAnonCredsResolver get_revocation_list abstract method

### DIFF
--- a/acapy_agent/anoncreds/base.py
+++ b/acapy_agent/anoncreds/base.py
@@ -127,7 +127,11 @@ class BaseAnonCredsResolver(BaseAnonCredsHandler):
 
     @abstractmethod
     async def get_revocation_list(
-        self, profile: Profile, revocation_registry_id: str, timestamp: int
+        self,
+        profile: Profile,
+        revocation_registry_id: str,
+        timestamp_from: Optional[int] = 0,
+        timestamp_to: Optional[int] = None,
     ) -> GetRevListResult:
         """Get a revocation list from the registry."""
 

--- a/acapy_agent/anoncreds/default/did_web/registry.py
+++ b/acapy_agent/anoncreds/default/did_web/registry.py
@@ -88,7 +88,11 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         raise NotImplementedError()
 
     async def get_revocation_list(
-        self, profile: Profile, revocation_registry_id: str, timestamp: int
+        self,
+        profile: Profile,
+        revocation_registry_id: str,
+        timestamp_from: Optional[int] = 0,
+        timestamp_to: Optional[int] = None,
     ) -> GetRevListResult:
         """Get a revocation list from the registry."""
         raise NotImplementedError()


### PR DESCRIPTION
Just adjusting the base class so that new implementations work properly. The anoncreds registry, when calls the get_revocation_list, sends 2 timestamps to the resolver. However, the base resolver's abstract method has only one. To avoid any implementation problems, the second timestamp was added to the base class abstract method.