### PR TITLE
:construction_worker: Fix Docker Caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,12 +68,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Ensure the repo owner is lowercase for the image name
+      - name: Lowercase Repo Owner
+        id: lower
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
+
       - name: Setup Image Metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/acapy-agent
+            ghcr.io/${{ steps.lower.outputs.owner }}/acapy-agent
           tags: |
             type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
 
@@ -98,7 +103,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/acapy-agent-bbs
+            ghcr.io/${{ steps.lower.outputs.owner }}/acapy-agent-bbs
           tags: |
             type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,22 +54,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || '' }}
-
-      - name: Gather image info
-        id: info
-        run: |
-          echo "repo-owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
 
       - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v3
@@ -83,12 +73,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ steps.info.outputs.repo-owner }}/acapy-agent
+            ghcr.io/${{ github.repository_owner }}/acapy-agent
           tags: |
             type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Build and Push Image to ghcr.io
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: .
@@ -99,8 +89,8 @@ jobs:
           build-args: |
             python_version=${{ matrix.python-version }}
             acapy_version=${{ inputs.tag || github.event.release.tag_name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha,scope=acapy-agent
+          cache-to: type=gha,scope=acapy-agent,mode=max
           platforms: ${{ env.PLATFORMS }}
 
       - name: Setup Image Metadata (BBS)
@@ -108,12 +98,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ steps.info.outputs.repo-owner }}/acapy-agent-bbs
+            ghcr.io/${{ github.repository_owner }}/acapy-agent-bbs
           tags: |
             type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Build and Push extended Image to ghcr.io
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: .
@@ -126,16 +116,8 @@ jobs:
             acapy_name=acapy-agent-bbs
             acapy_version=${{ inputs.tag || github.event.release.tag_name }}
             acapy_reqs=[askar,bbs,didcommv2]
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha,scope=acapy-agent-bbs
+          cache-to: type=gha,scope=acapy-agent-bbs,mode=max
           # Because of BBS, only linux/amd64 is supported for the extended image
           # https://github.com/openwallet-foundation/acapy/issues/2124#issuecomment-2293569659
           platforms: linux/amd64
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
* Instead of caching to the Runner FS and then uploading it, use native
  Docker caching to Github Actions
* Run and fix [`zizmor`](https://woodruffw.github.io/zizmor/) warnings
  * Disable persisting git credentials
    * https://woodruffw.github.io/zizmor/audits/#artipacked
  * Disable caching of Buildx binary
    * https://woodruffw.github.io/zizmor/audits/#cache-poisoning
* Rename "Gather image info" step to "Lowercase Repo Owner"
* Update `docker/build-push-action` from `v5` to `v6`