### PR TITLE
:sparkles: Refactor TailsServer injection pattern

### DIFF
--- a/acapy_agent/anoncreds/revocation.py
+++ b/acapy_agent/anoncreds/revocation.py
@@ -30,9 +30,7 @@ from ..askar.profile_anon import AskarAnoncredsProfile, AskarAnoncredsProfileSes
 from ..core.error import BaseError
 from ..core.event_bus import Event, EventBus
 from ..core.profile import Profile, ProfileSession
-from ..multitenant.base import BaseMultitenantManager
 from ..tails.anoncreds_tails_server import AnonCredsTailsServer
-from ..tails.base import BaseTailsServer
 from .error_messages import ANONCREDS_PROFILE_REQUIRED_MSG
 from .events import RevListFinishedEvent, RevRegDefFinishedEvent
 from .issuer import (
@@ -694,14 +692,8 @@ class AnonCredsRevocation:
 
     async def upload_tails_file(self, rev_reg_def: RevRegDef):
         """Upload the local tails file to the tails server."""
-        multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
-        if multitenant_mgr:
-            tails_server = AnonCredsTailsServer()
-        else:
-            tails_server = self.profile.inject_or(BaseTailsServer)
+        tails_server = AnonCredsTailsServer()
 
-        if not tails_server:
-            raise AnonCredsRevocationError("Tails server not configured")
         if not Path(self.get_local_tails_path(rev_reg_def)).is_file():
             raise AnonCredsRevocationError("Local tails file not found")
 

--- a/acapy_agent/config/default_context.py
+++ b/acapy_agent/config/default_context.py
@@ -14,7 +14,6 @@ from ..protocols.actionmenu.v1_0.driver_service import DriverMenuService
 from ..protocols.introduction.v0_1.base_service import BaseIntroductionService
 from ..protocols.introduction.v0_1.demo_service import DemoIntroductionService
 from ..resolver.did_resolver import DIDResolver
-from ..tails.base import BaseTailsServer
 from ..transport.wire_format import BaseWireFormat
 from ..utils.stats import Collector
 from ..wallet.default_verification_key_strategy import (
@@ -84,22 +83,6 @@ class DefaultContextBuilder(ContextBuilder):
         """Bind various class providers."""
 
         context.injector.bind_provider(ProfileManager, ProfileManagerProvider())
-
-        wallet_type = self.settings.get("wallet.type")
-        if wallet_type == "askar-anoncreds":
-            context.injector.bind_provider(
-                BaseTailsServer,
-                ClassProvider(
-                    "acapy_agent.tails.anoncreds_tails_server.AnonCredsTailsServer",
-                ),
-            )
-        else:
-            context.injector.bind_provider(
-                BaseTailsServer,
-                ClassProvider(
-                    "acapy_agent.tails.indy_tails_server.IndyTailsServer",
-                ),
-            )
 
         # Register default pack format
         context.injector.bind_provider(

--- a/acapy_agent/revocation/models/issuer_rev_reg_record.py
+++ b/acapy_agent/revocation/models/issuer_rev_reg_record.py
@@ -41,7 +41,7 @@ from ...messaging.valid import (
     INDY_REV_REG_ID_VALIDATE,
     UUID4_EXAMPLE,
 )
-from ...tails.base import BaseTailsServer
+from ...tails.indy_tails_server import IndyTailsServer
 from ..error import RevocationError
 from ..recover import generate_ledger_rrrecovery_txn
 from .issuer_cred_rev_record import IssuerCredRevRecord
@@ -474,9 +474,7 @@ class IssuerRevRegRecord(BaseRecord):
 
     async def upload_tails_file(self, profile: Profile):
         """Upload the local tails file to the tails server."""
-        tails_server = profile.inject_or(BaseTailsServer)
-        if not tails_server:
-            raise RevocationError("Tails server not configured")
+        tails_server = IndyTailsServer()
         if not self.has_local_tails_file:
             raise RevocationError("Local tails file not found")
 

--- a/acapy_agent/revocation/models/tests/test_issuer_rev_reg_record.py
+++ b/acapy_agent/revocation/models/tests/test_issuer_rev_reg_record.py
@@ -270,7 +270,14 @@ class TestIssuerRevRegRecord(IsolatedAsyncioTestCase):
         assert rec.state == IssuerRevRegRecord.STATE_POSTED
         self.ledger.send_revoc_reg_def.assert_called_once()
 
-        with mock.patch.object(test_module.Path, "is_file", lambda _: True):
+        with (
+            mock.patch.object(test_module.Path, "is_file", lambda _: True),
+            mock.patch.object(
+                test_module,
+                "IndyTailsServer",
+                mock.MagicMock(return_value=self.tails_server),
+            ),
+        ):
             await rec.upload_tails_file(self.profile)
         assert (
             rec.tails_public_uri

--- a/acapy_agent/revocation/models/tests/test_issuer_rev_reg_record.py
+++ b/acapy_agent/revocation/models/tests/test_issuer_rev_reg_record.py
@@ -7,7 +7,7 @@ from ....askar.profile import AskarProfileSession
 from ....indy.issuer import IndyIssuer, IndyIssuerError
 from ....indy.util import indy_client_dir
 from ....ledger.base import BaseLedger
-from ....tails.base import BaseTailsServer
+from ....tails.indy_tails_server import IndyTailsServer
 from ....tests import mock
 from ....utils.testing import create_test_profile
 from ...error import RevocationError
@@ -60,11 +60,10 @@ class TestIssuerRevRegRecord(IsolatedAsyncioTestCase):
         self.ledger.send_revoc_reg_entry = mock.CoroutineMock()
         self.profile.context.injector.bind_instance(BaseLedger, self.ledger)
 
-        self.tails_server = mock.MagicMock(BaseTailsServer, autospec=True)
+        self.tails_server = mock.MagicMock(IndyTailsServer, autospec=True)
         self.tails_server.upload_tails_file = mock.CoroutineMock(
             return_value=(True, "http://1.2.3.4:8088/rev-reg-id")
         )
-        self.profile.context.injector.bind_instance(BaseTailsServer, self.tails_server)
 
         self.session = await self.profile.session()
 

--- a/acapy_agent/tails/indy_tails_server.py
+++ b/acapy_agent/tails/indy_tails_server.py
@@ -47,10 +47,10 @@ class IndyTailsServer(BaseTailsServer):
             ledger_manager = context.injector.inject(BaseMultipleLedgerManager)
             write_ledger = context.injector.inject(BaseLedger)
             available_write_ledgers = await ledger_manager.get_write_ledgers()
-            LOGGER.debug(f"available write_ledgers = {available_write_ledgers}")
-            LOGGER.debug(f"write_ledger = {write_ledger}")
+            LOGGER.debug("available write_ledgers = %s", available_write_ledgers)
+            LOGGER.debug("write_ledger = %s", write_ledger)
             pool = write_ledger.pool
-            LOGGER.debug(f"write_ledger pool = {pool}")
+            LOGGER.debug("write_ledger pool = %s", pool)
 
             genesis_transactions = pool.genesis_txns
 


### PR DESCRIPTION
Resolves #3586

Removes the `context.injector.bind_provider` pattern for BaseTailsServer in the `DefaultContextBuilder.bind_providers` method. This is to support both IndyTailsServer and AnonCredsTailServer in a multitenancy scenario

It's a simple fix because in each context where the tails server is used, you know if it should be Indy or AnonCreds, so the dependency injection pattern is unnecessary.