### PR TITLE
:bug: Fix: allow anoncreds wallet to delete indy credentials

### DIFF
--- a/acapy_agent/holder/routes.py
+++ b/acapy_agent/holder/routes.py
@@ -351,7 +351,7 @@ async def credentials_remove(request: web.BaseRequest):
     credential_id = request.match_info["credential_id"]
     profile: Profile = context.profile
 
-    async def delete_credential_using_anoncreds(profile: Profile):
+    async def delete_credential_using_anoncreds():
         try:
             holder = AnonCredsHolder(profile)
             await holder.delete_credential(credential_id)
@@ -360,7 +360,7 @@ async def credentials_remove(request: web.BaseRequest):
                 raise web.HTTPNotFound(reason=err.roll_up) from err
             raise web.HTTPBadRequest(reason=err.roll_up) from err
 
-    async def delete_credential_using_indy(profile: Profile):
+    async def delete_credential_using_indy():
         async with profile.session() as session:
             try:
                 holder = session.inject(IndyHolder)
@@ -368,22 +368,22 @@ async def credentials_remove(request: web.BaseRequest):
             except WalletNotFoundError as err:
                 raise web.HTTPNotFound(reason=err.roll_up) from err
 
-    async def delete_using_anoncreds_or_indy(profile: Profile):
+    async def delete_using_anoncreds_or_indy():
         """Try to delete anoncreds credential with fallback to indy if not found."""
         try:
-            await delete_credential_using_anoncreds(profile)
+            await delete_credential_using_anoncreds()
         except web.HTTPNotFound as anoncreds_err:
             # If credential not found in anoncreds, try with indy
             try:
-                await delete_credential_using_indy(profile)
+                await delete_credential_using_indy()
             except web.HTTPNotFound:
                 # Raise original anoncreds error if neither found
                 raise web.HTTPNotFound(reason=anoncreds_err.reason) from anoncreds_err
 
     if context.settings.get(wallet_type_config) == "askar-anoncreds":
-        await delete_using_anoncreds_or_indy(profile)
+        await delete_using_anoncreds_or_indy()
     else:
-        await delete_credential_using_indy(profile)
+        await delete_credential_using_indy()
 
     # Notify event subscribers
     topic = "acapy::record::credential::delete"

--- a/acapy_agent/holder/tests/test_routes.py
+++ b/acapy_agent/holder/tests/test_routes.py
@@ -293,6 +293,7 @@ class TestHolderRoutes(IsolatedAsyncioTestCase):
             )
         )
 
+        # Anoncreds holder errors
         mock_delete_credential.side_effect = [
             None,
             AnonCredsHolderError("anoncreds error", error_code=AskarErrorCode.NOT_FOUND),
@@ -311,13 +312,17 @@ class TestHolderRoutes(IsolatedAsyncioTestCase):
         with mock.patch.object(
             test_module.web, "json_response", mock.Mock()
         ) as json_response:
+            # First mock delete has no side effect; delete succeeds
             result = await test_module.credentials_remove(self.request)
             json_response.assert_called_once_with({})
             assert result is json_response.return_value
             assert mock_delete_credential.called
 
+            # Not found after anoncreds not found and indy not found
             with self.assertRaises(test_module.web.HTTPNotFound):
                 await test_module.credentials_remove(self.request)
+
+            # Bad request after anoncreds unexpected error
             with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.credentials_remove(self.request)
 


### PR DESCRIPTION
Resolves #3550

If wallet-type is askar-anoncreds, then we will now first try to delete credential assuming it is anoncreds; if not found, then we attempt to delete as indy credential.