### PR TITLE
fix: connection reuse with multi-tenancy

### DIFF
--- a/acapy_agent/core/profile.py
+++ b/acapy_agent/core/profile.py
@@ -130,6 +130,21 @@ class Profile(ABC):
             self.__class__.__name__, self.backend, self.name
         )
 
+    def __eq__(self, other) -> bool:
+        """Equality checks for profiles.
+
+        Multiple profile instances can exist at the same time but point to the
+        same profile. This allows us to test equality based on the profile
+        pointed to by the instance rather than by object reference comparison.
+        """
+        if not isinstance(other, Profile):
+            return False
+
+        if type(self) is not type(other):
+            return False
+
+        return self.name == other.name
+
 
 class ProfileManager(ABC):
     """Handle provision and open for profile instances."""

--- a/acapy_agent/protocols/out_of_band/v1_0/routes.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/routes.py
@@ -328,6 +328,7 @@ async def invitation_receive(request: web.BaseRequest):
             mediation_id=mediation_id,
         )
     except (DIDXManagerError, StorageError, BaseModelError) as err:
+        LOGGER.exception("Error during receive invitation")
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response(result.serialize())


### PR DESCRIPTION
When using multi-tenancy, calls to `POST /out-of-band/receive-invitation?use_existing_connection=true` would fail with a record not found error, despite connection reuse actually being completed in the background.

The issue has to do with this line: https://github.com/openwallet-foundation/acapy/blob/6b228d7a81de1ce99cbf35437e8a864e69dd7d06/acapy_agent/core/event_bus.py#L179

During OOB handling, the receive invitation handler will asynchronously wait for connection reuse to complete before returning. The offending line above is within the code that waits for the events indicating connection reuse has completed. The issue is that, in multi-tenancy mode, there can be multiple profile instances, causing the equality check `waiting_profile == profile` to fail even though the profiles were pointing to the same logical profile because they did not point to the exact same instance.

This change adds an equality check for profiles that takes into account that multiple instances may exist that all point to the same logical profile by comparing profile names (which are guaranteed to be unique across profiles as of #3470).

As an aside, we should seriously consider removing this asynchronous waiting code. It is brittle and prone to breakage and does not adequately handle clustered environments. I regret to admit that I originally introduced the `wait_for_event` method (almost 4 years ago!) but I ultimately removed its use in the scenario I introduced it for. There are only two remaining instances of it being used, both of which are in OOB.

This (hopefully) resolves an issue that @thiagoromanos reported on discord in this message: https://discord.com/channels/1022962884864643214/1286299858994462842/1343937904803840063