### PR TITLE
Repair anoncreds holder revocation list request

### DIFF
--- a/acapy_agent/anoncreds/holder.py
+++ b/acapy_agent/anoncreds/holder.py
@@ -1,4 +1,4 @@
-"""Indy holder implementation."""
+"""Anoncreds holder implementation."""
 
 import asyncio
 import json
@@ -598,10 +598,10 @@ class AnonCredsHolder:
 
         Args:
             presentation_request: Valid indy format presentation request
-            requested_credentials: Indy format requested credentials
-            schemas: Indy formatted schemas JSON
-            credential_definitions: Indy formatted credential definitions JSON
-            rev_states: Indy format revocation states JSON
+            requested_credentials: Anoncreds format requested credentials
+            schemas: Anoncreds formatted schemas JSON
+            credential_definitions: Anoncreds formatted credential definitions JSON
+            rev_states: Anoncreds format revocation states JSON
 
         """
 
@@ -691,9 +691,9 @@ class AnonCredsHolder:
             presentation_request: Valid indy format presentation request
             requested_credentials_w3c: W3C format requested credentials
             credentials_w3c_metadata: W3C format credential metadata
-            schemas: Indy formatted schemas JSON
-            credential_definitions: Indy formatted credential definitions JSON
-            rev_states: Indy format revocation states JSON
+            schemas: Anoncreds formatted schemas JSON
+            credential_definitions: Anoncreds formatted credential definitions JSON
+            rev_states: Anoncreds format revocation states JSON
 
         """
         present_creds = PresentCredentials()

--- a/acapy_agent/protocols/present_proof/anoncreds/pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/anoncreds/pres_exch_handler.py
@@ -166,7 +166,8 @@ class AnonCredsPresExchHandler:
                     result = await anoncreds_registry.get_revocation_list(
                         self._profile,
                         rev_reg_id,
-                        reft_non_revoc_interval.get("to", epoch_now),
+                        timestamp_from=reft_non_revoc_interval.get("from", 0),
+                        timestamp_to=reft_non_revoc_interval.get("to", epoch_now),
                     )
 
                     rev_lists[key] = (

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -773,7 +773,10 @@ async def main(args):
                         raise Exception(
                             "Error invalid credential type:" + faber_agent.cred_type
                         )
-
+                    log_status(
+                        "Send a proof request to X: "
+                        + json.dumps(proof_request_web_request)
+                    )
                     await agent.admin_POST(
                         "/present-proof-2.0/send-request", proof_request_web_request
                     )

--- a/scenarios/examples/util.py
+++ b/scenarios/examples/util.py
@@ -358,6 +358,7 @@ async def anoncreds_present_proof_v2(
     requested_attributes: Optional[List[Mapping[str, Any]]] = None,
     requested_predicates: Optional[List[Mapping[str, Any]]] = None,
     non_revoked: Optional[Mapping[str, int]] = None,
+    cred_rev_id: Optional[str] = None,
 ):
     """Present an credential using present proof v2."""
 
@@ -412,6 +413,15 @@ async def anoncreds_present_proof_v2(
         f"/present-proof-2.0/records/{holder_pres_ex_id}/credentials",
         response=List[CredPrecis],
     )
+
+    # Filter credentials by revocation id to allow selecting non-revoked
+    if cred_rev_id:
+        relevant_creds = [
+            cred
+            for cred in relevant_creds
+            if cred.cred_info._extra.get("cred_rev_id") == cred_rev_id
+        ]
+
     assert holder_pres_ex.by_format.pres_request
     proof_request = holder_pres_ex.by_format.pres_request.get(
         "anoncreds"


### PR DESCRIPTION
I'm still not exactly sure when this happened but the anoncreds api changed slightly for fetching the revocation list. The request from the holder wasn't using named parameters and this caused the `to` value to become the `from` value. This would return a list without any indexes revoked in the list. Then because the accumulator value didn't match the verification would fail.
