### PR TITLE
:sparkles: Don't shutdown on ledger error

### DIFF
--- a/acapy_agent/core/tests/test_conductor.py
+++ b/acapy_agent/core/tests/test_conductor.py
@@ -1206,7 +1206,7 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         message_body = "{}"
         receipt = MessageReceipt(direct_response_mode="snail mail")
         message = InboundMessage(message_body, receipt)
-        exc = KeyError("sample exception")
+        exc = StorageNotFoundError("sample exception")
         mock_task = mock.MagicMock(
             exc_info=(type(exc), exc, exc.__traceback__),
             ident="abc",

--- a/acapy_agent/core/tests/test_conductor.py
+++ b/acapy_agent/core/tests/test_conductor.py
@@ -1,12 +1,10 @@
 from unittest import IsolatedAsyncioTestCase
 
-import pytest
-
-from ...connections.base_manager import BaseConnectionManager
 from ...admin.base_server import BaseAdminServer
 from ...askar.profile import AskarProfileManager
 from ...config.base_context import ContextBuilder
 from ...config.injection_context import InjectionContext
+from ...connections.base_manager import BaseConnectionManager
 from ...connections.models.conn_record import ConnRecord
 from ...connections.models.connection_target import ConnectionTarget
 from ...connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
@@ -868,7 +866,6 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
 
         await conductor.queue_outbound(conductor.root_profile, message)
 
-    @pytest.mark.skip("This test has a bad mock that isn't awaited")
     async def test_handle_not_returned_ledger_x(self):
         builder: ContextBuilder = StubContextBuilder(self.test_settings_admin)
         conductor = test_module.Conductor(builder)


### PR DESCRIPTION
Resolves #3518

Basically just removes:
```py
            if self.admin_server:
                self.admin_server.notify_fatal_error()
```
when there are ledger errors

And in `dispatch_complete`, instead of always logging stack traces, we log ledger or storage errors, and for other ones we log stack traces. Keeps logs less noisy.

___
Open to suggestions if shutdown logic is intentional. Can maybe be configured with an env var if it needs to be maintained
