### PR TITLE
:bug: Fix: allow multitenant askar-anoncreds wallets to present indy credentials

### DIFF
--- a/acapy_agent/askar/profile.py
+++ b/acapy_agent/askar/profile.py
@@ -178,11 +178,15 @@ class AskarProfile(Profile):
                 ),
             )
 
-    def session(self, context: Optional[InjectionContext] = None) -> ProfileSession:
+    def session(
+        self, context: Optional[InjectionContext] = None
+    ) -> "AskarProfileSession":
         """Start a new interactive session with no transaction support requested."""
         return AskarProfileSession(self, False, context=context)
 
-    def transaction(self, context: Optional[InjectionContext] = None) -> ProfileSession:
+    def transaction(
+        self, context: Optional[InjectionContext] = None
+    ) -> "AskarProfileSession":
         """Start a new interactive session with commit and rollback support.
 
         If the current backend does not support transactions, then commit

--- a/acapy_agent/indy/credx/holder.py
+++ b/acapy_agent/indy/credx/holder.py
@@ -80,20 +80,23 @@ class IndyCredxHolder(IndyHolder):
                     raise IndyHolderError("Error fetching link secret") from err
 
                 if record:
-                    wallet_type = self._profile.settings.get_value("wallet.type")
                     try:
-                        if wallet_type == "askar-anoncreds":
-                            LOGGER.debug("Loading LinkSecret from Anoncreds secret")
+                        LOGGER.debug("Loading LinkSecret")
+                        secret = LinkSecret.load(record.raw_value)
+                        LOGGER.debug("Loaded existing link secret.")
+                    except CredxError as err:
+                        LOGGER.info(
+                            "Attempt fallback method after error loading link secret: %s",
+                            err,
+                        )
+                        try:
                             ms_string = record.value.decode("ascii")
                             link_secret_dict = {"value": {"ms": ms_string}}
                             secret = LinkSecret.load(link_secret_dict)
-                        else:
-                            LOGGER.debug("Loading LinkSecret")
-                            secret = LinkSecret.load(record.raw_value)
-                        LOGGER.debug("Loaded existing link secret.")
-                    except CredxError as err:
-                        LOGGER.error("Error loading link secret: %s", err)
-                        raise IndyHolderError("Error loading link secret") from err
+                            LOGGER.debug("Loaded LinkSecret from Anoncreds secret.")
+                        except CredxError as decode_err:
+                            LOGGER.error("Error loading link secret: %s", decode_err)
+                            raise IndyHolderError("Error loading link secret") from err
                     break
                 else:
                     try:

--- a/acapy_agent/indy/credx/holder.py
+++ b/acapy_agent/indy/credx/holder.py
@@ -76,10 +76,21 @@ class IndyCredxHolder(IndyHolder):
                     )
                 except AskarError as err:
                     raise IndyHolderError("Error fetching link secret") from err
+
                 if record:
+                    wallet_type = self._profile.settings.get_value("wallet.type")
                     try:
-                        secret = LinkSecret.load(record.raw_value)
+                        if wallet_type == "askar-anoncreds":
+                            LOGGER.debug("Loading LinkSecret from Anoncreds secret")
+                            ms_string = record.value.decode("ascii")
+                            link_secret_dict = {"value": {"ms": ms_string}}
+                            secret = LinkSecret.load(link_secret_dict)
+                        else:
+                            LOGGER.debug("Loading LinkSecret")
+                            secret = LinkSecret.load(record.raw_value)
+                        LOGGER.debug("Loaded existing link secret.")
                     except CredxError as err:
+                        LOGGER.error("Error loading link secret: %s", err)
                         raise IndyHolderError("Error loading link secret") from err
                     break
                 else:

--- a/acapy_agent/indy/credx/tests/test_get_link_secret.py
+++ b/acapy_agent/indy/credx/tests/test_get_link_secret.py
@@ -1,0 +1,130 @@
+from unittest import IsolatedAsyncioTestCase
+
+import pytest
+from aries_askar import AskarError, AskarErrorCode
+
+from acapy_agent.indy.credx.holder import CredxError, IndyHolderError
+from acapy_agent.utils.testing import create_test_profile
+
+from ....tests import mock
+from .. import holder
+
+
+@pytest.mark.askar
+@pytest.mark.indy_credx
+class TestIndyCredxGetLinkSecret(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.holder_profile = await create_test_profile()
+        self.holder = holder.IndyCredxHolder(self.holder_profile)
+
+        self.mock_session = mock.MagicMock()
+        self.mock_session.__aenter__.return_value = self.mock_session
+        self.mock_session.__aexit__.return_value = None
+        self.holder._profile.session = mock.MagicMock(return_value=self.mock_session)
+
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.load")
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.create")
+    async def test_get_link_secret_existing(self, mock_create, mock_load):
+        # Mock session and record
+        mock_record = mock.MagicMock()
+        mock_record.raw_value = b'{"value": {"ms": "mocked_ms"}}'
+
+        self.mock_session.handle.fetch = mock.CoroutineMock(return_value=mock_record)
+
+        # Test fetching existing link secret
+        secret = await self.holder.get_link_secret()
+        assert secret is not None
+        mock_load.assert_called_once_with(mock_record.raw_value)
+        mock_create.assert_not_called()
+
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.load")
+    async def test_get_link_secret_fetch_error(self, mock_load):
+        # Mock session to raise an error
+        self.mock_session.handle.fetch = mock.CoroutineMock(
+            side_effect=AskarError(AskarErrorCode.BACKEND, "Fetch error")
+        )
+
+        with pytest.raises(IndyHolderError, match="Error fetching link secret"):
+            await self.holder.get_link_secret()
+
+        mock_load.assert_not_called()
+
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.load")
+    async def test_get_link_secret_load_error(self, mock_load):
+        # Mock session and record
+        mock_record = mock.MagicMock()
+        mock_record.raw_value = b'{"value": {"ms": "mocked_ms"}}'
+        self.mock_session.handle.fetch = mock.CoroutineMock(return_value=mock_record)
+
+        # Mock load to raise an error
+        mock_load.side_effect = CredxError(4, "Load error")
+
+        with pytest.raises(IndyHolderError, match="Error loading link secret"):
+            await self.holder.get_link_secret()
+
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.load")
+    async def test_get_link_secret_fallback_load(self, mock_load):
+        # Mock session and record
+        mock_record = mock.MagicMock()
+        mock_record.raw_value = b'{"value": {"ms": "mocked_ms"}}'
+        self.mock_session.handle.fetch = mock.CoroutineMock(return_value=mock_record)
+
+        # Mock load to raise an error initially
+        mock_load.side_effect = [CredxError(4, "Load error"), mock.MagicMock()]
+
+        # Test fallback method
+        secret = await self.holder.get_link_secret()
+        assert secret is not None
+        assert mock_load.call_count == 2
+
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.create")
+    async def test_get_link_secret_create_error(self, mock_create):
+        # Mock session to return no record
+        self.mock_session.handle.fetch = mock.CoroutineMock(return_value=None)
+
+        # Mock create to raise an error
+        mock_create.side_effect = CredxError(4, "Create error")
+
+        with pytest.raises(IndyHolderError, match="Error creating link secret"):
+            await self.holder.get_link_secret()
+
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.create")
+    async def test_get_link_secret_create_and_save(self, mock_create):
+        # Mock session to return no record
+        self.mock_session.handle.fetch = mock.CoroutineMock(return_value=None)
+
+        # Mock successful creation
+        mock_secret = mock.MagicMock()
+        mock_create.return_value = mock_secret
+
+        # Mock successful insert
+        self.mock_session.handle.insert = mock.CoroutineMock()
+
+        # Test creating and saving new link secret
+        secret = await self.holder.get_link_secret()
+        assert secret is not None
+        mock_create.assert_called_once()
+        self.mock_session.handle.insert.assert_called_once()
+
+    @mock.patch("acapy_agent.indy.credx.holder.LinkSecret.create")
+    async def test_get_link_secret_duplicate_error(self, mock_create):
+        # Mock session to return no record
+        self.mock_session.handle.fetch = mock.CoroutineMock(return_value=None)
+
+        # Mock successful creation
+        mock_secret = mock.MagicMock()
+        mock_create.return_value = mock_secret
+
+        # Mock insert to raise a duplicate error
+        self.mock_session.handle.insert = mock.CoroutineMock(
+            side_effect=[
+                AskarError(AskarErrorCode.DUPLICATE, "Duplicate error"),
+                mock.CoroutineMock(),
+            ]
+        )
+
+        # Test handling of duplicate error
+        secret = await self.holder.get_link_secret()
+        assert secret is not None
+        assert mock_create.call_count == 2
+        assert self.mock_session.handle.insert.call_count == 2

--- a/acapy_agent/protocols/present_proof/v2_0/formats/indy/handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/indy/handler.py
@@ -36,16 +36,10 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
     """Indy presentation format handler."""
 
     format = V20PresFormat.Format.INDY
-    anoncreds_handler = None
 
     def __init__(self, profile: Profile):
         """Shim initialization to check for new AnonCreds library."""
         super().__init__(profile)
-
-        # Temporary shim while the new anoncreds library integration is in progress
-        wallet_type = profile.settings.get_value("wallet.type")
-        if wallet_type == "askar-anoncreds":
-            self.anoncreds_handler = AnonCredsPresExchangeHandler(profile)
 
     @classmethod
     def validate_fields(cls, message_type: str, attachment_data: Mapping):
@@ -120,12 +114,6 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
             A tuple (updated presentation exchange record, presentation request message)
 
         """
-        # Temporary shim while the new anoncreds library integration is in progress
-        if self.anoncreds_handler:
-            return await self.anoncreds_handler.create_bound_request(
-                pres_ex_record,
-                request_data,
-            )
 
         indy_proof_request = pres_ex_record.pres_proposal.attachment(
             IndyPresExchangeHandler.format
@@ -148,12 +136,6 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
         request_data: Optional[dict] = None,
     ) -> Tuple[V20PresFormat, AttachDecorator]:
         """Create a presentation."""
-
-        if self.anoncreds_handler:
-            return await self.anoncreds_handler.create_pres(
-                pres_ex_record,
-                request_data,
-            )
 
         requested_credentials = {}
         if not request_data:
@@ -323,10 +305,6 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
                         f"restrictions {req_restrictions}"
                     )
 
-        # Temporary shim while the new anoncreds library integration is in progress
-        if self.anoncreds_handler:
-            return await self.anoncreds_handler.receive_pres(message, pres_ex_record)
-
         proof = message.attachment(IndyPresExchangeHandler.format)
         _check_proof_vs_proposal()
 
@@ -341,10 +319,6 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
             presentation exchange record, updated
 
         """
-        # Temporary shim while the new anoncreds library integration is in progress
-        if self.anoncreds_handler:
-            return await self.anoncreds_handler.verify_pres(pres_ex_record)
-
         pres_request_msg = pres_ex_record.pres_request
 
         # The `or` anoncreds format is for the indy <--> anoncreds compatibility


### PR DESCRIPTION
Removes the "temporary shim" that redirects from indy to anoncreds proof handler, and allows loading the LinkSecret from an Anoncreds master secret.

The shim prevented an askar-anoncreds wallet in a multitenant context from successfully presenting Indy creds.

Resolves #3516

___
Note: 🧪 tested this in acapy-cloud here: https://github.com/didx-xyz/acapy-cloud/pull/1362
^ Previously all of our verifier tests failed when Alice fixture was changed to askar-anoncreds. Now it's fixed!

There's 1 failing test, but unrelated to indy proofs. It's to do with deleting a credential, and I've created a separate issue for that here: #3550. Edit: Success! I included the fix in #3551 as well for the tests, and now everything passes 🎉