### PR TITLE
:construction_worker: Dependabot: don't ignore major releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Maintain dependencies for Python Packages
   - package-ecosystem: "pip"
@@ -30,6 +33,9 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Maintain dependencies for Python Packages
   - package-ecosystem: "pip"
@@ -39,6 +45,9 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Maintain dependencies for Python Packages
   - package-ecosystem: "pip"
@@ -48,6 +57,9 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,6 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
 
   # Maintain dependencies for Python Packages
   - package-ecosystem: "pip"
@@ -33,9 +30,6 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
 
   # Maintain dependencies for Python Packages
   - package-ecosystem: "pip"
@@ -45,9 +39,6 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
 
   # Maintain dependencies for Python Packages
   - package-ecosystem: "pip"
@@ -57,9 +48,6 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
Because they are good to know about
___
As mentioned in ACA-Pug meeting notes: https://lf-openwallet-foundation.atlassian.net/wiki/spaces/ACAPy/pages/82706433/2025-02-04+-+ACA-Py+Users+Group+Community+Meeting

>Enable major version update recommendations by Dependabot: review open PRs and pick-and-choose which ones could be merged as-is and which ones should be actioned by someone (more as a recommendation to update than as a solution). Project is in a testing state that allows us to move forward with this.
___
edit: now ignores patch releases instead