### PR TITLE
fix(acme.py): add missing log_timer import to resolve error

### DIFF
--- a/demo/runners/acme.py
+++ b/demo/runners/acme.py
@@ -14,6 +14,7 @@ from runners.support.utils import (  # noqa:E402
     check_requires,
     log_msg,
     log_status,
+    log_timer,
     prompt,
     prompt_loop,
 )


### PR DESCRIPTION
The script `runners/acme.py` was missing an import for `log_timer`, which caused an error during execution. This function was not mentioned in `AcmeDemoWorkshop.md`, but it is required for proper functionality.

Changes:
- Added `log_timer` to the import list in `runners/acme.py`.

This ensures that the script runs without import-related errors.