### PR TITLE
Indicate when interop tests fail

### DIFF
--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           route: GET /repos/${{ github.event.repository.full_name }}/pulls/${{ github.event.number }}
       - name: Prepare Interop Tests
-        if: steps.check-if-src-changed.outputs.run_tests != 'false'
         run: |
           # Get AATH 
           git clone https://github.com/openwallet-foundation/owl-agent-test-harness.git

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           route: GET /repos/${{ github.event.repository.full_name }}/pulls/${{ github.event.number }}
       - name: Prepare Interop Tests
+        if: (steps.check-if-src-changed.outputs.run_tests != 'false' || steps.check_if_release.outputs.is_release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           # Get AATH 
           git clone https://github.com/openwallet-foundation/owl-agent-test-harness.git

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -74,14 +74,31 @@ jobs:
 
           cd owl-agent-test-harness
           ./manage build -a acapy-main
-      - name: Run PR Interop Tests
+      - name: Run PR Interop Tests Indy
         if: (steps.check_if_release.outputs.is_release != 'true' && github.event_name == 'pull_request' && steps.check-if-src-changed.outputs.run_tests != 'false')
         run: |
           cd owl-agent-test-harness
-          NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @critical -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
-      - name: Run Release or Nightly Interop Tests
+          NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @critical -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound -t ~@Anoncreds >> output.txt
+      - name: Run Release or Nightly Interop Tests Indy
         if: (steps.check_if_release.outputs.is_release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && steps.check-if-src-changed.outputs.run_tests != 'false')
         run: |
           cd owl-agent-test-harness
-          NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
+          NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @critical -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound -t ~@Anoncreds >> output.txt
+      - name: Run Release or Nightly Interop Tests Anoncreds
+        if: (steps.check_if_release.outputs.is_release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && steps.check-if-src-changed.outputs.run_tests != 'false')
+        run: |
+          cd owl-agent-test-harness
+          BACKCHANNEL_EXTRA_acapy_main="{\"wallet-type\":\"askar-anoncreds\"}" NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound -t ~@Indy -t ~@CredFormat_Indy >> output.txt
+      - name: Check If Tests Failed
+        if: steps.check-if-src-changed.outputs.run_tests != 'false'
+        run: |
+          cd owl-agent-test-harness
+          cat output.txt
+          if grep "Failing scenarios:" output.txt; then
+              echo "Tests failed"
+              exit 1
+          else
+              echo "Tests passed"
+              exit 0
+          fi
 


### PR DESCRIPTION
This will cause the interop test run to indicate fail status. It outputs the test logs to a temporary file and then greps for `Failing scenarios:` which only happens when tests fails.

It also runs the anoncreds tests on the nightly runs. Currently there is one failing test, so this will fail currently. Running both the indy and anoncreds tests on PR's takes too long. (45mins)

I would like to parse the failed tests and output them to PR's as a comment but this is an improvement for now.