### PR TITLE
:art: Include the validation error in Unprocessable Entity reason

### DIFF
--- a/acapy_agent/admin/server.py
+++ b/acapy_agent/admin/server.py
@@ -176,7 +176,7 @@ async def ready_middleware(request: web.BaseRequest, handler: Coroutine):
             request.path,
             validation_error_message,
         )
-        raise
+        raise web.HTTPUnprocessableEntity(reason=validation_error_message) from e
     except (LedgerConfigError, LedgerTransactionError) as e:
         # fatal, signal server shutdown
         LOGGER.critical("Shutdown with %s", str(e))


### PR DESCRIPTION
Just raising the `HTTPUnprocessableEntity` exception doesn't report the validation error to the client, so we should include the parsed validation error message in the reason