### PR TITLE
:test_tube: Fix test warnings

### DIFF
--- a/acapy_agent/admin/tests/test_admin_server.py
+++ b/acapy_agent/admin/tests/test_admin_server.py
@@ -5,6 +5,7 @@ from unittest import IsolatedAsyncioTestCase
 
 import jwt
 import pytest
+import pytest_asyncio
 from aiohttp import ClientSession, DummyCookieJar, TCPConnector, web
 from aiohttp.test_utils import unused_port
 from marshmallow import ValidationError
@@ -577,7 +578,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             await test_module.upgrade_middleware(request, handler)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def server():
     test_class = TestAdminServer()
     await test_class.asyncSetUp()

--- a/acapy_agent/admin/tests/test_admin_server.py
+++ b/acapy_agent/admin/tests/test_admin_server.py
@@ -47,6 +47,12 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             cookie_jar=DummyCookieJar(), connector=self.connector
         )
 
+    async def asyncTearDown(self):
+        if self.client_session:
+            await self.client_session.close()
+        if self.connector:
+            await self.connector.close()
+
     async def test_debug_middleware(self):
         with mock.patch.object(test_module, "LOGGER", mock.MagicMock()) as mock_logger:
             mock_logger.isEnabledFor = mock.MagicMock(return_value=True)

--- a/acapy_agent/askar/didcomm/tests/test_v2.py
+++ b/acapy_agent/askar/didcomm/tests/test_v2.py
@@ -2,6 +2,7 @@ import json
 from unittest import mock
 
 import pytest
+import pytest_asyncio
 from aries_askar import AskarError, Key, KeyAlg, Session
 
 from ....utils.jwe import JweEnvelope, JweRecipient, b64url
@@ -14,7 +15,7 @@ CAROL_KID = "did:example:carol#key-2"
 MESSAGE = b"Expecto patronum"
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session():
     profile = await create_test_profile()
     async with profile.session() as session:

--- a/acapy_agent/cache/tests/test_in_memory_cache.py
+++ b/acapy_agent/cache/tests/test_in_memory_cache.py
@@ -1,12 +1,13 @@
 from asyncio import sleep, wait_for
 
 import pytest
+import pytest_asyncio
 
 from ..base import CacheError
 from ..in_memory import InMemoryCache
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def cache():
     cache = InMemoryCache()
     await cache.set("valid key", "value")

--- a/acapy_agent/connections/tests/test_base_manager.py
+++ b/acapy_agent/connections/tests/test_base_manager.py
@@ -1039,6 +1039,7 @@ class TestBaseConnectionManager(IsolatedAsyncioTestCase):
             assert target.routing_keys == [self.test_verkey]
             assert target.sender_key == local_did.verkey
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # create_did_document deprecation
     async def test_create_static_connection(self):
         self.multitenant_mgr = mock.MagicMock(MultitenantManager, autospec=True)
         self.multitenant_mgr.get_default_mediator = mock.CoroutineMock(return_value=None)
@@ -1053,6 +1054,7 @@ class TestBaseConnectionManager(IsolatedAsyncioTestCase):
 
         assert ConnRecord.State.get(conn_rec.state) is ConnRecord.State.COMPLETED
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # create_did_document deprecation
     async def test_create_static_connection_multitenant(self):
         self.context.update_settings(
             {"wallet.id": "test_wallet", "multitenant.enabled": True}
@@ -1084,6 +1086,7 @@ class TestBaseConnectionManager(IsolatedAsyncioTestCase):
 
             self.route_manager.route_static.assert_called_once()
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # create_did_document deprecation
     async def test_create_static_connection_multitenant_auto_disclose_features(self):
         self.context.update_settings(
             {
@@ -1193,6 +1196,7 @@ class TestBaseConnectionManager(IsolatedAsyncioTestCase):
                     their_endpoint=self.test_endpoint,
                 )
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # create_did_document deprecation
     async def test_create_static_connection_their_seed_only(self):
         self.multitenant_mgr = mock.MagicMock(MultitenantManager, autospec=True)
         self.multitenant_mgr.get_default_mediator = mock.CoroutineMock(return_value=None)

--- a/acapy_agent/indy/models/tests/test_pres_preview.py
+++ b/acapy_agent/indy/models/tests/test_pres_preview.py
@@ -367,6 +367,7 @@ class TestIndyPresPreviewAsync:
 
         assert indy_proof_req == INDY_PROOF_REQ_ATTR_NAMES
 
+    @pytest.mark.asyncio
     async def test_to_indy_proof_request_self_attested(self):
         """Test presentation preview to indy proof request with self-attested values."""
 

--- a/acapy_agent/ledger/tests/test_indy_vdr.py
+++ b/acapy_agent/ledger/tests/test_indy_vdr.py
@@ -2,6 +2,7 @@ import json
 
 import indy_vdr
 import pytest
+import pytest_asyncio
 
 from ...anoncreds.default.legacy_indy.registry import LegacyIndyRegistry
 from ...cache.base import BaseCache
@@ -34,7 +35,7 @@ WEB = DIDMethod(
 )
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def ledger():
     did_methods = DIDMethods()
     did_methods.register(WEB)

--- a/acapy_agent/messaging/decorators/tests/test_attach_decorator.py
+++ b/acapy_agent/messaging/decorators/tests/test_attach_decorator.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from unittest import TestCase
 
 import pytest
+import pytest_asyncio
 from uuid_utils import uuid4
 
 from ....messaging.models.base import BaseModelError
@@ -76,7 +77,7 @@ def seed():
     return [f"TestWalletSignVerifyAttachDeco0{i}" for i in [0, 1]]
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def wallet():
     profile = await create_test_profile()
     profile.context.injector.bind_instance(DIDMethods, DIDMethods())

--- a/acapy_agent/messaging/jsonld/tests/test_routes.py
+++ b/acapy_agent/messaging/jsonld/tests/test_routes.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from unittest import IsolatedAsyncioTestCase
 
 import pytest
+import pytest_asyncio
 from aiohttp import web
 from pyld import jsonld
 
@@ -81,7 +82,7 @@ def mock_verify_credential():
     test_module.verify_credential = temp
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def mock_sign_request(mock_sign_credential):
     profile = await create_test_profile(
         settings={
@@ -139,7 +140,7 @@ def request_body():
     }
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def mock_verify_request(mock_verify_credential, mock_resolver, request_body):
     profile = await create_test_profile(
         settings={

--- a/acapy_agent/multitenant/tests/test_route_manager.py
+++ b/acapy_agent/multitenant/tests/test_route_manager.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ...core.profile import Profile
 from ...messaging.responder import BaseResponder, MockResponder
@@ -25,14 +26,14 @@ def mock_responder():
     yield MockResponder()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def root_profile(mock_responder: MockResponder):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(BaseResponder, mock_responder)
     yield profile
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def sub_profile(mock_responder: MockResponder):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(BaseResponder, mock_responder)

--- a/acapy_agent/protocols/basicmessage/v1_0/handlers/tests/test_basicmessage_handler.py
+++ b/acapy_agent/protocols/basicmessage/v1_0/handlers/tests/test_basicmessage_handler.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+import pytest_asyncio
 
 from ......core.event_bus import Event, EventBus, MockEventBus
 from ......messaging.decorators.localization_decorator import LocalizationDecorator
@@ -11,7 +12,7 @@ from ...handlers.basicmessage_handler import BasicMessageHandler
 from ...messages.basicmessage import BasicMessage
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     yield RequestContext.test_context(await create_test_profile())
 

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/tests/test_keylist_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/tests/test_keylist_handler.py
@@ -3,6 +3,7 @@
 import logging
 
 import pytest
+import pytest_asyncio
 
 from ......connections.models.conn_record import ConnRecord
 from ......messaging.base_handler import HandlerException
@@ -17,7 +18,7 @@ TEST_CONN_ID = "conn-id"
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def context():
     """Fixture for context used in tests."""
     # pylint: disable=W0621
@@ -28,7 +29,7 @@ async def context():
     yield context
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def session(context):  # pylint: disable=W0621
     """Fixture for session used in tests"""
     yield await context.session()

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/tests/test_mediation_grant_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/tests/test_mediation_grant_handler.py
@@ -1,6 +1,7 @@
 """Test mediate grant message handler."""
 
 import pytest
+import pytest_asyncio
 
 from acapy_agent.core.profile import ProfileSession
 from acapy_agent.tests import mock
@@ -23,7 +24,7 @@ TEST_VERKEY = "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg34
 TEST_ENDPOINT = "https://example.com"
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def context():
     context = RequestContext.test_context(await create_test_profile())
     context.message = MediationGrant(endpoint=TEST_ENDPOINT, routing_keys=[TEST_VERKEY])
@@ -32,7 +33,7 @@ async def context():
     yield context
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session(context: RequestContext):
     yield await context.session()
 

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/tests/test_problem_report_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/tests/test_problem_report_handler.py
@@ -1,6 +1,7 @@
 """Test Problem Report Handler."""
 
 import pytest
+import pytest_asyncio
 
 from ......connections.models.conn_record import ConnRecord
 from ......messaging.request_context import RequestContext
@@ -11,14 +12,14 @@ from ...handlers import problem_report_handler as test_module
 from ...messages.problem_report import CMProblemReport, ProblemReportReason
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.message_receipt = MessageReceipt()
     yield ctx
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def connection_record(request_context, session):
     record = ConnRecord()
     request_context.connection_record = record
@@ -26,7 +27,7 @@ async def connection_record(request_context, session):
     yield record
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session(request_context):
     yield await request_context.session()
 

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/models/tests/test_mediation_record.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/models/tests/test_mediation_record.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+import pytest_asyncio
 
 from ......core.profile import ProfileSession
 from ......storage.base import BaseStorage
@@ -11,7 +12,7 @@ from ......utils.testing import create_test_profile
 from ..mediation_record import MediationRecord
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session():
     profile = await create_test_profile()
     async with profile.session() as session:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
@@ -3,6 +3,7 @@
 from typing import AsyncIterable, Iterable
 
 import pytest
+import pytest_asyncio
 
 from .....core.event_bus import EventBus
 from .....core.profile import Profile, ProfileSession
@@ -38,7 +39,7 @@ TEST_ROUTE_VERKEY = "did:key:z6MknxTj6Zj1VrDWc1ofaZtmCVv2zNXpD58Xup4ijDGoQhya#z6
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     """Fixture for profile used in tests."""
     profile = await create_test_profile()
@@ -52,7 +53,7 @@ def mock_event_bus(profile: Profile):
     yield profile.inject(EventBus)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def session(profile) -> AsyncIterable[ProfileSession]:  # pylint: disable=W0621
     """Fixture for profile session used in tests."""
     async with profile.session() as session:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/tests/test_route_manager.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/tests/test_route_manager.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from .....connections.models.conn_record import ConnRecord
 from .....core.profile import Profile
@@ -42,7 +43,7 @@ def mock_responder():
     yield MockResponder()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(mock_responder: MockResponder):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(BaseResponder, mock_responder)

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_ack_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_ack_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -8,7 +9,7 @@ from ...messages.ack import RotateAck
 from .. import ack_handler as test_module
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     yield ctx

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_hangup_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_hangup_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -8,7 +9,7 @@ from ...messages.hangup import Hangup
 from .. import hangup_handler as test_module
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     yield ctx

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_problem_report_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_problem_report_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -12,7 +13,7 @@ test_valid_rotate_request = {
 }
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     yield RequestContext.test_context(await create_test_profile())
 

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_rotate_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/tests/test_rotate_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -12,7 +13,7 @@ test_valid_rotate_request = {
 }
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     yield RequestContext.test_context(await create_test_profile())
 

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/tests/test_complete_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/tests/test_complete_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from acapy_agent.tests import mock
 
@@ -13,7 +14,7 @@ from ...messages.problem_report import ProblemReportReason
 from .. import complete_handler as test_module
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.injector.bind_instance(DIDMethods, DIDMethods())

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/tests/test_invitation_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/tests/test_invitation_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -10,7 +11,7 @@ from ...handlers.invitation_handler import InvitationHandler
 from ...messages.problem_report import DIDXProblemReport, ProblemReportReason
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.injector.bind_instance(DIDMethods, DIDMethods())

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/tests/test_problem_report_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/tests/test_problem_report_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from acapy_agent.tests import mock
 
@@ -11,7 +12,7 @@ from ...messages.problem_report import DIDXProblemReport
 from .. import problem_report_handler as test_module
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     yield RequestContext.test_context(await create_test_profile())
 

--- a/acapy_agent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/acapy_agent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -1,6 +1,7 @@
 import json
 from unittest import IsolatedAsyncioTestCase
 
+import pytest
 from pydid import DIDDocument
 
 from .....admin.server import AdminResponder
@@ -162,6 +163,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
             with self.assertRaises(DIDXManagerError):
                 await self.manager.verify_diddoc(wallet, did_doc_attach)
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # create_did_document deprecation
     async def test_receive_invitation(self):
         async with self.profile.session() as session:
             self.profile.context.update_settings({"public_invites": True})
@@ -198,6 +200,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
                 assert invitee_record.state == ConnRecord.State.REQUEST.rfc23
                 assert mock_send_reply.called
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # create_did_document deprecation
     async def test_receive_invitation_oob_public_did(self):
         async with self.profile.session() as session:
             wallet = session.inject(BaseWallet)
@@ -1547,6 +1550,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
 
             await self.manager.create_response(conn_rec, "http://10.20.30.40:5060/")
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # create_did_document deprecation
     async def test_create_response_mediation_id(self):
         async with self.profile.session() as session:
             mediation_record = MediationRecord(

--- a/acapy_agent/protocols/discovery/v1_0/handlers/tests/test_disclose_handler.py
+++ b/acapy_agent/protocols/discovery/v1_0/handlers/tests/test_disclose_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......core.protocol_registry import ProtocolRegistry
 from ......messaging.base_handler import HandlerException
@@ -16,7 +17,7 @@ TEST_MESSAGE_FAMILY = "doc/proto/1.0"
 TEST_MESSAGE_TYPE = TEST_MESSAGE_FAMILY + "/message"
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.connection_ready = True

--- a/acapy_agent/protocols/discovery/v1_0/handlers/tests/test_query_handler.py
+++ b/acapy_agent/protocols/discovery/v1_0/handlers/tests/test_query_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......core.protocol_registry import ProtocolRegistry
 from ......messaging.request_context import RequestContext
@@ -13,7 +14,7 @@ TEST_MESSAGE_FAMILY = "doc/proto/1.0"
 TEST_MESSAGE_TYPE = TEST_MESSAGE_FAMILY + "/message"
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     registry = ProtocolRegistry()

--- a/acapy_agent/protocols/discovery/v2_0/handlers/tests/test_disclosures_handler.py
+++ b/acapy_agent/protocols/discovery/v2_0/handlers/tests/test_disclosures_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......core.protocol_registry import ProtocolRegistry
 from ......messaging.base_handler import HandlerException
@@ -17,7 +18,7 @@ TEST_MESSAGE_FAMILY = "doc/proto/1.0"
 TEST_MESSAGE_TYPE = TEST_MESSAGE_FAMILY + "/message"
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.connection_ready = True

--- a/acapy_agent/protocols/discovery/v2_0/handlers/tests/test_queries_handler.py
+++ b/acapy_agent/protocols/discovery/v2_0/handlers/tests/test_queries_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......core.goal_code_registry import GoalCodeRegistry
 from ......core.protocol_registry import ProtocolRegistry
@@ -25,7 +26,7 @@ TEST_MESSAGE_FAMILY = "doc/proto/1.0"
 TEST_MESSAGE_TYPE = TEST_MESSAGE_FAMILY + "/message"
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     protocol_registry = ProtocolRegistry()

--- a/acapy_agent/protocols/out_of_band/v1_0/handlers/tests/test_problem_report_handler.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/handlers/tests/test_problem_report_handler.py
@@ -1,6 +1,7 @@
 """Test Problem Report Handler."""
 
 import pytest
+import pytest_asyncio
 
 from ......connections.models.conn_record import ConnRecord
 from ......messaging.request_context import RequestContext
@@ -13,14 +14,14 @@ from ...manager import OutOfBandManagerError
 from ...messages.problem_report import OOBProblemReport, ProblemReportReason
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.message_receipt = MessageReceipt()
     yield ctx
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def connection_record(request_context, session):
     record = ConnRecord()
     request_context.connection_record = record
@@ -28,7 +29,7 @@ async def connection_record(request_context, session):
     yield record
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session(request_context):
     yield await request_context.session()
 

--- a/acapy_agent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_accept_handler.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_accept_handler.py
@@ -1,6 +1,7 @@
 """Test Reuse Accept Message Handler."""
 
 import pytest
+import pytest_asyncio
 
 from ......connections.models.conn_record import ConnRecord
 from ......messaging.request_context import RequestContext
@@ -13,14 +14,14 @@ from ...manager import OutOfBandManagerError
 from ...messages.reuse_accept import HandshakeReuseAccept
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.message_receipt = MessageReceipt()
     yield ctx
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def connection_record(request_context, session):
     record = ConnRecord()
     request_context.connection_record = record
@@ -28,7 +29,7 @@ async def connection_record(request_context, session):
     yield record
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session(request_context):
     yield await request_context.session()
 

--- a/acapy_agent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_handler.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_handler.py
@@ -3,6 +3,7 @@
 from typing import AsyncGenerator
 
 import pytest
+import pytest_asyncio
 
 from ......connections.models.conn_record import ConnRecord
 from ......core.profile import ProfileSession
@@ -17,14 +18,14 @@ from ...messages.reuse import HandshakeReuse
 from ...messages.reuse_accept import HandshakeReuseAccept
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     ctx = RequestContext.test_context(await create_test_profile())
     ctx.message_receipt = MessageReceipt()
     yield ctx
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session(request_context) -> AsyncGenerator[ProfileSession, None]:
     yield await request_context.session()
 

--- a/acapy_agent/protocols/out_of_band/v1_0/models/tests/test_out_of_band.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/models/tests/test_out_of_band.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......core.profile import ProfileSession
 from ......utils.testing import create_test_profile
@@ -6,7 +7,7 @@ from ...messages.invitation import InvitationMessage
 from ..oob_record import OobRecord
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def session():
     profile = await create_test_profile()
     async with profile.session() as session:

--- a/acapy_agent/protocols/problem_report/v1_0/tests/test_handler.py
+++ b/acapy_agent/protocols/problem_report/v1_0/tests/test_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from .....core.event_bus import EventBus, MockEventBus
 from .....messaging.request_context import RequestContext
@@ -9,7 +10,7 @@ from ..handler import ProblemReportHandler
 from ..message import ProblemReport
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     yield RequestContext.test_context(await create_test_profile())
 

--- a/acapy_agent/protocols/revocation_notification/v1_0/handlers/tests/test_revoke_handler.py
+++ b/acapy_agent/protocols/revocation_notification/v1_0/handlers/tests/test_revoke_handler.py
@@ -3,6 +3,7 @@
 from typing import Generator
 
 import pytest
+import pytest_asyncio
 
 from ......core.event_bus import EventBus, MockEventBus
 from ......core.profile import Profile
@@ -23,7 +24,7 @@ def responder():
     yield MockResponder()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(event_bus):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(EventBus, event_bus)

--- a/acapy_agent/protocols/revocation_notification/v1_0/models/tests/test_rev_notification_record.py
+++ b/acapy_agent/protocols/revocation_notification/v1_0/models/tests/test_rev_notification_record.py
@@ -1,6 +1,7 @@
 """Test RevNotificationRecord."""
 
 import pytest
+import pytest_asyncio
 
 from ......storage.error import StorageDuplicateError, StorageNotFoundError
 from ......utils.testing import create_test_profile
@@ -8,7 +9,7 @@ from ...messages.revoke import Revoke
 from ..rev_notification_record import RevNotificationRecord
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     profile = await create_test_profile()
     yield profile

--- a/acapy_agent/protocols/revocation_notification/v1_0/tests/test_routes.py
+++ b/acapy_agent/protocols/revocation_notification/v1_0/tests/test_routes.py
@@ -1,6 +1,7 @@
 """Test routes.py"""
 
 import pytest
+import pytest_asyncio
 
 from .....config.settings import Settings
 from .....core.event_bus import Event, MockEventBus
@@ -25,7 +26,7 @@ def responder():
     yield MockResponder()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(responder):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(BaseResponder, responder)

--- a/acapy_agent/protocols/revocation_notification/v2_0/handlers/tests/test_revoke_handler.py
+++ b/acapy_agent/protocols/revocation_notification/v2_0/handlers/tests/test_revoke_handler.py
@@ -3,6 +3,7 @@
 from typing import Generator
 
 import pytest
+import pytest_asyncio
 
 from ......core.event_bus import EventBus, MockEventBus
 from ......core.profile import Profile
@@ -23,7 +24,7 @@ def responder():
     yield MockResponder()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(event_bus):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(EventBus, event_bus)

--- a/acapy_agent/protocols/revocation_notification/v2_0/models/tests/test_rev_notification_record.py
+++ b/acapy_agent/protocols/revocation_notification/v2_0/models/tests/test_rev_notification_record.py
@@ -1,6 +1,7 @@
 """Test RevNotificationRecord."""
 
 import pytest
+import pytest_asyncio
 
 from ......storage.error import StorageDuplicateError, StorageNotFoundError
 from ......utils.testing import create_test_profile
@@ -8,7 +9,7 @@ from ...messages.revoke import Revoke
 from ..rev_notification_record import RevNotificationRecord
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     profile = await create_test_profile()
     yield profile

--- a/acapy_agent/protocols/revocation_notification/v2_0/tests/test_routes.py
+++ b/acapy_agent/protocols/revocation_notification/v2_0/tests/test_routes.py
@@ -1,6 +1,7 @@
 """Test routes.py"""
 
 import pytest
+import pytest_asyncio
 
 from .....config.settings import Settings
 from .....core.event_bus import Event, MockEventBus
@@ -23,7 +24,7 @@ def responder():
     yield MockResponder()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(responder):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(BaseResponder, responder)

--- a/acapy_agent/protocols/trustping/v1_0/handlers/tests/test_ping_handler.py
+++ b/acapy_agent/protocols/trustping/v1_0/handlers/tests/test_ping_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -9,7 +10,7 @@ from ...messages.ping import Ping
 from ...messages.ping_response import PingResponse
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     yield RequestContext.test_context(await create_test_profile())
 

--- a/acapy_agent/protocols/trustping/v1_0/handlers/tests/test_ping_response_handler.py
+++ b/acapy_agent/protocols/trustping/v1_0/handlers/tests/test_ping_response_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -8,7 +9,7 @@ from ...handlers.ping_response_handler import PingResponseHandler
 from ...messages.ping_response import PingResponse
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def request_context():
     yield RequestContext.test_context(await create_test_profile())
 

--- a/acapy_agent/resolver/default/tests/test_indy.py
+++ b/acapy_agent/resolver/default/tests/test_indy.py
@@ -1,6 +1,7 @@
 """Test IndyDIDResolver."""
 
 import pytest
+import pytest_asyncio
 
 from ....core.profile import Profile
 from ....ledger.base import BaseLedger
@@ -38,7 +39,7 @@ def ledger():
     yield ledger
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(ledger):
     """Profile fixture."""
     profile = await create_test_profile()

--- a/acapy_agent/resolver/default/tests/test_jwk.py
+++ b/acapy_agent/resolver/default/tests/test_jwk.py
@@ -1,6 +1,7 @@
 """Test JwkDIDResolver."""
 
 import pytest
+import pytest_asyncio
 
 from ....core.profile import Profile
 from ....utils.testing import create_test_profile
@@ -22,7 +23,7 @@ def resolver():
     yield JwkDIDResolver()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     """Profile fixture."""
     profile = await create_test_profile()

--- a/acapy_agent/resolver/default/tests/test_key.py
+++ b/acapy_agent/resolver/default/tests/test_key.py
@@ -1,6 +1,7 @@
 """Test KeyDIDResolver."""
 
 import pytest
+import pytest_asyncio
 
 from ....core.profile import Profile
 from ....messaging.valid import DIDKey
@@ -19,7 +20,7 @@ def resolver():
     yield KeyDIDResolver()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     """Profile fixture."""
     profile = await create_test_profile()

--- a/acapy_agent/resolver/default/tests/test_legacy_peer.py
+++ b/acapy_agent/resolver/default/tests/test_legacy_peer.py
@@ -2,6 +2,7 @@
 
 import pydid
 import pytest
+import pytest_asyncio
 
 from ....cache.base import BaseCache
 from ....cache.in_memory import InMemoryCache
@@ -24,7 +25,7 @@ def resolver():
     yield LegacyPeerDIDResolver()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     """Profile fixture."""
     profile = await create_test_profile()

--- a/acapy_agent/resolver/default/tests/test_peer2.py
+++ b/acapy_agent/resolver/default/tests/test_peer2.py
@@ -1,6 +1,7 @@
 """Test PeerDIDResolver."""
 
 import pytest
+import pytest_asyncio
 
 from ....core.profile import Profile
 from ....utils.testing import create_test_profile
@@ -15,7 +16,7 @@ def resolver():
     yield PeerDID2Resolver()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     """Profile fixture."""
     profile = await create_test_profile()

--- a/acapy_agent/resolver/default/tests/test_peer3.py
+++ b/acapy_agent/resolver/default/tests/test_peer3.py
@@ -1,6 +1,7 @@
 """Test PeerDIDResolver."""
 
 import pytest
+import pytest_asyncio
 from did_peer_2 import peer2to3
 
 from ....connections.models.conn_record import ConnRecord
@@ -21,7 +22,7 @@ def event_bus():
     yield EventBus()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(event_bus: EventBus):
     """Profile fixture."""
     profile = await create_test_profile()
@@ -29,7 +30,7 @@ async def profile(event_bus: EventBus):
     yield profile
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def resolver(profile):
     """Resolver fixture."""
     instance = PeerDID3Resolver()

--- a/acapy_agent/resolver/default/tests/test_peer4.py
+++ b/acapy_agent/resolver/default/tests/test_peer4.py
@@ -1,6 +1,7 @@
 """Test PeerDIDResolver."""
 
 import pytest
+import pytest_asyncio
 
 from ....core.event_bus import EventBus
 from ....core.profile import Profile
@@ -18,7 +19,7 @@ def event_bus():
     yield EventBus()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(event_bus: EventBus):
     """Profile fixture."""
     profile = await create_test_profile()
@@ -26,7 +27,7 @@ async def profile(event_bus: EventBus):
     yield profile
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def resolver(profile):
     """Resolver fixture."""
     instance = PeerDID4Resolver()

--- a/acapy_agent/resolver/default/tests/test_universal.py
+++ b/acapy_agent/resolver/default/tests/test_universal.py
@@ -4,6 +4,7 @@ import re
 from typing import Dict, Optional, Union
 
 import pytest
+import pytest_asyncio
 
 from ....config.settings import Settings
 from ....tests import mock
@@ -13,7 +14,7 @@ from .. import universal as test_module
 from ..universal import UniversalResolver
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def resolver():
     """Resolver fixture."""
     yield UniversalResolver(
@@ -21,7 +22,7 @@ async def resolver():
     )
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     """Profile fixture."""
     profile = await create_test_profile()

--- a/acapy_agent/resolver/default/tests/test_webvh.py
+++ b/acapy_agent/resolver/default/tests/test_webvh.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ....core.profile import Profile
 from ....messaging.valid import DIDWebvh
@@ -14,7 +15,7 @@ def resolver():
     yield WebvhDIDResolver()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     """Profile fixture."""
     yield await create_test_profile()

--- a/acapy_agent/resolver/tests/test_did_resolver.py
+++ b/acapy_agent/resolver/tests/test_did_resolver.py
@@ -4,6 +4,7 @@ import re
 from typing import Pattern
 
 import pytest
+import pytest_asyncio
 from pydid import DID, BasicDIDDocument, DIDDocument, VerificationMethod
 
 from ...utils.testing import create_test_profile
@@ -93,7 +94,7 @@ def resolver():
     return DIDResolver(did_resolver_registry)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     profile = await create_test_profile()
     yield profile

--- a/acapy_agent/resolver/tests/test_routes.py
+++ b/acapy_agent/resolver/tests/test_routes.py
@@ -3,6 +3,7 @@
 # pylint: disable=redefined-outer-name
 
 import pytest
+import pytest_asyncio
 from pydid import DIDDocument
 
 from ...admin.request_context import AdminRequestContext
@@ -56,7 +57,7 @@ def mock_resolver(resolution_result):
     yield did_resolver
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     profile = await create_test_profile(
         settings={

--- a/acapy_agent/settings/tests/test_routes.py
+++ b/acapy_agent/settings/tests/test_routes.py
@@ -3,6 +3,7 @@
 # pylint: disable=redefined-outer-name
 
 import pytest
+import pytest_asyncio
 
 from ...admin.request_context import AdminRequestContext
 from ...multitenant.base import BaseMultitenantManager
@@ -21,13 +22,13 @@ def mock_response():
     test_module.web.json_response = temp_value
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     profile = await create_test_profile()
     yield profile
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def admin_profile():
     profile = await create_test_profile(
         settings={

--- a/acapy_agent/storage/tests/test_askar_storage.py
+++ b/acapy_agent/storage/tests/test_askar_storage.py
@@ -3,6 +3,7 @@ import os
 from unittest import IsolatedAsyncioTestCase
 
 import pytest
+import pytest_asyncio
 
 from ...askar.profile import AskarProfileManager
 from ...config.injection_context import InjectionContext
@@ -15,7 +16,7 @@ from ..error import StorageError, StorageSearchError
 from ..record import StorageRecord
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def store():
     context = InjectionContext()
     profile = await AskarProfileManager().provision(

--- a/acapy_agent/storage/vc_holder/tests/test_askar_vc_holder.py
+++ b/acapy_agent/storage/vc_holder/tests/test_askar_vc_holder.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from ....storage.error import StorageDuplicateError, StorageNotFoundError
 from ....utils.testing import create_test_profile
@@ -14,7 +15,7 @@ VC_SCHEMA_ID = "https://example.org/examples/degree.json"
 VC_GIVEN_ID = "http://example.edu/credentials/3732"
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def holder():
     profile = await create_test_profile(settings={"wallet.type": "askar"})
     yield profile.inject(VCHolder)

--- a/acapy_agent/vc/vc_di/tests/test_manager.py
+++ b/acapy_agent/vc/vc_di/tests/test_manager.py
@@ -1,6 +1,7 @@
 """Test VCDIManager."""
 
 import pytest
+import pytest_asyncio
 from anoncreds import W3cPresentation
 
 from ....anoncreds.registry import AnonCredsRegistry
@@ -145,7 +146,7 @@ VP = {
 }
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile():
     profile = await create_test_profile()
     profile.context.injector.bind_instance(DIDResolver, DIDResolver([KeyDIDResolver()]))

--- a/acapy_agent/vc/vc_di/tests/test_prove.py
+++ b/acapy_agent/vc/vc_di/tests/test_prove.py
@@ -1,6 +1,7 @@
 """test prove.py"""
 
 import pytest
+import pytest_asyncio
 from anoncreds import CredentialRevocationState, RevocationStatusList
 
 from ....anoncreds.holder import AnonCredsHolder, AnonCredsHolderError
@@ -33,7 +34,7 @@ def resolver():
     yield DIDResolver([KeyDIDResolver()])
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def profile(resolver: DIDResolver):
     profile = await create_test_profile()
     profile.context.injector.bind_instance(DIDMethods, DIDMethods())


### PR DESCRIPTION
- ignores the expected `create_did_document` deprecation warning in relevant tests
- correctly tear down ClientSession in TestAdminServer
- use `pytest_asyncio.fixture` for async test fixtures (allows tests to successfully run with `--asyncio-mode=strict`)
___
There remains 1 test warning:
```
acapy_agent/messaging/jsonld/tests/test_routes.py::TestJSONLDRoutes::test_verify_credential
  /root/anaconda3/envs/acapy/lib/python3.12/site-packages/pytest_asyncio/plugin.py:788: DeprecationWarning: pytest-asyncio detected an unclosed event loop when tearing down the event_loop
  fixture: <_UnixSelectorEventLoop running=False closed=False debug=False>
  pytest-asyncio will close the event loop for you, but future versions of the
  library will no longer do so. In order to ensure compatibility with future
  versions, please make sure that:
      1. Any custom "event_loop" fixture properly closes the loop after yielding it
      2. The scopes of your custom "event_loop" fixtures do not overlap
      3. Your code does not modify the event loop in async fixtures or tests
  ```

I've tried - I can't figure out what's causing an unclosed event loop here. It doesn't occur when the test, or the module is run in isolation, but for a full test run it appears.

I believe it's related to `nest_asyncio` being used in the json-ld logic, but I'm not sure.

Nevertheless, 1 warning is better than 8. Progress