### PR TITLE
:art: Add type hints to anoncreds module

### DIFF
--- a/acapy_agent/anoncreds/__init__.py
+++ b/acapy_agent/anoncreds/__init__.py
@@ -7,7 +7,7 @@ from .registry import AnonCredsRegistry
 LOGGER = logging.getLogger(__name__)
 
 
-async def setup(context: InjectionContext):
+async def setup(context: InjectionContext) -> None:
     """Set up default resolvers."""
     registry = context.inject_or(AnonCredsRegistry)
     if not registry:

--- a/acapy_agent/anoncreds/base.py
+++ b/acapy_agent/anoncreds/base.py
@@ -66,7 +66,7 @@ class AnonCredsObjectAlreadyExists(AnonCredsRegistrationError, Generic[T]):
         self.obj = obj
 
     @property
-    def message(self):
+    def message(self) -> str:
         """Message."""
         return f"{self._message}: {self.obj_id}, {self.obj}"
 
@@ -75,12 +75,12 @@ class AnonCredsSchemaAlreadyExists(AnonCredsObjectAlreadyExists[AnonCredsSchema]
     """Raised when a schema already exists."""
 
     @property
-    def schema_id(self):
+    def schema_id(self) -> str:
         """Get Schema Id."""
         return self.obj_id
 
     @property
-    def schema(self):
+    def schema(self) -> AnonCredsSchema:
         """Get Schema."""
         return self.obj
 

--- a/acapy_agent/anoncreds/default/did_indy/registry.py
+++ b/acapy_agent/anoncreds/default/did_indy/registry.py
@@ -40,7 +40,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         return self._supported_identifiers_regex
         # TODO: fix regex (too general)
 
-    async def setup(self, context: InjectionContext):
+    async def setup(self, context: InjectionContext) -> None:
         """Setup."""
         LOGGER.info("Successfully registered DIDIndyRegistry")
 

--- a/acapy_agent/anoncreds/default/did_web/registry.py
+++ b/acapy_agent/anoncreds/default/did_web/registry.py
@@ -46,7 +46,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Setup."""
         LOGGER.info("Successfully registered DIDWebRegistry")
 
-    async def get_schema(self, profile, schema_id: str) -> GetSchemaResult:
+    async def get_schema(self, profile: Profile, schema_id: str) -> GetSchemaResult:
         """Get a schema from the registry."""
         raise NotImplementedError()
 

--- a/acapy_agent/anoncreds/default/did_web/registry.py
+++ b/acapy_agent/anoncreds/default/did_web/registry.py
@@ -42,7 +42,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         return self._supported_identifiers_regex
         # TODO: fix regex (too general)
 
-    async def setup(self, context: InjectionContext):
+    async def setup(self, context: InjectionContext) -> None:
         """Setup."""
         LOGGER.info("Successfully registered DIDWebRegistry")
 

--- a/acapy_agent/anoncreds/default/legacy_indy/author.py
+++ b/acapy_agent/anoncreds/default/legacy_indy/author.py
@@ -5,12 +5,15 @@ from typing import Optional
 from aiohttp import web
 
 from acapy_agent.connections.models.conn_record import ConnRecord
+from acapy_agent.core.profile import Profile
 from acapy_agent.messaging.models.base import BaseModelError
 from acapy_agent.protocols.endorse_transaction.v1_0.util import get_endorser_connection_id
 from acapy_agent.storage.error import StorageNotFoundError
 
 
-async def get_endorser_info(profile, options: Optional[dict] = None):
+async def get_endorser_info(
+    profile: Profile, options: Optional[dict] = None
+) -> tuple[str, str]:
     """Gets the endorser did for the current transaction."""
     options = options or {}
     endorser_connection_id = options.get("endorser_connection_id", None)
@@ -43,8 +46,8 @@ async def get_endorser_info(profile, options: Optional[dict] = None):
     if "endorser_did" not in endorser_info.keys():
         raise web.HTTPForbidden(
             reason=(
-                ' "endorser_did" is not set in "endorser_info"'
-                " in connection metadata for this connection record"
+                '"endorser_did" is not set in "endorser_info" '
+                "in connection metadata for this connection record"
             )
         )
 

--- a/acapy_agent/anoncreds/default/legacy_indy/recover.py
+++ b/acapy_agent/anoncreds/default/legacy_indy/recover.py
@@ -90,7 +90,7 @@ async def fetch_txns(
     return registry_from_ledger, revoked
 
 
-async def generate_ledger_rrrecovery_txn(genesis_txns: str, rev_list: RevList):
+async def generate_ledger_rrrecovery_txn(genesis_txns: str, rev_list: RevList) -> dict:
     """Generate a new ledger accum entry, using the wallet value if revocations ahead of ledger."""  # noqa: E501
 
     registry_from_ledger, prev_revoked = await fetch_txns(

--- a/acapy_agent/anoncreds/default/legacy_indy/registry.py
+++ b/acapy_agent/anoncreds/default/legacy_indy/registry.py
@@ -138,7 +138,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Supported Identifiers Regular Expression."""
         return self._supported_identifiers_regex
 
-    async def setup(self, context: InjectionContext):
+    async def setup(self, context: InjectionContext) -> None:
         """Setup."""
         LOGGER.info("Successfully registered LegacyIndyRegistry")
 

--- a/acapy_agent/anoncreds/holder.py
+++ b/acapy_agent/anoncreds/holder.py
@@ -41,7 +41,7 @@ CATEGORY_CREDENTIAL = "credential"
 CATEGORY_MASTER_SECRET = "master_secret"
 
 
-def _make_cred_info(cred_id, cred: Credential):
+def _make_cred_info(cred_id: str, cred: Credential) -> dict:
     cred_info = cred.to_dict()  # not secure!
     rev_info = cred_info["signature"]["r_credential"]
     return {

--- a/acapy_agent/anoncreds/holder.py
+++ b/acapy_agent/anoncreds/holder.py
@@ -372,7 +372,7 @@ class AnonCredsHolder:
 
         return credential_id
 
-    async def get_credentials(self, *, offset: int, limit: int, wql: dict):
+    async def get_credentials(self, *, offset: int, limit: int, wql: dict) -> list[dict]:
         """Get credentials stored in the wallet.
 
         Args:
@@ -410,7 +410,7 @@ class AnonCredsHolder:
         offset: int,
         limit: int,
         extra_query: Optional[dict] = None,
-    ):
+    ) -> list:
         """Get credentials stored in the wallet.
 
         Args:
@@ -543,7 +543,7 @@ class AnonCredsHolder:
 
         return cred.rev_reg_index in set_revoked
 
-    async def delete_credential(self, credential_id: str):
+    async def delete_credential(self, credential_id: str) -> None:
         """Remove a credential stored in the wallet.
 
         Args:

--- a/acapy_agent/anoncreds/issuer.py
+++ b/acapy_agent/anoncreds/issuer.py
@@ -98,7 +98,7 @@ class AnonCredsIssuer:
 
         return self._profile
 
-    async def notify(self, event: Event):
+    async def notify(self, event: Event) -> None:
         """Accessor for the event bus instance."""
         event_bus = self.profile.inject(EventBus)
         await event_bus.notify(self._profile, event)
@@ -134,7 +134,7 @@ class AnonCredsIssuer:
     async def store_schema(
         self,
         result: SchemaResult,
-    ):
+    ) -> None:
         """Store schema after reaching finished state."""
         identifier = result.job_id or result.schema_state.schema_id
         if not identifier:
@@ -234,7 +234,7 @@ class AnonCredsIssuer:
         except (AnoncredsError, BaseAnonCredsError) as err:
             raise AnonCredsIssuerError("Error creating schema") from err
 
-    async def finish_schema(self, job_id: str, schema_id: str):
+    async def finish_schema(self, job_id: str, schema_id: str) -> None:
         """Mark a schema as finished."""
         async with self.profile.transaction() as txn:
             await self._finish_registration(txn, CATEGORY_SCHEMA, job_id, schema_id)
@@ -386,7 +386,7 @@ class AnonCredsIssuer:
         support_revocation: bool,
         max_cred_num: int,
         options: Optional[dict] = None,
-    ):
+    ) -> None:
         """Store the cred def and it's components in the wallet."""
         options = options or {}
         identifier = (
@@ -443,7 +443,7 @@ class AnonCredsIssuer:
 
     async def finish_cred_def(
         self, job_id: str, cred_def_id: str, options: Optional[dict] = None
-    ):
+    ) -> None:
         """Finish a cred def."""
         async with self.profile.transaction() as txn:
             entry = await self._finish_registration(

--- a/acapy_agent/anoncreds/models/credential.py
+++ b/acapy_agent/anoncreds/models/credential.py
@@ -65,7 +65,7 @@ class DictWithAnonCredsAttrValueSchema(fields.Dict):
             **kwargs,
         )
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value: dict, attr: str, data: dict, **kwargs) -> dict:
         """Deserialize dict with anoncreds attribute value."""
         if not isinstance(value, dict):
             raise ValidationError("Value must be a dict.")

--- a/acapy_agent/anoncreds/models/credential_definition.py
+++ b/acapy_agent/anoncreds/models/credential_definition.py
@@ -239,7 +239,7 @@ class CredDef(BaseModel):
         """Convert a native credential definition to a CredDef object."""
         return cls.deserialize(cred_def.to_json())
 
-    def to_native(self):
+    def to_native(self) -> CredentialDefinition:
         """Convert to native anoncreds credential definition."""
         return CredentialDefinition.load(self.serialize())
 

--- a/acapy_agent/anoncreds/models/credential_proposal.py
+++ b/acapy_agent/anoncreds/models/credential_proposal.py
@@ -76,7 +76,9 @@ CRED_DEF_EVENT_PREFIX = "acapy::CRED_DEF::"
 EVENT_LISTENER_PATTERN = re.compile(f"^{CRED_DEF_EVENT_PREFIX}(.*)?$")
 
 
-async def notify_cred_def_event(profile: Profile, cred_def_id: str, meta_data: dict):
+async def notify_cred_def_event(
+    profile: Profile, cred_def_id: str, meta_data: dict
+) -> None:
     """Send notification for a cred def post-process event."""
     await profile.notify(
         CRED_DEF_EVENT_PREFIX + cred_def_id,

--- a/acapy_agent/anoncreds/models/presentation_request.py
+++ b/acapy_agent/anoncreds/models/presentation_request.py
@@ -163,7 +163,7 @@ class AnonCredsPresentationReqAttrSpecSchema(OpenAPISchema):
     )
 
     @validates_schema
-    def validate_fields(self, data, **kwargs):
+    def validate_fields(self, data: dict, **kwargs) -> None:
         """Validate schema fields.
 
         Data must have exactly one of name or names; if names then restrictions are

--- a/acapy_agent/anoncreds/models/revocation.py
+++ b/acapy_agent/anoncreds/models/revocation.py
@@ -113,7 +113,7 @@ class RevRegDef(BaseModel):
         """Convert a native revocation registry definition to a RevRegDef object."""
         return cls.deserialize(rev_reg_def.to_json())
 
-    def to_native(self):
+    def to_native(self) -> RevocationRegistryDefinition:
         """Convert to native anoncreds revocation registry definition."""
         return RevocationRegistryDefinition.load(self.serialize())
 
@@ -250,12 +250,12 @@ class RevRegDefResult(BaseModel):
         )
 
     @property
-    def rev_reg_def_id(self):
+    def rev_reg_def_id(self) -> str:
         """Revocation Registry Definition ID."""
         return self.revocation_registry_definition_state.revocation_registry_definition_id
 
     @property
-    def rev_reg_def(self):
+    def rev_reg_def(self) -> RevRegDef:
         """Revocation Registry Definition."""
         return self.revocation_registry_definition_state.revocation_registry_definition
 
@@ -362,7 +362,7 @@ class RevList(BaseModel):
         """Convert from native revocation list."""
         return cls.deserialize(rev_list.to_json())
 
-    def to_native(self):
+    def to_native(self) -> RevocationStatusList:
         """Convert to native revocation list."""
         return RevocationStatusList.load(self.serialize())
 
@@ -498,7 +498,7 @@ class RevListResult(BaseModel):
         self.revocation_list_metadata = revocation_list_metadata
 
     @property
-    def rev_reg_def_id(self):
+    def rev_reg_def_id(self) -> str:
         """Rev reg def id."""
         return self.revocation_list_state.revocation_list.rev_reg_def_id
 

--- a/acapy_agent/anoncreds/models/schema.py
+++ b/acapy_agent/anoncreds/models/schema.py
@@ -41,7 +41,7 @@ class AnonCredsSchema(BaseModel):
         """Convert from native object."""
         return cls.deserialize(schema.to_dict())
 
-    def to_native(self):
+    def to_native(self) -> Schema:
         """Convert to native object."""
         return Schema.load(self.serialize())
 

--- a/acapy_agent/anoncreds/models/utils.py
+++ b/acapy_agent/anoncreds/models/utils.py
@@ -16,7 +16,7 @@ async def get_requested_creds_from_proof_request_preview(
     proof_request: dict,
     *,
     holder: AnonCredsHolder,
-):
+) -> dict[str, dict]:
     """Build anoncreds requested-credentials structure.
 
     Given input proof request and presentation preview, use credentials in
@@ -81,7 +81,7 @@ async def get_requested_creds_from_proof_request_preview(
     return req_creds
 
 
-def extract_non_revocation_intervals_from_proof_request(proof_req: dict):
+def extract_non_revocation_intervals_from_proof_request(proof_req: dict) -> dict:
     """Return non-revocation intervals by requested item referent in proof request."""
     non_revoc_intervals = {}
     for req_item_type in ("requested_attributes", "requested_predicates"):

--- a/acapy_agent/anoncreds/registry.py
+++ b/acapy_agent/anoncreds/registry.py
@@ -37,7 +37,7 @@ class AnonCredsRegistry:
             for registry in registries:
                 self.register(registry)
 
-    def register(self, registry: BaseAnonCredsHandler):
+    def register(self, registry: BaseAnonCredsHandler) -> None:
         """Register a new registry."""
         if isinstance(registry, BaseAnonCredsResolver):
             self.resolvers.append(registry)

--- a/acapy_agent/anoncreds/revocation.py
+++ b/acapy_agent/anoncreds/revocation.py
@@ -1528,8 +1528,10 @@ class AnonCredsRevocation:
 
     async def set_tails_file_public_uri(self, rev_reg_id: str, tails_public_uri: str):
         """Update Revocation Registry tails file public uri."""
+        # TODO: Implement or remove
         pass
 
     async def set_rev_reg_state(self, rev_reg_id: str, state: str):
         """Update Revocation Registry state."""
+        # TODO: Implement or remove
         pass

--- a/acapy_agent/anoncreds/revocation.py
+++ b/acapy_agent/anoncreds/revocation.py
@@ -99,7 +99,7 @@ class AnonCredsRevocation:
 
         return self._profile
 
-    async def notify(self, event: Event):
+    async def notify(self, event: Event) -> None:
         """Emit an event on the event bus."""
         event_bus = self.profile.inject(EventBus)
         await event_bus.notify(self.profile, event)
@@ -216,7 +216,7 @@ class AnonCredsRevocation:
         result: RevRegDefResult,
         rev_reg_def_private: RevocationRegistryDefinitionPrivate,
         options: Optional[dict] = None,
-    ):
+    ) -> None:
         """Store a revocation registry definition."""
         options = options or {}
         identifier = result.job_id or result.rev_reg_def_id
@@ -259,7 +259,7 @@ class AnonCredsRevocation:
 
     async def finish_revocation_registry_definition(
         self, job_id: str, rev_reg_def_id: str, options: Optional[dict] = None
-    ):
+    ) -> None:
         """Mark a rev reg def as finished."""
         options = options or {}
         async with self.profile.transaction() as txn:
@@ -333,7 +333,7 @@ class AnonCredsRevocation:
 
         return None
 
-    async def set_active_registry(self, rev_reg_def_id: str):
+    async def set_active_registry(self, rev_reg_def_id: str) -> None:
         """Mark a registry as active."""
         async with self.profile.transaction() as txn:
             entry = await txn.handle.fetch(
@@ -391,7 +391,7 @@ class AnonCredsRevocation:
 
     async def create_and_register_revocation_list(
         self, rev_reg_def_id: str, options: Optional[dict] = None
-    ):
+    ) -> RevListResult:
         """Create and register a revocation list."""
         options = options or {}
         try:
@@ -460,7 +460,7 @@ class AnonCredsRevocation:
 
         return result
 
-    async def store_revocation_registry_list(self, result: RevListResult):
+    async def store_revocation_registry_list(self, result: RevListResult) -> None:
         """Store a revocation registry list."""
 
         identifier = result.job_id or result.rev_reg_def_id
@@ -502,7 +502,7 @@ class AnonCredsRevocation:
 
     async def finish_revocation_list(
         self, job_id: str, rev_reg_def_id: str, revoked: list
-    ):
+    ) -> None:
         """Mark a revocation list as finished."""
         async with self.profile.transaction() as txn:
             # Finish the registration if the list is new, otherwise already updated
@@ -529,7 +529,7 @@ class AnonCredsRevocation:
         curr: RevList,
         revoked: Sequence[int],
         options: Optional[dict] = None,
-    ):
+    ) -> RevListResult:
         """Publish and update to a revocation list."""
         options = options or {}
         try:
@@ -672,7 +672,7 @@ class AnonCredsRevocation:
         if not (parsed.scheme and parsed.netloc and parsed.path):
             raise AnonCredsRevocationError("URI {} is not a valid URL".format(url))
 
-    def generate_public_tails_uri(self, rev_reg_def: RevRegDef):
+    def generate_public_tails_uri(self, rev_reg_def: RevRegDef) -> str:
         """Construct tails uri from rev_reg_def."""
         tails_base_url = self.profile.settings.get("tails_server_base_url")
         if not tails_base_url:
@@ -690,7 +690,7 @@ class AnonCredsRevocation:
         tails_dir = indy_client_dir("tails", create=False)
         return os.path.join(tails_dir, rev_reg_def.value.tails_hash)
 
-    async def upload_tails_file(self, rev_reg_def: RevRegDef):
+    async def upload_tails_file(self, rev_reg_def: RevRegDef) -> None:
         """Upload the local tails file to the tails server."""
         tails_server = AnonCredsTailsServer()
 
@@ -730,7 +730,7 @@ class AnonCredsRevocation:
 
     # Registry Management
 
-    async def handle_full_registry(self, rev_reg_def_id: str):
+    async def handle_full_registry(self, rev_reg_def_id: str) -> None:
         """Update the registry status and start the next registry generation."""
         async with self.profile.session() as session:
             active_rev_reg_def = await session.handle.fetch(
@@ -791,7 +791,7 @@ class AnonCredsRevocation:
             LOGGER.info(f"Current rev_reg_def_id = {backup_rev_reg_def_id}")
             LOGGER.info(f"Backup reg = {backup_reg.rev_reg_def_id}")
 
-    async def decommission_registry(self, cred_def_id: str):
+    async def decommission_registry(self, cred_def_id: str) -> list:
         """Decommission post-init registries and start the next registry generation."""
         active_reg = await self.get_or_create_active_registry(cred_def_id)
 
@@ -1449,7 +1449,7 @@ class AnonCredsRevocation:
         )
         return result
 
-    async def mark_pending_revocations(self, rev_reg_def_id: str, *crids: int):
+    async def mark_pending_revocations(self, rev_reg_def_id: str, *crids: int) -> None:
         """Cred rev ids stored to publish later."""
         async with self.profile.transaction() as txn:
             entry = await txn.handle.fetch(
@@ -1495,7 +1495,7 @@ class AnonCredsRevocation:
         txn: ProfileSession,
         rev_reg_def_id: str,
         crid_mask: Optional[Sequence[int]] = None,
-    ):
+    ) -> None:
         """Clear pending revocations."""
         if not isinstance(txn, AskarAnonCredsProfileSession):
             raise ValueError("Askar wallet required")

--- a/acapy_agent/anoncreds/revocation.py
+++ b/acapy_agent/anoncreds/revocation.py
@@ -667,7 +667,7 @@ class AnonCredsRevocation:
 
         return str(tails_file_path)
 
-    def _check_url(self, url) -> None:
+    def _check_url(self, url: str) -> None:
         parsed = urlparse(url)
         if not (parsed.scheme and parsed.netloc and parsed.path):
             raise AnonCredsRevocationError("URI {} is not a valid URL".format(url))
@@ -1526,10 +1526,10 @@ class AnonCredsRevocation:
             tags=tags,
         )
 
-    async def set_tails_file_public_uri(self, rev_reg_id, tails_public_uri):
+    async def set_tails_file_public_uri(self, rev_reg_id: str, tails_public_uri: str):
         """Update Revocation Registry tails file public uri."""
         pass
 
-    async def set_rev_reg_state(self, rev_reg_id, state):
+    async def set_rev_reg_state(self, rev_reg_id: str, state: str):
         """Update Revocation Registry state."""
         pass

--- a/acapy_agent/anoncreds/revocation_setup.py
+++ b/acapy_agent/anoncreds/revocation_setup.py
@@ -58,13 +58,13 @@ class DefaultRevocationSetup(AnonCredsRevocationSetupManager):
     def __init__(self):
         """Init manager."""
 
-    def register_events(self, event_bus: EventBus):
+    def register_events(self, event_bus: EventBus) -> None:
         """Register event listeners."""
         event_bus.subscribe(CRED_DEF_FINISHED_PATTERN, self.on_cred_def)
         event_bus.subscribe(REV_REG_DEF_FINISHED_PATTERN, self.on_rev_reg_def)
         event_bus.subscribe(REV_LIST_FINISHED_PATTERN, self.on_rev_list)
 
-    async def on_cred_def(self, profile: Profile, event: CredDefFinishedEvent):
+    async def on_cred_def(self, profile: Profile, event: CredDefFinishedEvent) -> None:
         """Handle cred def finished."""
         payload = event.payload
 
@@ -80,7 +80,9 @@ class DefaultRevocationSetup(AnonCredsRevocationSetupManager):
                     options=payload.options,
                 )
 
-    async def on_rev_reg_def(self, profile: Profile, event: RevRegDefFinishedEvent):
+    async def on_rev_reg_def(
+        self, profile: Profile, event: RevRegDefFinishedEvent
+    ) -> None:
         """Handle rev reg def finished."""
         payload = event.payload
 
@@ -110,7 +112,7 @@ class DefaultRevocationSetup(AnonCredsRevocationSetupManager):
                 # Mark the first registry as active
                 await revoc.set_active_registry(payload.rev_reg_def_id)
 
-    async def on_rev_list(self, profile: Profile, event: RevListFinishedEvent):
+    async def on_rev_list(self, profile: Profile, event: RevListFinishedEvent) -> None:
         """Handle rev list finished."""
         await notify_revocation_published_event(
             profile, event.payload.rev_reg_id, event.payload.revoked

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -778,14 +778,14 @@ async def set_active_registry(request: web.BaseRequest):
         raise web.HTTPInternalServerError(reason=str(e)) from e
 
 
-def register_events(event_bus: EventBus):
+def register_events(event_bus: EventBus) -> None:
     """Register events."""
     # TODO Make this pluggable?
     setup_manager = DefaultRevocationSetup()
     setup_manager.register_events(event_bus)
 
 
-async def register(app: web.Application):
+async def register(app: web.Application) -> None:
     """Register routes."""
 
     app.add_routes(
@@ -812,7 +812,7 @@ async def register(app: web.Application):
     )
 
 
-def post_process_routes(app: web.Application):
+def post_process_routes(app: web.Application) -> None:
     """Amend swagger API."""
 
     # Add top-level tags description

--- a/acapy_agent/anoncreds/util.py
+++ b/acapy_agent/anoncreds/util.py
@@ -45,7 +45,7 @@ def indy_client_dir(subpath: Optional[str] = None, create: bool = False) -> str:
     return target_dir
 
 
-def handle_value_error(e: ValueError):
+def handle_value_error(e: ValueError) -> None:
     """Handle ValueError message as web response type."""
     if ANONCREDS_PROFILE_REQUIRED_MSG in str(e):
         raise web.HTTPForbidden(reason=str(e)) from e

--- a/acapy_agent/anoncreds/verifier.py
+++ b/acapy_agent/anoncreds/verifier.py
@@ -428,12 +428,12 @@ class AnonCredsVerifier:
 
     async def verify_presentation(
         self,
-        pres_req,
-        pres,
-        schemas,
-        credential_definitions,
-        rev_reg_defs,
-        rev_lists,
+        pres_req: dict,
+        pres: dict,
+        schemas: dict,
+        credential_definitions: dict,
+        rev_reg_defs: dict,
+        rev_lists: dict,
     ) -> Tuple[bool, list]:
         """Verify a presentation.
 
@@ -490,7 +490,7 @@ class AnonCredsVerifier:
         return (verified, msgs)
 
     async def verify_presentation_w3c(
-        self, pres_req, pres, cred_metadata
+        self, pres_req: dict, pres: dict, cred_metadata: list
     ) -> PresentationVerificationResult:
         """Verify a W3C presentation.
 

--- a/acapy_agent/vc/vc_di/prove.py
+++ b/acapy_agent/vc/vc_di/prove.py
@@ -166,11 +166,11 @@ async def create_rev_states(
 
 
 async def prepare_data_for_presentation(
-    presentation,
-    w3c_creds,
-    pres_definition,
-    profile,
-    challenge,
+    presentation: dict,
+    w3c_creds: list,
+    pres_definition: dict,
+    profile: Profile,
+    challenge: str,
 ) -> tuple[dict[str, Any], list, list]:
     """prepare_data_for_presentation.
 


### PR DESCRIPTION
Ruff can check for when type hints or return types are missing, e.g.:
```sh
ruff check acapy_agent/anoncreds/ --select ANN001,ANN201 --exclude '**/test*/**','*/routes.py'
```

ANN201 is for return types. ANN001 checks for method arg types. Ignoring test files, and routes.py (because they all just need -> web.Response | None)

In Python, it's really worth it to add type hints. For maintainability/readability - it improves clarity (e.g. it's better to know a method returns `list[dict]`, instead of just `list`), and intentionality - you can much easier see, oh, this method should actually be returning something.

But there's more than 1000 errors when scanning the codebase.
In the long run I think it would be good to add ANN001/ANN201 to the set of ruff rules that are enforced. But it'll take some work to get there. 
Chunking is better than doing it all in one go. So, I've started the effort by going through the acapy_agent/anoncreds module, and adding type hints + return types
