### PR TITLE
:art: Fix swagger tag names for AnonCreds endpoints

### DIFF
--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -49,6 +49,9 @@ from .util import handle_value_error
 
 LOGGER = logging.getLogger(__name__)
 
+CRED_DEF_TAG_TITLE = "AnonCreds - Credential Definitions"
+SCHEMAS_TAG_TITLE = "AnonCreds - Schemas"
+
 SPEC_URI = "https://hyperledger.github.io/anoncreds-spec"
 
 endorser_connection_id_description = (
@@ -154,7 +157,10 @@ class SchemaPostRequestSchema(OpenAPISchema):
     options = fields.Nested(SchemaPostOptionSchema())
 
 
-@docs(tags=["anoncreds - schemas"], summary="Create a schema on the connected datastore")
+@docs(
+    tags=[SCHEMAS_TAG_TITLE],
+    summary="Create a schema on the connected datastore",
+)
 @request_schema(SchemaPostRequestSchema())
 @response_schema(SchemaResultSchema(), 200, description="")
 @tenant_authentication
@@ -226,7 +232,10 @@ async def schemas_post(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason=e.roll_up) from e
 
 
-@docs(tags=["anoncreds - schemas"], summary="Retrieve an individual schemas details")
+@docs(
+    tags=[SCHEMAS_TAG_TITLE],
+    summary="Retrieve an individual schemas details",
+)
 @match_info_schema(SchemaIdMatchInfo())
 @response_schema(GetSchemaResultSchema(), 200, description="")
 @tenant_authentication
@@ -256,7 +265,10 @@ async def schema_get(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason=e.roll_up) from e
 
 
-@docs(tags=["anoncreds - schemas"], summary="Retrieve all schema ids")
+@docs(
+    tags=[SCHEMAS_TAG_TITLE],
+    summary="Retrieve all schema ids",
+)
 @querystring_schema(SchemasQueryStringSchema())
 @response_schema(GetSchemasResponseSchema(), 200, description="")
 @tenant_authentication
@@ -398,7 +410,7 @@ class CredDefsQueryStringSchema(OpenAPISchema):
 
 
 @docs(
-    tags=["anoncreds - credential definitions"],
+    tags=[CRED_DEF_TAG_TITLE],
     summary="Create a credential definition on the connected datastore",
 )
 @request_schema(CredDefPostRequestSchema())
@@ -450,7 +462,7 @@ async def cred_def_post(request: web.BaseRequest):
 
 
 @docs(
-    tags=["anoncreds - credential definitions"],
+    tags=[CRED_DEF_TAG_TITLE],
     summary="Retrieve an individual credential definition details",
 )
 @match_info_schema(CredIdMatchInfo())
@@ -498,7 +510,7 @@ class GetCredDefsResponseSchema(OpenAPISchema):
 
 
 @docs(
-    tags=["anoncreds - credential definitions"],
+    tags=[CRED_DEF_TAG_TITLE],
     summary="Retrieve all credential definition ids",
 )
 @querystring_schema(CredDefsQueryStringSchema())
@@ -821,14 +833,14 @@ def post_process_routes(app: web.Application):
         app._state["swagger_dict"]["tags"] = []
     app._state["swagger_dict"]["tags"].append(
         {
-            "name": "AnonCreds - Schemas",
+            "name": SCHEMAS_TAG_TITLE,
             "description": "AnonCreds schema management",
             "externalDocs": {"description": "Specification", "url": SPEC_URI},
         }
     )
     app._state["swagger_dict"]["tags"].append(
         {
-            "name": "AnonCreds - Credential Definitions",
+            "name": CRED_DEF_TAG_TITLE,
             "description": "AnonCreds credential definition management",
             "externalDocs": {"description": "Specification", "url": SPEC_URI},
         }

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -26,7 +26,6 @@ from ..messaging.valid import (
     UUIDFour,
 )
 from ..revocation.error import RevocationNotSupportedError
-from ..revocation_anoncreds.routes import TAG_TITLE as REVOCATION_TAG_TITLE
 from ..storage.error import StorageNotFoundError
 from ..utils.profiles import is_not_anoncreds_profile_raise_web_exception
 from .base import (
@@ -51,6 +50,7 @@ LOGGER = logging.getLogger(__name__)
 
 CRED_DEF_TAG_TITLE = "AnonCreds - Credential Definitions"
 SCHEMAS_TAG_TITLE = "AnonCreds - Schemas"
+REVOCATION_TAG_TITLE = "AnonCreds - Revocation"
 
 SPEC_URI = "https://hyperledger.github.io/anoncreds-spec"
 

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -26,6 +26,7 @@ from ..messaging.valid import (
     UUIDFour,
 )
 from ..revocation.error import RevocationNotSupportedError
+from ..revocation_anoncreds.routes import TAG_TITLE as REVOCATION_TAG_TITLE
 from ..storage.error import StorageNotFoundError
 from ..utils.profiles import is_not_anoncreds_profile_raise_web_exception
 from .base import (
@@ -592,7 +593,7 @@ class RevRegCreateRequestSchemaAnonCreds(OpenAPISchema):
 
 
 @docs(
-    tags=["anoncreds - revocation"],
+    tags=[REVOCATION_TAG_TITLE],
     summary="Create and publish a registration revocation on the connected datastore",
 )
 @request_schema(RevRegCreateRequestSchemaAnonCreds())
@@ -677,7 +678,7 @@ class RevListCreateRequestSchema(OpenAPISchema):
 
 
 @docs(
-    tags=["anoncreds - revocation"],
+    tags=[REVOCATION_TAG_TITLE],
     summary="Create and publish a revocation status list on the connected datastore",
 )
 @request_schema(RevListCreateRequestSchema())
@@ -713,7 +714,7 @@ async def rev_list_post(request: web.BaseRequest):
 
 
 @docs(
-    tags=["anoncreds - revocation"],
+    tags=[REVOCATION_TAG_TITLE],
     summary="Upload local tails file to server",
 )
 @match_info_schema(AnonCredsRevRegIdMatchInfoSchema())
@@ -749,7 +750,7 @@ async def upload_tails_file(request: web.BaseRequest):
 
 
 @docs(
-    tags=["anoncreds - revocation"],
+    tags=[REVOCATION_TAG_TITLE],
     summary="Update the active registry",
 )
 @match_info_schema(AnonCredsRevRegIdMatchInfoSchema())

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -313,7 +313,7 @@ class PublishRevocationsOptions(OpenAPISchema):
 
     endorser_connection_id = fields.Str(
         metadata={
-            "description": endorser_connection_id_description,  # noqa: F821
+            "description": endorser_connection_id_description,
             "required": False,
             "example": UUIDFour.EXAMPLE,
         }

--- a/acapy_agent/wallet/keys/routes.py
+++ b/acapy_agent/wallet/keys/routes.py
@@ -10,6 +10,7 @@ from ...admin.decorators.auth import tenant_authentication
 from ...admin.request_context import AdminRequestContext
 from ...messaging.models.openapi import OpenAPISchema
 from ...wallet.error import WalletDuplicateError, WalletNotFoundError
+from ..routes import WALLET_TAG_TITLE
 from .manager import DEFAULT_ALG, MultikeyManager, MultikeyManagerError
 
 LOGGER = logging.getLogger(__name__)
@@ -124,7 +125,7 @@ class FetchKeyResponseSchema(OpenAPISchema):
     )
 
 
-@docs(tags=["wallet"], summary="Fetch key info.")
+@docs(tags=[WALLET_TAG_TITLE], summary="Fetch key info.")
 @response_schema(FetchKeyResponseSchema, 200, description="")
 @tenant_authentication
 async def fetch_key(request: web.BaseRequest):
@@ -149,7 +150,7 @@ async def fetch_key(request: web.BaseRequest):
         return web.json_response({"message": str(err)}, status=400)
 
 
-@docs(tags=["wallet"], summary="Create a key pair")
+@docs(tags=[WALLET_TAG_TITLE], summary="Create a key pair")
 @request_schema(CreateKeyRequestSchema())
 @response_schema(CreateKeyResponseSchema, 200, description="")
 @tenant_authentication
@@ -184,7 +185,7 @@ async def create_key(request: web.BaseRequest):
         return web.json_response({"message": str(err)}, status=400)
 
 
-@docs(tags=["wallet"], summary="Update a key pair's kid")
+@docs(tags=[WALLET_TAG_TITLE], summary="Update a key pair's kid")
 @request_schema(UpdateKeyRequestSchema())
 @response_schema(UpdateKeyResponseSchema, 200, description="")
 @tenant_authentication

--- a/acapy_agent/wallet/routes.py
+++ b/acapy_agent/wallet/routes.py
@@ -1341,8 +1341,8 @@ class UpgradeResultSchema(OpenAPISchema):
 
 @docs(
     tags=[UPGRADE_TAG_TITLE],
-    summary="Upgrade the wallet from askar to anoncreds - Be very careful with this! "
-    "You cannot go back! See migration guide for more information.",
+    summary="Upgrade the wallet from askar to askar-anoncreds. Be very careful with this!"
+    " You cannot go back! See migration guide for more information.",
 )
 @querystring_schema(UpgradeVerificationSchema())
 @response_schema(UpgradeResultSchema(), description="")

--- a/acapy_agent/wallet/routes.py
+++ b/acapy_agent/wallet/routes.py
@@ -88,6 +88,9 @@ from .util import EVENT_LISTENER_PATTERN
 
 LOGGER = logging.getLogger(__name__)
 
+WALLET_TAG_TITLE = "wallet"
+UPGRADE_TAG_TITLE = "AnonCreds - Wallet Upgrade"
+
 
 class WalletModuleResponseSchema(OpenAPISchema):
     """Response schema for Wallet Module."""
@@ -447,7 +450,7 @@ def format_did_info(info: DIDInfo):
         }
 
 
-@docs(tags=["wallet"], summary="List wallet DIDs")
+@docs(tags=[WALLET_TAG_TITLE], summary="List wallet DIDs")
 @querystring_schema(DIDListQueryStringSchema())
 @response_schema(DIDListSchema, 200, description="")
 @tenant_authentication
@@ -553,7 +556,7 @@ async def wallet_did_list(request: web.BaseRequest):
     return web.json_response({"results": results})
 
 
-@docs(tags=["wallet"], summary="Create a local DID")
+@docs(tags=[WALLET_TAG_TITLE], summary="Create a local DID")
 @request_schema(DIDCreateSchema())
 @response_schema(DIDResultSchema, 200, description="")
 @tenant_authentication
@@ -680,7 +683,7 @@ async def wallet_create_did(request: web.BaseRequest):
     return web.json_response({"result": format_did_info(info)})
 
 
-@docs(tags=["wallet"], summary="Fetch the current public DID")
+@docs(tags=[WALLET_TAG_TITLE], summary="Fetch the current public DID")
 @response_schema(DIDResultSchema, 200, description="")
 @tenant_authentication
 async def wallet_get_public_did(request: web.BaseRequest):
@@ -707,7 +710,7 @@ async def wallet_get_public_did(request: web.BaseRequest):
     return web.json_response({"result": format_did_info(info)})
 
 
-@docs(tags=["wallet"], summary="Assign the current public DID")
+@docs(tags=[WALLET_TAG_TITLE], summary="Assign the current public DID")
 @querystring_schema(DIDQueryStringSchema())
 @querystring_schema(CreateAttribTxnForEndorserOptionSchema())
 @querystring_schema(AttribConnIdMatchInfoSchema())
@@ -952,7 +955,10 @@ async def promote_wallet_public_did(
     return info, attrib_def
 
 
-@docs(tags=["wallet"], summary="Update endpoint in wallet and on ledger if posted to it")
+@docs(
+    tags=[WALLET_TAG_TITLE],
+    summary="Update endpoint in wallet and on ledger if posted to it",
+)
 @request_schema(DIDEndpointWithTypeSchema)
 @querystring_schema(CreateAttribTxnForEndorserOptionSchema())
 @querystring_schema(AttribConnIdMatchInfoSchema())
@@ -1083,7 +1089,7 @@ async def wallet_set_did_endpoint(request: web.BaseRequest):
         return web.json_response({"txn": transaction.serialize()})
 
 
-@docs(tags=["wallet"], summary="Create a jws using did keys with a given payload")
+@docs(tags=[WALLET_TAG_TITLE], summary="Create a jws using did keys with a given payload")
 @request_schema(JWSCreateSchema)
 @response_schema(WalletModuleResponseSchema(), description="")
 @tenant_authentication
@@ -1121,7 +1127,10 @@ async def wallet_jwt_sign(request: web.BaseRequest):
     return web.json_response(jws)
 
 
-@docs(tags=["wallet"], summary="Create an sd-jws using did keys with a given payload")
+@docs(
+    tags=[WALLET_TAG_TITLE],
+    summary="Create an sd-jws using did keys with a given payload",
+)
 @request_schema(SDJWSCreateSchema)
 @response_schema(WalletModuleResponseSchema(), description="")
 @tenant_authentication
@@ -1163,7 +1172,7 @@ async def wallet_sd_jwt_sign(request: web.BaseRequest):
     return web.json_response(sd_jws)
 
 
-@docs(tags=["wallet"], summary="Verify a jws using did keys with a given JWS")
+@docs(tags=[WALLET_TAG_TITLE], summary="Verify a jws using did keys with a given JWS")
 @request_schema(JWSVerifySchema())
 @response_schema(JWSVerifyResponseSchema(), 200, description="")
 @tenant_authentication
@@ -1204,7 +1213,7 @@ async def wallet_jwt_verify(request: web.BaseRequest):
 
 
 @docs(
-    tags=["wallet"],
+    tags=[WALLET_TAG_TITLE],
     summary="Verify an sd-jws using did keys with a given SD-JWS with "
     "optional key binding",
 )
@@ -1239,7 +1248,7 @@ async def wallet_sd_jwt_verify(request: web.BaseRequest):
     return web.json_response(result.serialize())
 
 
-@docs(tags=["wallet"], summary="Query DID endpoint in wallet")
+@docs(tags=[WALLET_TAG_TITLE], summary="Query DID endpoint in wallet")
 @querystring_schema(DIDQueryStringSchema())
 @response_schema(DIDEndpointSchema, 200, description="")
 @tenant_authentication
@@ -1273,7 +1282,9 @@ async def wallet_get_did_endpoint(request: web.BaseRequest):
     return web.json_response({"did": did, "endpoint": endpoint})
 
 
-@docs(tags=["wallet"], summary="Rotate keypair for a DID not posted to the ledger")
+@docs(
+    tags=[WALLET_TAG_TITLE], summary="Rotate keypair for a DID not posted to the ledger"
+)
 @querystring_schema(DIDQueryStringSchema())
 @response_schema(WalletModuleResponseSchema(), description="")
 @tenant_authentication
@@ -1329,7 +1340,7 @@ class UpgradeResultSchema(OpenAPISchema):
 
 
 @docs(
-    tags=["anoncreds - wallet upgrade"],
+    tags=[UPGRADE_TAG_TITLE],
     summary="""
         Upgrade the wallet from askar to anoncreds - Be very careful with this! You 
         cannot go back! See migration guide for more information.
@@ -1484,7 +1495,7 @@ def post_process_routes(app: web.Application):
         app._state["swagger_dict"]["tags"] = []
     app._state["swagger_dict"]["tags"].append(
         {
-            "name": "wallet",
+            "name": WALLET_TAG_TITLE,
             "description": "DID and tag policy management",
             "externalDocs": {
                 "description": "Design",
@@ -1497,7 +1508,7 @@ def post_process_routes(app: web.Application):
     )
     app._state["swagger_dict"]["tags"].append(
         {
-            "name": "AnonCreds - Wallet Upgrade",
+            "name": UPGRADE_TAG_TITLE,
             "description": "AnonCreds wallet upgrade",
             "externalDocs": {
                 "description": "Specification",

--- a/acapy_agent/wallet/routes.py
+++ b/acapy_agent/wallet/routes.py
@@ -1341,10 +1341,8 @@ class UpgradeResultSchema(OpenAPISchema):
 
 @docs(
     tags=[UPGRADE_TAG_TITLE],
-    summary="""
-        Upgrade the wallet from askar to anoncreds - Be very careful with this! You 
-        cannot go back! See migration guide for more information.
-    """,
+    summary="Upgrade the wallet from askar to anoncreds - Be very careful with this! "
+    "You cannot go back! See migration guide for more information.",
 )
 @querystring_schema(UpgradeVerificationSchema())
 @response_schema(UpgradeResultSchema(), description="")

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1110,7 +1110,7 @@
             "description" : ""
           }
         },
-        "summary" : "Upgrade the wallet from askar to anoncreds - Be very careful with this! You cannot go back! See migration guide for more information.",
+        "summary" : "Upgrade the wallet from askar to askar-anoncreds. Be very careful with this! You cannot go back! See migration guide for more information.",
         "tags" : [ "AnonCreds - Wallet Upgrade" ]
       }
     },

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -394,7 +394,7 @@
           }
         },
         "summary" : "Create a credential definition on the connected datastore",
-        "tags" : [ "anoncreds - credential definitions" ],
+        "tags" : [ "AnonCreds - Credential Definitions" ],
         "x-codegen-request-body-name" : "body"
       }
     },
@@ -422,7 +422,7 @@
           }
         },
         "summary" : "Retrieve an individual credential definition details",
-        "tags" : [ "anoncreds - credential definitions" ]
+        "tags" : [ "AnonCreds - Credential Definitions" ]
       }
     },
     "/anoncreds/credential-definitions" : {
@@ -469,7 +469,7 @@
           }
         },
         "summary" : "Retrieve all credential definition ids",
-        "tags" : [ "anoncreds - credential definitions" ]
+        "tags" : [ "AnonCreds - Credential Definitions" ]
       }
     },
     "/anoncreds/registry/{rev_reg_id}/active" : {
@@ -497,7 +497,7 @@
           }
         },
         "summary" : "Update the active registry",
-        "tags" : [ "anoncreds - revocation" ]
+        "tags" : [ "AnonCreds - Revocation" ]
       }
     },
     "/anoncreds/registry/{rev_reg_id}/tails-file" : {
@@ -525,7 +525,7 @@
           }
         },
         "summary" : "Upload local tails file to server",
-        "tags" : [ "anoncreds - revocation" ]
+        "tags" : [ "AnonCreds - Revocation" ]
       }
     },
     "/anoncreds/revocation-list" : {
@@ -553,7 +553,7 @@
           }
         },
         "summary" : "Create and publish a revocation status list on the connected datastore",
-        "tags" : [ "anoncreds - revocation" ],
+        "tags" : [ "AnonCreds - Revocation" ],
         "x-codegen-request-body-name" : "body"
       }
     },
@@ -582,7 +582,7 @@
           }
         },
         "summary" : "Create and publish a registration revocation on the connected datastore",
-        "tags" : [ "anoncreds - revocation" ],
+        "tags" : [ "AnonCreds - Revocation" ],
         "x-codegen-request-body-name" : "body"
       }
     },
@@ -1016,7 +1016,7 @@
           }
         },
         "summary" : "Create a schema on the connected datastore",
-        "tags" : [ "anoncreds - schemas" ],
+        "tags" : [ "AnonCreds - Schemas" ],
         "x-codegen-request-body-name" : "body"
       }
     },
@@ -1044,7 +1044,7 @@
           }
         },
         "summary" : "Retrieve an individual schemas details",
-        "tags" : [ "anoncreds - schemas" ]
+        "tags" : [ "AnonCreds - Schemas" ]
       }
     },
     "/anoncreds/schemas" : {
@@ -1084,7 +1084,7 @@
           }
         },
         "summary" : "Retrieve all schema ids",
-        "tags" : [ "anoncreds - schemas" ]
+        "tags" : [ "AnonCreds - Schemas" ]
       }
     },
     "/anoncreds/wallet/upgrade" : {
@@ -1110,8 +1110,8 @@
             "description" : ""
           }
         },
-        "summary" : "\n        Upgrade the wallet from askar to anoncreds - Be very careful with this! You \n        cannot go back! See migration guide for more information.\n    ",
-        "tags" : [ "anoncreds - wallet upgrade" ]
+        "summary" : "Upgrade the wallet from askar to anoncreds - Be very careful with this! You cannot go back! See migration guide for more information.",
+        "tags" : [ "AnonCreds - Wallet Upgrade" ]
       }
     },
     "/connections" : {

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -335,7 +335,7 @@
     },
     "/anoncreds/credential-definition" : {
       "post" : {
-        "tags" : [ "anoncreds - credential definitions" ],
+        "tags" : [ "AnonCreds - Credential Definitions" ],
         "summary" : "Create a credential definition on the connected datastore",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -358,7 +358,7 @@
     },
     "/anoncreds/credential-definition/{cred_def_id}" : {
       "get" : {
-        "tags" : [ "anoncreds - credential definitions" ],
+        "tags" : [ "AnonCreds - Credential Definitions" ],
         "summary" : "Retrieve an individual credential definition details",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -380,7 +380,7 @@
     },
     "/anoncreds/credential-definitions" : {
       "get" : {
-        "tags" : [ "anoncreds - credential definitions" ],
+        "tags" : [ "AnonCreds - Credential Definitions" ],
         "summary" : "Retrieve all credential definition ids",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -420,7 +420,7 @@
     },
     "/anoncreds/registry/{rev_reg_id}/active" : {
       "put" : {
-        "tags" : [ "anoncreds - revocation" ],
+        "tags" : [ "AnonCreds - Revocation" ],
         "summary" : "Update the active registry",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -443,7 +443,7 @@
     },
     "/anoncreds/registry/{rev_reg_id}/tails-file" : {
       "put" : {
-        "tags" : [ "anoncreds - revocation" ],
+        "tags" : [ "AnonCreds - Revocation" ],
         "summary" : "Upload local tails file to server",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -466,7 +466,7 @@
     },
     "/anoncreds/revocation-list" : {
       "post" : {
-        "tags" : [ "anoncreds - revocation" ],
+        "tags" : [ "AnonCreds - Revocation" ],
         "summary" : "Create and publish a revocation status list on the connected datastore",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -489,7 +489,7 @@
     },
     "/anoncreds/revocation-registry-definition" : {
       "post" : {
-        "tags" : [ "anoncreds - revocation" ],
+        "tags" : [ "AnonCreds - Revocation" ],
         "summary" : "Create and publish a registration revocation on the connected datastore",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -845,7 +845,7 @@
     },
     "/anoncreds/schema" : {
       "post" : {
-        "tags" : [ "anoncreds - schemas" ],
+        "tags" : [ "AnonCreds - Schemas" ],
         "summary" : "Create a schema on the connected datastore",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -868,7 +868,7 @@
     },
     "/anoncreds/schema/{schema_id}" : {
       "get" : {
-        "tags" : [ "anoncreds - schemas" ],
+        "tags" : [ "AnonCreds - Schemas" ],
         "summary" : "Retrieve an individual schemas details",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -890,7 +890,7 @@
     },
     "/anoncreds/schemas" : {
       "get" : {
-        "tags" : [ "anoncreds - schemas" ],
+        "tags" : [ "AnonCreds - Schemas" ],
         "summary" : "Retrieve all schema ids",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -924,8 +924,8 @@
     },
     "/anoncreds/wallet/upgrade" : {
       "post" : {
-        "tags" : [ "anoncreds - wallet upgrade" ],
-        "summary" : "\n        Upgrade the wallet from askar to anoncreds - Be very careful with this! You \n        cannot go back! See migration guide for more information.\n    ",
+        "tags" : [ "AnonCreds - Wallet Upgrade" ],
+        "summary" : "Upgrade the wallet from askar to anoncreds - Be very careful with this! You cannot go back! See migration guide for more information.",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "wallet_name",

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -925,7 +925,7 @@
     "/anoncreds/wallet/upgrade" : {
       "post" : {
         "tags" : [ "AnonCreds - Wallet Upgrade" ],
-        "summary" : "Upgrade the wallet from askar to anoncreds - Be very careful with this! You cannot go back! See migration guide for more information.",
+        "summary" : "Upgrade the wallet from askar to askar-anoncreds. Be very careful with this! You cannot go back! See migration guide for more information.",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "wallet_name",


### PR DESCRIPTION
Resolves #3658

Some duplicated tag names were not caught in the renaming PR: #3573

___
Note: there's a bit of a knot created by the fact that there's `revocation_anoncreds/routes.py`, and then some revocation endpoints being defined in `anoncreds/routes.py`. Not gonna try fix that here. Ideally should be cleaned up by the original contributors, or logged as a to-do