### PR TITLE
Repair BDD integration release tests

### DIFF
--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -268,10 +268,8 @@ Feature: RFC 0453 Aries agent issue credential
     Examples:
        | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          | Key_type | Sig_type             |
        | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2018 |
-       | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2018 |
        | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2018 |
        | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2020 |
-       | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2020 |
        | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2020 |
 
     @Release @WalletType_Askar @BBS

--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -17,13 +17,6 @@ Feature: RFC 0453 Aries agent issue credential
        | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          | Acme_extra | Bob_extra |
        | --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |            |           |
 
-    @Release @WalletType_Askar @AltTests
-    Examples:
-       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          | Acme_extra | Bob_extra |
-       | --public-did                           |                           | driverslicense | Data_DL_NormalizedValues |            |           |
-       | --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |            |           |
-       | --public-did --multitenant             | --multitenant --log-file  | driverslicense | Data_DL_NormalizedValues |            |           |
-
     @Release @WalletType_Askar_AnonCreds @BasicTest @cred_type_vc_di
     Examples:
        | Acme_capabilities                                            | Bob_capabilities              | Schema_name    | Credential_data          | Acme_extra | Bob_extra |
@@ -208,10 +201,8 @@ Feature: RFC 0453 Aries agent issue credential
     Examples:
        | Acme_capabilities                                         | Bob_capabilities          | Schema_name    | Credential_data          | Key_type | Sig_type             |
        | --public-did --cred-type json-ld --did-exchange           | --did-exchange            | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2018 | 
-       | --public-did --cred-type json-ld --mediation              | --mediation               | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2018 |
        | --public-did --cred-type json-ld --multitenant --log-file | --multitenant             | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2018 |
        | --public-did --cred-type json-ld --did-exchange           | --did-exchange            | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2020 |
-       | --public-did --cred-type json-ld --mediation              | --mediation               | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2020 |
        | --public-did --cred-type json-ld --multitenant --log-file | --multitenant             | driverslicense | Data_DL_NormalizedValues | ed25519  | Ed25519Signature2020 |
 
     @Release @WalletType_Askar @BBS

--- a/demo/features/0454-present-proof.feature
+++ b/demo/features/0454-present-proof.feature
@@ -198,7 +198,7 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verified
 
-      @Release @WalletType_Askar
+      @Release @WalletType_Askar @Failing
       Examples:
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |

--- a/demo/features/0454-present-proof.feature
+++ b/demo/features/0454-present-proof.feature
@@ -198,7 +198,7 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verified
 
-      @Release @WalletType_Askar @Failing
+      @Release @WalletType_Askar
       Examples:
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |

--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -23,9 +23,7 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       Examples:
          | Acme_capabilities         | Bob_capabilities          | Schema_name    |
          | --did-exchange            | --did-exchange            | driverslicense |
-         | --mediation               | --mediation               | driverslicense |
          | --multitenant             | --multitenant             | driverslicense |
-         | --mediation --multitenant | --mediation --multitenant | driverslicense |
 
       @TODO @Mulitledger
       Examples:

--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -108,8 +108,6 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       Examples:
          | Acme_capabilities                                   | Bob_capabilities                          | Schema_name    | Credential_data          |
          | --revocation --public-did --did-exchange            | --revocation --did-exchange               | driverslicense | Data_DL_NormalizedValues |
-         | --revocation --public-did --mediation               | --revocation --mediation                  | driverslicense | Data_DL_NormalizedValues |
-         | --revocation --public-did --mediation --multitenant | --revocation --mediation --multitenant    | driverslicense | Data_DL_NormalizedValues |
 
       @Mulitledger
       Examples:

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -23,6 +23,7 @@ from runners.support.agent import (  # noqa:E402
     WALLET_TYPE_INDY,
     DemoAgent,
     connect_wallet_to_endorser,
+    connect_wallet_to_mediator,
     default_genesis_txns,
     start_endorser_agent,
     start_mediator_agent,

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -23,7 +23,6 @@ from runners.support.agent import (  # noqa:E402
     WALLET_TYPE_INDY,
     DemoAgent,
     connect_wallet_to_endorser,
-    connect_wallet_to_mediator,
     default_genesis_txns,
     start_endorser_agent,
     start_mediator_agent,
@@ -394,7 +393,7 @@ class AriesAgent(DemoAgent):
                 if credentials:
                     for row in sorted(
                         credentials,
-                        key=lambda c: int(c["cred_info"]["attrs"]["timestamp"]),
+                        key=lambda c: int(c["cred_info"]["attrs"].get("timestamp", 0)),
                         reverse=True,
                     ):
                         for referent in row["presentation_referents"]:
@@ -500,7 +499,7 @@ class AriesAgent(DemoAgent):
                                 sorted_creds = sorted(
                                     creds,
                                     key=lambda c: int(
-                                        c["cred_info"]["attrs"]["timestamp"]
+                                        c["cred_info"]["attrs"].get("timestamp", 0)
                                     ),
                                     reverse=True,
                                 )


### PR DESCRIPTION
There was a few tests for mediation that used connection v1 protocol so I removed them. They are covered by the OATH tests. Also there was an issue for revoked credentials when some had a timestamp and some didn't.