### PR TITLE
Catch and log universal resolver setup error

### DIFF
--- a/acapy_agent/resolver/__init__.py
+++ b/acapy_agent/resolver/__init__.py
@@ -5,6 +5,7 @@ import logging
 from ..config.injection_context import InjectionContext
 from ..config.provider import ClassProvider
 from ..resolver.did_resolver import DIDResolver
+from .base import ResolverError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -56,11 +57,14 @@ async def setup(context: InjectionContext):
     registry.register_resolver(webvh_resolver)
 
     if context.settings.get("resolver.universal"):
-        universal_resolver = ClassProvider(
-            "acapy_agent.resolver.default.universal.UniversalResolver"
-        ).provide(context.settings, context.injector)
-        await universal_resolver.setup(context)
-        registry.register_resolver(universal_resolver)
+        try:
+            universal_resolver = ClassProvider(
+                "acapy_agent.resolver.default.universal.UniversalResolver"
+            ).provide(context.settings, context.injector)
+            await universal_resolver.setup(context)
+            registry.register_resolver(universal_resolver)
+        except ResolverError as err:
+            LOGGER.warning(f"Universal Resolver setup failed: {err}")
 
     peer_did_1_resolver = ClassProvider(
         "acapy_agent.resolver.default.peer1.PeerDID1Resolver"

--- a/acapy_agent/resolver/default/universal.py
+++ b/acapy_agent/resolver/default/universal.py
@@ -103,12 +103,15 @@ class UniversalResolver(BaseDIDResolver):
     async def _fetch_resolver_props(self) -> dict:
         """Retrieve universal resolver properties."""
         async with aiohttp.ClientSession(headers=self.__default_headers) as session:
-            async with session.get(f"{self._endpoint}/properties/") as resp:
-                if 200 <= resp.status < 400:
-                    return await resp.json()
-                raise ResolverError(
-                    "Failed to retrieve resolver properties: " + await resp.text()
-                )
+            try:
+                async with session.get(f"{self._endpoint}/properties/") as resp:
+                    if 200 <= resp.status < 400:
+                        return await resp.json()
+                    raise ResolverError(
+                        "Failed to retrieve resolver properties: " + await resp.text()
+                    )
+            except aiohttp.ClientError as err:
+                raise ResolverError(f"Failed to fetch resolver properties: {err}")
 
     async def _get_supported_did_regex(self):
         props = await self._fetch_resolver_props()

--- a/scenarios/examples/simple/docker-compose.yml
+++ b/scenarios/examples/simple/docker-compose.yml
@@ -21,12 +21,13 @@
         --auto-provision
         --log-level debug
         --debug-webhooks
+        --universal-resolver
     healthcheck:
       test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
-      start_period: 30s
+      start_period: 50s
       interval: 7s
       timeout: 5s
-      retries: 5
+      retries: 10
     depends_on:
       tails:
         condition: service_started


### PR DESCRIPTION
This will catch the error that gets thrown when the universal resolver fails to get or process the response and log a warning. Allowing the agent to start up normally without the universal resolver available.

Not sure if any of the other resolvers could possibly fail and create this startup crash. I know the indy/sov resolver does here but I believe that's still the intended behavior when a ledger is configured.

The OATH tests should start working after this but the startup will be slow. I'll be looking at removing the universal resolver from the OATH tests.