### PR TITLE
Fix Class import for AnonCreds Registry routes

### DIFF
--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -25,7 +25,10 @@ from ..messaging.valid import (
     UUIDFour,
 )
 from ..revocation.error import RevocationNotSupportedError
-from ..revocation_anoncreds.routes import RevocationModuleResponseSchema, RevRegIdMatchInfoSchema
+from ..revocation_anoncreds.routes import (
+    RevocationModuleResponseSchema,
+    RevRegIdMatchInfoSchema,
+)
 from ..storage.error import StorageNotFoundError
 from ..utils.profiles import is_not_anoncreds_profile_raise_web_exception
 from .base import (

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -62,7 +62,7 @@ create_transaction_for_endorser_description = (
 )
 
 
-class AnonCredsRevocationModuleResponseSchema(OpenAPISchema):
+class AnoncredsRevocationModuleResponseSchema(OpenAPISchema):
     """Response schema for Revocation Module."""
 
 
@@ -717,7 +717,7 @@ async def rev_list_post(request: web.BaseRequest):
     summary="Upload local tails file to server",
 )
 @match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
-@response_schema(AnonCredsRevocationModuleResponseSchema(), description="")
+@response_schema(AnoncredsRevocationModuleResponseSchema(), description="")
 @tenant_authentication
 async def upload_tails_file(request: web.BaseRequest):
     """Request handler to upload local tails file for revocation registry.
@@ -753,7 +753,7 @@ async def upload_tails_file(request: web.BaseRequest):
     summary="Update the active registry",
 )
 @match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
-@response_schema(AnonCredsRevocationModuleResponseSchema(), description="")
+@response_schema(AnoncredsRevocationModuleResponseSchema(), description="")
 @tenant_authentication
 async def set_active_registry(request: web.BaseRequest):
     """Request handler to set the active registry.

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -21,14 +21,11 @@ from ..messaging.valid import (
     ANONCREDS_CRED_DEF_ID_EXAMPLE,
     ANONCREDS_DID_EXAMPLE,
     ANONCREDS_REV_REG_ID_EXAMPLE,
+    ANONCREDS_REV_REG_ID_VALIDATE,
     ANONCREDS_SCHEMA_ID_EXAMPLE,
     UUIDFour,
 )
 from ..revocation.error import RevocationNotSupportedError
-from ..revocation_anoncreds.routes import (
-    RevocationModuleResponseSchema,
-    RevRegIdMatchInfoSchema,
-)
 from ..storage.error import StorageNotFoundError
 from ..utils.profiles import is_not_anoncreds_profile_raise_web_exception
 from .base import (
@@ -64,6 +61,23 @@ create_transaction_for_endorser_description = (
     "create a transaction for an endorser to sign."
 )
 
+
+
+class AnonCredsRevocationModuleResponseSchema(OpenAPISchema):
+    """Response schema for Revocation Module."""
+
+
+class AnonCredsRevRegIdMatchInfoSchema(OpenAPISchema):
+    """Path parameters and validators for request taking rev reg id."""
+
+    rev_reg_id = fields.Str(
+        required=True,
+        validate=ANONCREDS_REV_REG_ID_VALIDATE,
+        metadata={
+            "description": "Revocation Registry identifier",
+            "example": ANONCREDS_REV_REG_ID_EXAMPLE,
+        },
+    )
 
 class SchemaIdMatchInfo(OpenAPISchema):
     """Path parameters and validators for request taking schema id."""
@@ -702,8 +716,8 @@ async def rev_list_post(request: web.BaseRequest):
     tags=["anoncreds - revocation"],
     summary="Upload local tails file to server",
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
-@response_schema(RevocationModuleResponseSchema(), description="")
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
+@response_schema(AnonCredsRevocationModuleResponseSchema(), description="")
 @tenant_authentication
 async def upload_tails_file(request: web.BaseRequest):
     """Request handler to upload local tails file for revocation registry.
@@ -738,8 +752,8 @@ async def upload_tails_file(request: web.BaseRequest):
     tags=["anoncreds - revocation"],
     summary="Update the active registry",
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
-@response_schema(RevocationModuleResponseSchema(), description="")
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
+@response_schema(AnonCredsRevocationModuleResponseSchema(), description="")
 @tenant_authentication
 async def set_active_registry(request: web.BaseRequest):
     """Request handler to set the active registry.

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -62,7 +62,6 @@ create_transaction_for_endorser_description = (
 )
 
 
-
 class AnonCredsRevocationModuleResponseSchema(OpenAPISchema):
     """Response schema for Revocation Module."""
 
@@ -78,6 +77,7 @@ class AnonCredsRevRegIdMatchInfoSchema(OpenAPISchema):
             "example": ANONCREDS_REV_REG_ID_EXAMPLE,
         },
     )
+
 
 class SchemaIdMatchInfo(OpenAPISchema):
     """Path parameters and validators for request taking schema id."""

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -25,7 +25,7 @@ from ..messaging.valid import (
     UUIDFour,
 )
 from ..revocation.error import RevocationNotSupportedError
-from ..revocation.routes import RevocationModuleResponseSchema, RevRegIdMatchInfoSchema
+from ..revocation_anoncreds.routes import RevocationModuleResponseSchema, RevRegIdMatchInfoSchema
 from ..storage.error import StorageNotFoundError
 from ..utils.profiles import is_not_anoncreds_profile_raise_web_exception
 from .base import (

--- a/acapy_agent/messaging/valid.py
+++ b/acapy_agent/messaging/valid.py
@@ -592,6 +592,21 @@ class IndyCredRevId(Regexp):
         )
 
 
+class AnonCredsCredRevId(Regexp):
+    """Validate value against anoncreds credential revocation identifier specification."""
+
+    EXAMPLE = "12345"
+    PATTERN = r"^[1-9][0-9]*$"
+
+    def __init__(self):
+        """Initialize the instance."""
+
+        super().__init__(
+            AnonCredsCredRevId.PATTERN,
+            error="Value {input} is not an anoncreds credential revocation identifier",
+        )
+
+
 class Predicate(OneOf):
     """Validate value against predicate."""
 
@@ -1052,6 +1067,9 @@ ANONCREDS_REV_REG_ID_EXAMPLE = AnoncredsRevRegId.EXAMPLE
 
 INDY_CRED_REV_ID_VALIDATE = IndyCredRevId()
 INDY_CRED_REV_ID_EXAMPLE = IndyCredRevId.EXAMPLE
+
+ANONCREDS_CRED_REV_ID_VALIDATE = AnonCredsCredRevId()
+ANONCREDS_CRED_REV_ID_EXAMPLE = AnonCredsCredRevId.EXAMPLE
 
 MAJOR_MINOR_VERSION_VALIDATE = MajorMinorVersion()
 MAJOR_MINOR_VERSION_EXAMPLE = MajorMinorVersion.EXAMPLE

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -29,7 +29,7 @@ from ..anoncreds.revocation import AnonCredsRevocation, AnonCredsRevocationError
 from ..anoncreds.routes import (
     create_transaction_for_endorser_description,
     endorser_connection_id_description,
-    AnonCredsRevRegIdMatchInfoSchema
+    AnonCredsRevRegIdMatchInfoSchema,
 )
 from ..askar.profile_anon import AskarAnoncredsProfile
 from ..indy.issuer import IndyIssuerError
@@ -278,7 +278,6 @@ class SetRevRegStateQueryStringSchema(OpenAPISchema):
         ),
         metadata={"description": "Revocation registry state to set"},
     )
-
 
 
 class RevocationCredDefIdMatchInfoSchema(OpenAPISchema):

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -30,6 +30,7 @@ from ..anoncreds.routes import (
     create_transaction_for_endorser_description,
     endorser_connection_id_description,
     AnonCredsRevRegIdMatchInfoSchema,
+    AnoncredsRevocationModuleResponseSchema,
 )
 from ..askar.profile_anon import AskarAnoncredsProfile
 from ..indy.issuer import IndyIssuerError
@@ -67,10 +68,6 @@ from .models.issuer_cred_rev_record import (
 LOGGER = logging.getLogger(__name__)
 
 TAG_TITLE = "anoncreds - revocation"
-
-
-class RevocationAnoncredsModuleResponseSchema(OpenAPISchema):
-    """Response schema for Revocation Module."""
 
 
 class RevRegResultSchemaAnoncreds(OpenAPISchema):
@@ -443,7 +440,7 @@ class RevokeRequestSchemaAnoncreds(CredRevRecordQueryStringSchema):
     summary="Revoke an issued credential",
 )
 @request_schema(RevokeRequestSchemaAnoncreds())
-@response_schema(RevocationAnoncredsModuleResponseSchema(), description="")
+@response_schema(AnoncredsRevocationModuleResponseSchema(), description="")
 @tenant_authentication
 async def revoke(request: web.BaseRequest):
     """Request handler for storing a credential revocation.
@@ -981,7 +978,7 @@ async def get_cred_rev_record(request: web.BaseRequest):
     produces=["application/octet-stream"],
 )
 @match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
-@response_schema(RevocationAnoncredsModuleResponseSchema, description="tails file")
+@response_schema(AnoncredsRevocationModuleResponseSchema, description="tails file")
 @tenant_authentication
 async def get_tails_file(request: web.BaseRequest) -> web.FileResponse:
     """Request handler to download tails file for revocation registry.

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -71,6 +71,7 @@ TAG_TITLE = "anoncreds - revocation"
 class RevocationModuleResponseSchema(OpenAPISchema):
     """Response schema for Revocation Module."""
 
+
 class RevocationAnoncredsModuleResponseSchema(OpenAPISchema):
     """Response schema for Revocation Module."""
 

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -68,6 +68,9 @@ LOGGER = logging.getLogger(__name__)
 TAG_TITLE = "anoncreds - revocation"
 
 
+class RevocationModuleResponseSchema(OpenAPISchema):
+    """Response schema for Revocation Module."""
+
 class RevocationAnoncredsModuleResponseSchema(OpenAPISchema):
     """Response schema for Revocation Module."""
 

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -29,6 +29,7 @@ from ..anoncreds.revocation import AnonCredsRevocation, AnonCredsRevocationError
 from ..anoncreds.routes import (
     create_transaction_for_endorser_description,
     endorser_connection_id_description,
+    AnonCredsRevRegIdMatchInfoSchema
 )
 from ..askar.profile_anon import AskarAnoncredsProfile
 from ..indy.issuer import IndyIssuerError
@@ -66,10 +67,6 @@ from .models.issuer_cred_rev_record import (
 LOGGER = logging.getLogger(__name__)
 
 TAG_TITLE = "anoncreds - revocation"
-
-
-class RevocationModuleResponseSchema(OpenAPISchema):
-    """Response schema for Revocation Module."""
 
 
 class RevocationAnoncredsModuleResponseSchema(OpenAPISchema):
@@ -282,18 +279,6 @@ class SetRevRegStateQueryStringSchema(OpenAPISchema):
         metadata={"description": "Revocation registry state to set"},
     )
 
-
-class RevRegIdMatchInfoSchema(OpenAPISchema):
-    """Path parameters and validators for request taking rev reg id."""
-
-    rev_reg_id = fields.Str(
-        required=True,
-        validate=ANONCREDS_REV_REG_ID_VALIDATE,
-        metadata={
-            "description": "Revocation Registry identifier",
-            "example": ANONCREDS_REV_REG_ID_EXAMPLE,
-        },
-    )
 
 
 class RevocationCredDefIdMatchInfoSchema(OpenAPISchema):
@@ -589,7 +574,7 @@ async def get_rev_regs(request: web.BaseRequest):
     tags=[TAG_TITLE],
     summary="Get revocation registry by revocation registry id",
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
 @response_schema(RevRegResultSchemaAnoncreds(), 200, description="")
 @tenant_authentication
 async def get_rev_reg(request: web.BaseRequest):
@@ -727,7 +712,7 @@ async def rotate_rev_reg(request: web.BaseRequest):
     tags=[TAG_TITLE],
     summary="Get number of credentials issued against revocation registry",
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
 @response_schema(RevRegIssuedResultSchemaAnoncreds(), 200, description="")
 @tenant_authentication
 async def get_rev_reg_issued_count(request: web.BaseRequest):
@@ -768,7 +753,7 @@ async def get_rev_reg_issued_count(request: web.BaseRequest):
     tags=[TAG_TITLE],
     summary="Get details of credentials issued against revocation registry",
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
 @response_schema(CredRevRecordDetailsResultSchemaAnoncreds(), 200, description="")
 @tenant_authentication
 async def get_rev_reg_issued(request: web.BaseRequest):
@@ -810,7 +795,7 @@ async def get_rev_reg_issued(request: web.BaseRequest):
     tags=[TAG_TITLE],
     summary="Get details of revoked credentials from ledger",
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
 @response_schema(CredRevIndyRecordsResultSchemaAnoncreds(), 200, description="")
 @tenant_authentication
 async def get_rev_reg_indy_recs(request: web.BaseRequest):
@@ -855,7 +840,7 @@ async def get_rev_reg_indy_recs(request: web.BaseRequest):
     tags=[TAG_TITLE],
     summary="Fix revocation state in wallet and return number of updated entries",
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
 @querystring_schema(RevRegUpdateRequestMatchInfoSchema())
 @response_schema(RevRegWalletUpdatedResultSchemaAnoncreds(), 200, description="")
 @tenant_authentication
@@ -996,7 +981,7 @@ async def get_cred_rev_record(request: web.BaseRequest):
     summary="Download tails file",
     produces=["application/octet-stream"],
 )
-@match_info_schema(RevRegIdMatchInfoSchema())
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
 @response_schema(RevocationAnoncredsModuleResponseSchema, description="tails file")
 @tenant_authentication
 async def get_tails_file(request: web.BaseRequest) -> web.FileResponse:
@@ -1034,7 +1019,7 @@ async def get_tails_file(request: web.BaseRequest) -> web.FileResponse:
 
 
 @docs(tags=[TAG_TITLE], summary="Set revocation registry state manually")
-@match_info_schema(RevRegIdMatchInfoSchema())
+@match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
 @querystring_schema(SetRevRegStateQueryStringSchema())
 @response_schema(RevRegResultSchemaAnoncreds(), 200, description="")
 @tenant_authentication

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -40,8 +40,8 @@ from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import (
     ANONCREDS_CRED_DEF_ID_EXAMPLE,
     ANONCREDS_CRED_DEF_ID_VALIDATE,
-    INDY_CRED_REV_ID_EXAMPLE,
-    INDY_CRED_REV_ID_VALIDATE,
+    ANONCREDS_CRED_REV_ID_EXAMPLE,
+    ANONCREDS_CRED_REV_ID_VALIDATE,
     ANONCREDS_REV_REG_ID_EXAMPLE,
     ANONCREDS_REV_REG_ID_VALIDATE,
     UUID4_EXAMPLE,
@@ -111,10 +111,10 @@ class CredRevRecordQueryStringSchema(OpenAPISchema):
     )
     cred_rev_id = fields.Str(
         required=False,
-        validate=INDY_CRED_REV_ID_VALIDATE,
+        validate=ANONCREDS_CRED_REV_ID_VALIDATE,
         metadata={
             "description": "Credential revocation identifier",
-            "example": INDY_CRED_REV_ID_EXAMPLE,
+            "example": ANONCREDS_CRED_REV_ID_EXAMPLE,
         },
     )
     cred_ex_id = fields.Str(
@@ -355,10 +355,10 @@ class PublishRevocationsSchemaAnoncreds(OpenAPISchema):
         keys=fields.Str(metadata={"example": ANONCREDS_REV_REG_ID_EXAMPLE}),
         values=fields.List(
             fields.Str(
-                validate=INDY_CRED_REV_ID_VALIDATE,
+                validate=ANONCREDS_CRED_REV_ID_VALIDATE,
                 metadata={
                     "description": "Credential revocation identifier",
-                    "example": INDY_CRED_REV_ID_EXAMPLE,
+                    "example": ANONCREDS_CRED_REV_ID_EXAMPLE,
                 },
             )
         ),
@@ -375,10 +375,10 @@ class PublishRevocationsResultSchemaAnoncreds(OpenAPISchema):
         keys=fields.Str(metadata={"example": ANONCREDS_REV_REG_ID_EXAMPLE}),
         values=fields.List(
             fields.Str(
-                validate=INDY_CRED_REV_ID_VALIDATE,
+                validate=ANONCREDS_CRED_REV_ID_VALIDATE,
                 metadata={
                     "description": "Credential revocation identifier",
-                    "example": INDY_CRED_REV_ID_EXAMPLE,
+                    "example": ANONCREDS_CRED_REV_ID_EXAMPLE,
                 },
             )
         ),

--- a/acapy_agent/revocation_anoncreds/tests/test_routes.py
+++ b/acapy_agent/revocation_anoncreds/tests/test_routes.py
@@ -43,7 +43,7 @@ class TestRevocationRoutes(IsolatedAsyncioTestCase):
             req.validate_fields(
                 {
                     "rev_reg_id": test_module.ANONCREDS_REV_REG_ID_EXAMPLE,
-                    "cred_rev_id": test_module.INDY_CRED_REV_ID_EXAMPLE,
+                    "cred_rev_id": test_module.ANONCREDS_CRED_REV_ID_EXAMPLE,
                 }
             )
             req.validate_fields({"cred_ex_id": test_module.UUID4_EXAMPLE})
@@ -54,7 +54,7 @@ class TestRevocationRoutes(IsolatedAsyncioTestCase):
                     {"rev_reg_id": test_module.ANONCREDS_REV_REG_ID_EXAMPLE}
                 )
             with self.assertRaises(test_module.ValidationError):
-                req.validate_fields({"cred_rev_id": test_module.INDY_CRED_REV_ID_EXAMPLE})
+                req.validate_fields({"cred_rev_id": test_module.ANONCREDS_CRED_REV_ID_EXAMPLE})
             with self.assertRaises(test_module.ValidationError):
                 req.validate_fields(
                     {
@@ -65,7 +65,7 @@ class TestRevocationRoutes(IsolatedAsyncioTestCase):
             with self.assertRaises(test_module.ValidationError):
                 req.validate_fields(
                     {
-                        "cred_rev_id": test_module.INDY_CRED_REV_ID_EXAMPLE,
+                        "cred_rev_id": test_module.ANONCREDS_CRED_REV_ID_EXAMPLE,
                         "cred_ex_id": test_module.UUID4_EXAMPLE,
                     }
                 )
@@ -73,7 +73,7 @@ class TestRevocationRoutes(IsolatedAsyncioTestCase):
                 req.validate_fields(
                     {
                         "rev_reg_id": test_module.ANONCREDS_REV_REG_ID_EXAMPLE,
-                        "cred_rev_id": test_module.INDY_CRED_REV_ID_EXAMPLE,
+                        "cred_rev_id": test_module.ANONCREDS_CRED_REV_ID_EXAMPLE,
                         "cred_ex_id": test_module.UUID4_EXAMPLE,
                     }
                 )

--- a/acapy_agent/revocation_anoncreds/tests/test_routes.py
+++ b/acapy_agent/revocation_anoncreds/tests/test_routes.py
@@ -54,7 +54,9 @@ class TestRevocationRoutes(IsolatedAsyncioTestCase):
                     {"rev_reg_id": test_module.ANONCREDS_REV_REG_ID_EXAMPLE}
                 )
             with self.assertRaises(test_module.ValidationError):
-                req.validate_fields({"cred_rev_id": test_module.ANONCREDS_CRED_REV_ID_EXAMPLE})
+                req.validate_fields(
+                    {"cred_rev_id": test_module.ANONCREDS_CRED_REV_ID_EXAMPLE}
+                )
             with self.assertRaises(test_module.ValidationError):
                 req.validate_fields(
                     {


### PR DESCRIPTION
The wrong validator was being imported for 2 of the AnonCreds revocation management routes, validating the ID against the indy method.