### PR TITLE
fix: tenant access to endpoints leading to access the base wallet

### DIFF
--- a/acapy_agent/admin/decorators/auth.py
+++ b/acapy_agent/admin/decorators/auth.py
@@ -78,7 +78,7 @@ def tenant_authentication(handler):
             (multitenant_enabled and authorization_header)
             or (not multitenant_enabled and valid_key)
             or (multitenant_enabled and valid_key and base_wallet_allowed_route)
-            or insecure_mode
+            or (insecure_mode and not multitenant_enabled)
             or request.method == "OPTIONS"
         ):
             return await handler(request)

--- a/acapy_agent/admin/tests/test_auth.py
+++ b/acapy_agent/admin/tests/test_auth.py
@@ -86,11 +86,11 @@ class TestTenantAuthentication(IsolatedAsyncioTestCase):
         await decor_func(self.request)
         self.decorated_handler.assert_called_once_with(self.request)
 
-    async def test_insecure_mode(self):
+    async def test_insecure_mode_witout_token(self):
         self.profile.settings["admin.admin_insecure_mode"] = True
         decor_func = tenant_authentication(self.decorated_handler)
-        await decor_func(self.request)
-        self.decorated_handler.assert_called_once_with(self.request)
+        with self.assertRaises(web.HTTPUnauthorized):
+            await decor_func(self.request)
 
     async def test_single_tenant_invalid_api_key(self):
         self.profile.settings["multitenant.enabled"] = False


### PR DESCRIPTION
When using acapy with `multitenant` enabled **and** `admin-insecure-mode`, tenant endpoints (like `[GET] /wallet/did` for example) could be accessed **without a bearer token**.

With this fix, single tenant agents will access agent's endpoints with no problem, and multi-tenant agents will require a bearer token to access those endpoints.