### PR TITLE
chore(demo): remove aip 10 code

### DIFF
--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -1376,7 +1376,7 @@ def arg_parser(ident: str = None, port: int = 8020):
         type=str,
         default=20,
         metavar=("<api>"),
-        help="API level (10 or 20 (default))",
+        help="API level (20)",
     )
     parser.add_argument("--timing", action="store_true", help="Enable timing information")
     parser.add_argument(
@@ -1546,11 +1546,10 @@ async def create_agent_with_args(args, ident: str = None, extra_args: list = Non
 
     if "aip" in args:
         aip = int(args.aip)
-        if aip not in [
-            10,
-            20,
-        ]:
-            raise Exception("Invalid value for aip, should be 10 or 20")
+        if aip == 10:  # helpful message to flag legacy usage
+            raise Exception("Invalid value for aip, 10 is no longer supported. Use 20 instead.")
+        if aip != 20:
+            raise Exception("Invalid value for aip, should be 20")
     else:
         aip = 20
 
@@ -1582,16 +1581,10 @@ async def create_agent_with_args(args, ident: str = None, extra_args: list = Non
     )
 
     reuse_connections = "reuse_connections" in args and args.reuse_connections
-    # if reuse_connections and aip != 20:
-    #     raise Exception("Can only specify `--reuse-connections` with AIP 2.0")
     multi_use_invitations = "multi_use_invitations" in args and args.multi_use_invitations
-    if multi_use_invitations and aip != 20:
-        raise Exception("Can only specify `--multi-use-invitations` with AIP 2.0")
     public_did_connections = (
         "public_did_connections" in args and args.public_did_connections
     )
-    if public_did_connections and aip != 20:
-        raise Exception("Can only specify `--public-did-connections` with AIP 2.0")
 
     anoncreds_legacy_revocation = None
     if "anoncreds_legacy_revocation" in args and args.anoncreds_legacy_revocation:


### PR DESCRIPTION
This PR completes the work documented in Issue #3617. It removes the AIP 10 code from conditional statements and a few function signatures, but leaves the scaffolding in place so that new versions can be added in the future. (If there's no chance that there will be a new AIP version in the future, please let me know so that I can do an even deeper clean.)

The default view of the diffs looks more complicated than it actually is, because git diff sometimes scrambles the code between the half of the conditionals that are removed (aip == 10) and the code that remains (aip == 20). To see a cleaner version of the diffs, you can view them [ignoring whitespace](https://github.com/openwallet-foundation/acapy/compare/main...davidchaiken:acapy:dc_issue_3617?w=1).

I tested these changes manually using local docker on my MacBook and in the PWD environment. I ran both the alice/faber and the "Alice Gets a Phone" version of the demo. I also verified that `run_bdd` works, but noted that it doesn't actually use the faber.py runner.