### PR TITLE
fix post-vcdm 2.0 fetch all calls

### DIFF
--- a/acapy_agent/storage/askar.py
+++ b/acapy_agent/storage/askar.py
@@ -215,7 +215,6 @@ class AskarStorage(BaseStorage):
         self,
         type_filter: str,
         tag_query: Optional[Mapping] = None,
-        order_by: Optional[str] = None,
         descending: bool = False,
         options: Optional[Mapping] = None,
     ):
@@ -225,8 +224,6 @@ class AskarStorage(BaseStorage):
         for row in await self._session.handle.fetch_all(
             category=type_filter,
             tag_filter=tag_query,
-            order_by=order_by,
-            descending=descending,
             for_update=for_update,
         ):
             results.append(


### PR DESCRIPTION
vcdm 2.0 removed the default issuance date field from all credential and as a result it is no longer possible to sort stored vc. There is still a call to the `fetch_all` askar wallet with a `descending` ordering, which is removed here. This was causing the agent to crash.