### PR TITLE
:bug: Fix public did no longer being correctly configured

### DIFF
--- a/acapy_agent/config/tests/test_wallet.py
+++ b/acapy_agent/config/tests/test_wallet.py
@@ -154,7 +154,14 @@ class TestWalletConfig(IsolatedAsyncioTestCase):
                 await test_module.wallet_config(self.context, provision=False)
 
             self.context.update_settings({"auto_provision": True})
-            await test_module.wallet_config(self.context, provision=False)
+            profile, did_info = await test_module.wallet_config(
+                self.context, provision=False
+            )
+
+            self.assertEqual(profile, self.profile)
+            self.assertIsNotNone(did_info)
+            self.assertEqual(did_info.did, TEST_DID)
+            self.assertEqual(did_info.verkey, TEST_VERKEY)
 
     async def test_wallet_config_non_indy_x(self):
         self.context.update_settings(
@@ -227,7 +234,14 @@ class TestWalletConfig(IsolatedAsyncioTestCase):
         ):
             mock_seed_to_did.return_value = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
-            await test_module.wallet_config(self.context, provision=True)
+            profile, did_info = await test_module.wallet_config(
+                self.context, provision=True
+            )
+
+            self.assertEqual(profile, self.profile)
+            self.assertIsNotNone(did_info)
+            self.assertEqual(did_info.did, TEST_DID)
+            self.assertEqual(did_info.verkey, TEST_VERKEY)
 
     async def test_wallet_config_seed_public(self):
         self.context.update_settings(
@@ -254,9 +268,17 @@ class TestWalletConfig(IsolatedAsyncioTestCase):
                 test_module, "add_or_update_version_to_storage", mock.CoroutineMock()
             ),
         ):
-            await test_module.wallet_config(self.context, provision=True)
+            profile, did_info = await test_module.wallet_config(
+                self.context, provision=True
+            )
+
+            self.assertEqual(profile, self.profile)
+            self.assertIsNotNone(did_info)
+            self.assertEqual(did_info.did, TEST_DID)
+            self.assertEqual(did_info.verkey, TEST_VERKEY)
 
     async def test_wallet_config_seed_no_public_did(self):
+        self.context.update_settings({"wallet.seed": "original_seed"})
         mock_wallet = mock.MagicMock(
             get_public_did=mock.CoroutineMock(return_value=None),
             set_public_did=mock.CoroutineMock(),
@@ -268,15 +290,17 @@ class TestWalletConfig(IsolatedAsyncioTestCase):
 
         with (
             mock.patch.object(
-                test_module, "seed_to_did", mock.MagicMock()
-            ) as mock_seed_to_did,
-            mock.patch.object(
                 test_module, "add_or_update_version_to_storage", mock.CoroutineMock()
             ),
         ):
-            mock_seed_to_did.return_value = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            profile, did_info = await test_module.wallet_config(
+                self.context, provision=True
+            )
 
-            await test_module.wallet_config(self.context, provision=True)
+            self.assertEqual(profile, self.profile)
+            self.assertIsNotNone(did_info)
+            self.assertEqual(did_info.did, TEST_DID)
+            self.assertEqual(did_info.verkey, TEST_VERKEY)
 
     async def test_wallet_config_for_key_derivation_method(self):
         self.context.update_settings(

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -179,7 +179,7 @@ async def wallet_config(
 
     LOGGER.info(
         "%s Profile name: %s, backend: %s",
-        "Created new profile - " if profile.created else "Opened existing profile - ",
+        "Created new profile -" if profile.created else "Opened existing profile -",
         profile.name,
         profile.backend,
     )

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -199,8 +199,9 @@ async def wallet_config(
             settings, wallet, create_local_did, wallet_seed
         )
 
-    if provision and not create_local_did and not public_did_info.did:
-        LOGGER.info("No public DID")
+    public_did = public_did_info.did if public_did_info else None
+    if provision and not create_local_did and not public_did:
+        LOGGER.info("No public DID created")
 
     await _initialize_with_debug_settings(settings, wallet)
 

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -129,7 +129,7 @@ async def _initialize_with_debug_settings(settings: dict, wallet: BaseWallet):
 
 async def _initialize_with_seed(
     settings: dict, wallet: BaseWallet, create_local_did: bool, seed: str
-):
+) -> DIDInfo:
     if create_local_did:
         endpoint = settings.get("default_endpoint")
         metadata = {"endpoint": endpoint} if endpoint else None
@@ -149,6 +149,7 @@ async def _initialize_with_seed(
         did_info.did,
         did_info.verkey,
     )
+    return did_info
 
 
 async def wallet_config(

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -83,7 +83,10 @@ async def _initialize_with_public_did(
                 f"public did {public_did}"
             )
 
-        LOGGER.info("Replacing public DID due to --replace-public-did flag")
+        LOGGER.info(
+            "Replacing public DID which doesn't match the seed "
+            "(as configured by --replace-public-did)"
+        )
         replace_did_info = await wallet.create_local_did(
             method=SOV, key_type=ED25519, seed=wallet_seed
         )

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -88,8 +88,8 @@ async def _initialize_with_public_did(
     if wallet_seed and (seed_to_did(wallet_seed) != public_did):
         if not settings.get("wallet.replace_public_did"):
             raise ConfigError(
-                "New seed provided which doesn't match the registered"
-                + f" public did {public_did}"
+                "New seed provided which doesn't match the registered "
+                f"public did {public_did}"
             )
 
         LOGGER.info("Replacing public DID due to --replace-public-did flag")
@@ -122,7 +122,7 @@ async def _initialize_with_seed(
 ):
     def _log_did_info(did: str, verkey: str, is_public: bool):
         LOGGER.info(
-            f"Created new {'public' if is_public else 'local'}"
+            f"Created new {'public' if is_public else 'local'} "
             f"DID: {did}, Verkey: {verkey}"
         )
 

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -130,32 +130,25 @@ async def _initialize_with_debug_settings(settings: dict, wallet: BaseWallet):
 async def _initialize_with_seed(
     settings: dict, wallet: BaseWallet, create_local_did: bool, seed: str
 ):
-    def _log_did_info(did: str, verkey: str, is_public: bool):
-        LOGGER.info(
-            "Created new %s DID: %s, Verkey: %s",
-            "public" if is_public else "local",
-            did,
-            verkey,
-        )
-
     if create_local_did:
         endpoint = settings.get("default_endpoint")
         metadata = {"endpoint": endpoint} if endpoint else None
 
-        local_did_info = await wallet.create_local_did(
+        did_info = await wallet.create_local_did(
             method=SOV,
             key_type=ED25519,
             seed=seed,
             metadata=metadata,
         )
-        local_did = local_did_info.did
-        _log_did_info(local_did, local_did_info.verkey, False)
     else:
-        public_did_info = await wallet.create_public_did(
-            method=SOV, key_type=ED25519, seed=seed
-        )
-        public_did = public_did_info.did
-        _log_did_info(public_did, public_did_info.verkey, True)
+        did_info = await wallet.create_public_did(method=SOV, key_type=ED25519, seed=seed)
+
+    LOGGER.info(
+        "Created new %s DID: %s, Verkey: %s",
+        "local" if create_local_did else "public",
+        did_info.did,
+        did_info.verkey,
+    )
 
 
 async def wallet_config(

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -94,6 +94,7 @@ async def _initialize_with_public_did(
             public_did,
             replace_did_info.verkey,
         )
+    return public_did
 
 
 async def _initialize_with_debug_settings(settings: dict, wallet: BaseWallet):

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -68,15 +68,6 @@ async def _attempt_open_profile(
     return (profile, provision)
 
 
-def _log_provision_info(profile: Profile) -> None:
-    LOGGER.info(
-        "Created new profile - "
-        if profile.created
-        else "Opened existing profile - "
-        f"Profile name: {profile.name}, backend: {profile.backend}"
-    )
-
-
 async def _initialize_with_public_did(
     public_did_info: DIDInfo,
     wallet: BaseWallet,
@@ -165,7 +156,12 @@ async def wallet_config(
             profile_manager, context, profile_config, settings
         )
 
-    _log_provision_info(profile)
+    LOGGER.info(
+        "Created new profile - "
+        if profile.created
+        else "Opened existing profile - "
+        f"Profile name: {profile.name}, backend: {profile.backend}"
+    )
 
     txn = await profile.transaction()
     wallet = txn.inject(BaseWallet)

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -109,7 +109,7 @@ async def _initialize_with_debug_settings(settings: dict, wallet: BaseWallet):
 
 
 async def _initialize_with_seed(
-    settings: dict, wallet: BaseWallet, provision: bool, create_local_did: bool, seed: str
+    settings: dict, wallet: BaseWallet, create_local_did: bool, seed: str
 ):
     def _log_did_info(did: str, verkey: str, is_public: bool):
         LOGGER.info(
@@ -173,9 +173,7 @@ async def wallet_config(
             public_did_info, wallet, settings, wallet_seed
         )
     elif wallet_seed:
-        await _initialize_with_seed(
-            settings, wallet, provision, create_local_did, wallet_seed
-        )
+        await _initialize_with_seed(settings, wallet, create_local_did, wallet_seed)
 
     if provision and not create_local_did and not public_did:
         LOGGER.info("No public DID")

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -90,8 +90,9 @@ async def _initialize_with_public_did(
         public_did = replace_did_info.did
         await wallet.set_public_did(public_did)
         LOGGER.info(
-            f"Created new public DID: {public_did}, "
-            f"with verkey: {replace_did_info.verkey}"
+            "Created new public DID: %s, with verkey: %s",
+            public_did,
+            replace_did_info.verkey,
         )
 
 
@@ -113,8 +114,10 @@ async def _initialize_with_seed(
 ):
     def _log_did_info(did: str, verkey: str, is_public: bool):
         LOGGER.info(
-            f"Created new {'public' if is_public else 'local'} "
-            f"DID: {did}, Verkey: {verkey}"
+            "Created new %s DID: %s, Verkey: %s",
+            "public" if is_public else "local",
+            did,
+            verkey,
         )
 
     if create_local_did:
@@ -157,10 +160,10 @@ async def wallet_config(
         )
 
     LOGGER.info(
-        "Created new profile - "
-        if profile.created
-        else "Opened existing profile - "
-        f"Profile name: {profile.name}, backend: {profile.backend}"
+        "%s Profile name: %s, backend: %s",
+        "Created new profile - " if profile.created else "Opened existing profile - ",
+        profile.name,
+        profile.backend,
     )
 
     txn = await profile.transaction()

--- a/acapy_agent/core/conductor.py
+++ b/acapy_agent/core/conductor.py
@@ -395,8 +395,8 @@ class Conductor:
                 )
                 from_version_storage = record.value
                 LOGGER.info(
-                    "Existing acapy_version storage record found, "
-                    f"version set to {from_version_storage}"
+                    "Existing acapy_version storage record found, version set to %s",
+                    from_version_storage,
                 )
             except StorageNotFoundError:
                 LOGGER.warning("Wallet version storage record not found.")
@@ -432,8 +432,8 @@ class Conductor:
             LOGGER.warning(
                 (
                     "No upgrade from version was found from wallet or via"
-                    " --from-version startup argument. Defaulting to "
-                    f"{DEFAULT_ACAPY_VERSION}."
+                    " --from-version startup argument. Defaulting to %s.",
+                    DEFAULT_ACAPY_VERSION,
                 )
             )
             from_version = DEFAULT_ACAPY_VERSION
@@ -469,9 +469,12 @@ class Conductor:
             )
             LOGGER.info(
                 "Created static connection for test suite\n"
-                f" - My DID: {test_conn.my_did}\n"
-                f" - Their DID: {test_conn.their_did}\n"
-                f" - Their endpoint: {their_endpoint}\n"
+                " - My DID: %s\n"
+                " - Their DID: %s\n"
+                " - Their endpoint: %s\n",
+                test_conn.my_did,
+                test_conn.their_did,
+                their_endpoint,
             )
             del mgr
             LOGGER.debug("Static connection for test suite created and manager deleted.")
@@ -490,7 +493,7 @@ class Conductor:
             mediation_mgr = MediationManager(self.root_profile)
             try:
                 await mediation_mgr.set_default_mediator_by_id(default_mediator_id)
-                LOGGER.info(f"Default mediator set to {default_mediator_id}")
+                LOGGER.info("Default mediator set to %s", default_mediator_id)
             except Exception:
                 LOGGER.exception("Error updating default mediator.")
 
@@ -512,7 +515,7 @@ class Conductor:
                 )
                 base_url = context.settings.get("invite_base_url")
                 invite_url = invi_rec.invitation.to_url(base_url)
-                LOGGER.info(f"Invitation URL:\n{invite_url}")
+                LOGGER.info("Invitation URL:\n%s", invite_url)
                 qr = QRCode(border=1)
                 qr.add_data(invite_url)
                 qr.print_ascii(invert=True)
@@ -880,7 +883,8 @@ class Conductor:
                 if acapy_version:
                     storage_type_from_storage = STORAGE_TYPE_VALUE_ASKAR
                     LOGGER.info(
-                        f"Existing agent found. Setting wallet type to {storage_type_from_storage}."  # noqa: E501
+                        "Existing agent found. Setting wallet type to %s.",
+                        storage_type_from_storage,
                     )
                     await storage.add_record(
                         StorageRecord(
@@ -891,7 +895,7 @@ class Conductor:
                 else:
                     storage_type_from_storage = storage_type_from_config
                     LOGGER.info(
-                        f"New agent. Setting wallet type to {storage_type_from_config}."
+                        "New agent. Setting wallet type to %s.", storage_type_from_config
                     )
                     await storage.add_record(
                         StorageRecord(


### PR DESCRIPTION
Resolves #3645

The `wallet_config` changes introduced in #3253 did not return the updated public did info to the conductor, so the Indy ledger was not being correctly configured downstream.

___
🚧 Testing changes in acapy-cloud 
✅ success!