### PR TITLE
👷 Split Docker Builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,4 +56,3 @@ jobs:
         tag: ["nightly-${{needs.setup_and_check_pub.outputs.date}}", nightly]
     with:
       tag: ${{ matrix.tag }}
-      platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,6 +83,8 @@ jobs:
             acapy-reqs: ""
           - image-type: bbs
             image-name: acapy-agent-bbs
+            # Because of BBS, only linux/amd64 is supported for the extended image
+            # https://github.com/openwallet-foundation/acapy/issues/2124#issuecomment-2293569659
             platforms: linux/amd64
             acapy-reqs: "[askar,bbs,didcommv2]"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,16 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Image tag'
+        description: Image tag
         required: true
-        type: string
-      platforms:
-        description: 'Platforms - Comma separated list of the platforms to support.'
-        required: true
-        default: linux/amd64,linux/arm64
         type: string
       ref:
-        description: 'Optional - The branch, tag or SHA to checkout.'
+        description: Optional - The branch, tag or SHA to checkout.
         required: false
         type: string
   workflow_call:
@@ -24,28 +19,25 @@ on:
       tag:
         required: true
         type: string
-      platforms:
-        required: true
-        default: linux/amd64,linux/arm64
-        type: string
       ref:
         required: false
         type: string
 
-env:
-  # linux/386 platform support has been disabled pending a permanent fix for https://github.com/openwallet-foundation/acapy/issues/2124
-  # PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64,linux/386' }}
-  PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
-
 jobs:
-  publish-image:
+  build-image:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']
+        python-version: ["3.12"]
+        arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
 
-    name: Publish ACA-Py Image
-    runs-on: ubuntu-latest
+    name: Build ACA-Py Image
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
       packages: write
@@ -60,6 +52,61 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           cache-binary: false
+          install: true
+          version: latest
+
+      - name: Build and Cache Image
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          context: .
+          file: docker/Dockerfile
+          build-args: |
+            python_version=${{ matrix.python-version }}
+            acapy_version=${{ inputs.tag || github.event.release.tag_name }}
+          cache-from: type=gha,scope=acapy-agent-${{ matrix.arch }}
+          cache-to: type=gha,scope=acapy-agent-${{ matrix.arch }},mode=max
+          platforms: linux/${{ matrix.arch }}
+
+  publish-images:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+        image-type: ["standard", "bbs"]
+        include:
+          - image-type: standard
+            image-name: acapy-agent
+            # linux/386 platform support has been disabled pending a permanent fix for https://github.com/openwallet-foundation/acapy/issues/2124
+            # platforms: linux/amd64,linux/arm64,linux/386
+            platforms: linux/amd64,linux/arm64
+            acapy-reqs: ""
+          - image-type: bbs
+            image-name: acapy-agent-bbs
+            platforms: linux/amd64
+            acapy-reqs: "[askar,bbs,didcommv2]"
+
+    name: Publish ACA-Py ${{ matrix.image-type == 'bbs' && 'BBS ' || '' }} Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    needs: build-image
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || '' }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
+          install: true
+          version: latest
 
       - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v3
@@ -78,11 +125,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ steps.lower.outputs.owner }}/acapy-agent
+            ghcr.io/${{ steps.lower.outputs.owner }}/${{ matrix.image-name }}
           tags: |
             type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
 
-      - name: Build and Push Image to ghcr.io
+      - name: Publish Image to GHCR.io
         uses: docker/build-push-action@v6
         with:
           push: true
@@ -90,39 +137,14 @@ jobs:
           file: docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          target: main
           build-args: |
             python_version=${{ matrix.python-version }}
             acapy_version=${{ inputs.tag || github.event.release.tag_name }}
-          cache-from: type=gha,scope=acapy-agent
-          cache-to: type=gha,scope=acapy-agent,mode=max
-          platforms: ${{ env.PLATFORMS }}
-
-      - name: Setup Image Metadata (BBS)
-        id: meta-bbs
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/${{ steps.lower.outputs.owner }}/acapy-agent-bbs
-          tags: |
-            type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
-
-      - name: Build and Push extended Image to ghcr.io
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          context: .
-          file: docker/Dockerfile
-          tags: ${{ steps.meta-bbs.outputs.tags }}
-          labels: ${{ steps.meta-bbs.outputs.labels }}
-          target: main
-          build-args: |
-            python_version=${{ matrix.python-version }}
-            acapy_name=acapy-agent-bbs
-            acapy_version=${{ inputs.tag || github.event.release.tag_name }}
-            acapy_reqs=[askar,bbs,didcommv2]
-          cache-from: type=gha,scope=acapy-agent-bbs
-          cache-to: type=gha,scope=acapy-agent-bbs,mode=max
-          # Because of BBS, only linux/amd64 is supported for the extended image
-          # https://github.com/openwallet-foundation/acapy/issues/2124#issuecomment-2293569659
-          platforms: linux/amd64
+            ${{ matrix.image-type == 'bbs' && 'acapy_name=acapy-agent-bbs' || '' }}
+            ${{ matrix.acapy-reqs != '' && format('acapy_reqs={0}', matrix.acapy-reqs) || '' }}
+          cache-from: |
+            ${{ matrix.image-type == 'standard' && 'type=gha,scope=acapy-agent-arm64' || '' }}
+            ${{ matrix.image-type == 'standard' && 'type=gha,scope=acapy-agent-amd64' || '' }}
+            ${{ matrix.image-type == 'bbs' && 'type=gha,scope=acapy-agent-bbs' || ''}}
+          cache-to: ${{ matrix.image-type == 'bbs' && 'type=gha,scope=acapy-agent-bbs,mode=max' || '' }}
+          platforms: ${{ matrix.platforms }}


### PR DESCRIPTION
* Build Standard image on native CPU architectures
  * `linux/arm64` builds on `ubuntu-24.04-arm` (`arm64`)
  * `linux/amd64` builds on `ubuntu-24.04` (`x86_64`)
* Split build and publish
  * Build docker images on native runners, don't push, cache to GHA
  * Combine multi-arch, read from cache, push to GHCR.io
* Due to a version mismatch in buildx between `ubuntu-24.04` and 
`ubuntu-24.04-arm`, have to ensure the latest version of `buildx` is installed
* Due to how the platforms are being handled, I've removed the `platforms`
input to the workflow

---

With zero cache, purely building the images goes from ±5 minutes to ±1 minute.
Full pipeline run is ±3 minutes.
https://github.com/didx-xyz/acapy/actions/runs/14472669065/attempts/1

With cache, purely building is ±30 seconds.
Full pipeline run is ±1.5 minutes
https://github.com/didx-xyz/acapy/actions/runs/14472669065/attempts/2

If I enable caching of the Buildx binary it'll reduce the build time by ±30 seconds,
but zizmor doesn't like it due to risk of cache poisoning.
Might still be worth doing though?