### PR TITLE
:zap: Automatically use pytest-xdist to run tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ line-length = 90
 [tool.pytest.ini_options]
 testpaths = "acapy_agent"
 addopts = """
+    -n auto
     --quiet --junitxml=./test-reports/junit.xml
     --cov-config .coveragerc --cov-report term --cov-report xml
     --ruff


### PR DESCRIPTION
pytest-xdist already exists as a dev dependency, but it's not configured to be used automatically.

So, this PR adds `-n auto` to the pytest.ini_options, so that running `pytest` will automatically try use as many parallel instances as it can. This should also configure it to be used in the PR tests GitHub action

On my machine, this speeds up tests from ~6m30s to ~1m30s

Edit: Ah, I see the GitHub action is already configured to run with `-n auto`