### PR TITLE
Fix revocation accum sync when endorsement txn fails

### DIFF
--- a/acapy_agent/revocation/routes.py
+++ b/acapy_agent/revocation/routes.py
@@ -1557,6 +1557,10 @@ def register_events(event_bus: EventBus):
         re.compile(f"^{REVOCATION_EVENT_PREFIX}{REVOCATION_ENTRY_EVENT}.*"),
         on_revocation_entry_event,
     )
+    event_bus.subscribe(
+        re.compile(f"^{REVOCATION_EVENT_PREFIX}REV_REG_ENTRY_TXN_FAILED.*"),
+        on_rev_reg_entry_txn_failed,
+    )
 
 
 async def on_revocation_registry_init_event(profile: Profile, event: Event):
@@ -1745,6 +1749,12 @@ async def on_revocation_registry_endorsed_event(profile: Profile, event: Event):
             registry_record.revoc_def_type,
             endorser_connection_id=endorser_connection_id,
         )
+
+
+async def on_rev_reg_entry_txn_failed(profile: Profile, event: Event):
+    """Handle revocation registry entry transaction failed event."""
+    manager = RevocationManager(profile)
+    await manager.fix_and_publish_from_invalid_accum_err(event.payload.get("msg"))
 
 
 class TailsDeleteResponseSchema(OpenAPISchema):

--- a/acapy_agent/revocation/util.py
+++ b/acapy_agent/revocation/util.py
@@ -76,3 +76,12 @@ async def notify_pending_cleared_event(
     """Send notification of credential revoked as issuer."""
     topic = f"{REVOCATION_EVENT_PREFIX}{REVOCATION_CLEAR_PENDING_EVENT}::{rev_reg_id}"
     await profile.notify(topic, {"rev_reg_id": rev_reg_id})
+
+
+async def notify_rev_reg_entry_txn_failed(
+    profile: Profile,
+    msg: str,
+):
+    """Send notification that a revocation registry entry transaction failed."""
+    topic = f"{REVOCATION_EVENT_PREFIX}REV_REG_ENTRY_TXN_FAILED"
+    await profile.notify(topic, {"msg": msg})


### PR DESCRIPTION
When the endorsement transaction fails, create an event in the response handler. Check the rev_reg_defs on the ledger to find the problem entry. Create a recovery transaction and update the local wallet and re-send the transaction to the endorser. 

Retry the same accumulator error 5 times and then log the error.


***Note:*** The `fix-revocation-entry-state` endpoint with create transaction still doesn't create an endorsed transaction. I didn't want to try a change that for this commit which needs to be backported. Also anoncreds (did:sov) likely has the same problem and this does not attempt to fix it here. Only for indy revocation.