### PR TITLE
feat(demo): remove broken aip 10 and fix aip 20

### DIFF
--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1004,17 +1004,21 @@ class DemoAgent:
         decorator = {
             "recipientKeys": [agent_public_did["result"]["verkey"]],
             # "routingKeys": [agent_public_did["result"]["verkey"]],
-            "serviceEndpoint": agent_endpoint["endpoint"],
+            "serviceEndpoint": agent_endpoint["endpoint"] or (
+                "http://"
+                + os.getenv("DOCKERHOST").replace(
+                    "{PORT}", str(self.admin_port + 1)
+                )),
         }
         return decorator
 
     async def _send_connectionless_proof_req(self, request: ClientRequest):
         pres_req_id = request.match_info["pres_req_id"]
-        url = "/present-proof/records/" + pres_req_id
+        url = "/present-proof-2.0/records/" + pres_req_id
         proof_exch = await self.admin_GET(url)
         if not proof_exch:
             return web.Response(status=404)
-        proof_reg_txn = proof_exch["presentation_request_dict"]
+        proof_reg_txn = proof_exch["pres_request"]
         proof_reg_txn["~service"] = await self.service_decorator()
         if request.headers.get("Accept") == "application/json":
             return web.json_response(proof_reg_txn)

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1004,11 +1004,7 @@ class DemoAgent:
         decorator = {
             "recipientKeys": [agent_public_did["result"]["verkey"]],
             # "routingKeys": [agent_public_did["result"]["verkey"]],
-            "serviceEndpoint": agent_endpoint["endpoint"] or (
-                "http://"
-                + os.getenv("DOCKERHOST").replace(
-                    "{PORT}", str(self.admin_port + 1)
-                )),
+            "serviceEndpoint": agent_endpoint["endpoint"] or self.endpoint,
         }
         return decorator
 

--- a/docs/demo/AliceGetsAPhone.md
+++ b/docs/demo/AliceGetsAPhone.md
@@ -142,10 +142,8 @@ If you are running in a _local bash shell_, navigate to the `demo` directory in
 your fork/clone of the ACA-Py repository and run:
 
 ```bash
-TAILS_NETWORK=docker_tails-server LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --aip 10 --revocation --events
+TAILS_NETWORK=docker_tails-server LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --revocation --events
 ```
-
-(Note that we have to start faber with `--aip 10` for compatibility with mobile clients.)
 
 The `TAILS_NETWORK` parameter lets the demo script know how to connect to the tails server (which should be running in a separate shell on the same machine).
 
@@ -155,7 +153,7 @@ If you are running in _Play with Docker_, navigate to the `demo` folder in the
 clone of ACA-Py and run the following:
 
 ```bash
-PUBLIC_TAILS_URL=https://c4f7fbb85911.ngrok.io LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --aip 10 --revocation --events
+PUBLIC_TAILS_URL=https://c4f7fbb85911.ngrok.io LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --revocation --events
 ```
 
 The `PUBLIC_TAILS_URL` parameter lets the demo script know how to connect to the tails server. This can be running in another PWD session, or even on your local machine - the ngrok endpoint is public and will map to the correct location.


### PR DESCRIPTION
The mobile phone demo (AliceGetsAPhone) documentation says to run with AIP 10, which is deprecated and no longer works. Starting the faber agent results in [this error](https://gist.github.com/davidchaiken/cf047fa6be02ba00f339bca267b7bc7f). Instead of trying to repair the AIP 10 option, it seemed best to try to roll forward to AIP 20.

I found that using AIP 20 works with the BC Wallet mobile agent, except that the connectionless proof request interaction (CLI option 2a) with the faber agent was broken.

This pull request:
* Removes the deprecated and broken AIP 10.
* Fixes the connectionless proof request interaction for AIP 20.

I have tested these fixes manually in the Play With Docker (PWD) environment with the BC Wallet.

I also got it working running the faber agent in a docker container on my development machine, but that involved some ngrok configuration hacks and a small change to the demo code. I'd be happy to submit the code and ngrok configuration documentation in a separate PR.