### PR TITLE
Use current version of aca-py in devcontainer

### DIFF
--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -8,8 +8,8 @@ WORKSPACE_DIR=$(pwd)
 python -m pip install --upgrade pip
 pip3 install -r demo/requirements.txt -r demo/requirements.behave.txt
 
-# install a version of acapy-agent so the pytests can pick up a version
-pip3 install acapy-agent
+# install current version of acapy-agent so the pytests can pick up a version
+pip3 install .
 
 # hack/workaround to allow `pytest .` and `poetry run pytest` work.
 # need to not run ruff...


### PR DESCRIPTION
This fixes an issue where installing `acapy-agent` would pull in mismatched dependencies that would cause the debug profiles to stop running. Installing from the local source has teh same result, and pulls in the same dependency versions as what is specified in `pyproject.toml` at the time of installation.

I wanted to also remove the use of pip to install other requirements and have everything managed in the same `pyproject.toml` using `poetry`: using two package managers on the same package repo can lead to unpredictable issues, and there will almost definitely be mismatched dependency versions after an install (also depending on which order they are executed). Will leave this for a different PR as it turned out to be A LOT more involved than I initially expected.