### PR TITLE
:art: Rename did:indy create/response schema objects

### DIFF
--- a/acapy_agent/did/indy/routes.py
+++ b/acapy_agent/did/indy/routes.py
@@ -65,10 +65,10 @@ async def create_indy_did(request: web.BaseRequest):
     """Create a INDY DID."""
     context: AdminRequestContext = request["context"]
     body = await request.json()
+    options = body.get("options", {})
     try:
-        return web.json_response(
-            (await DidIndyManager(context.profile).register(body.get("options"))),
-        )
+        result = await DidIndyManager(context.profile).register(options)
+        return web.json_response(result)
     except WalletError as e:
         raise web.HTTPBadRequest(reason=str(e))
 

--- a/acapy_agent/did/indy/routes.py
+++ b/acapy_agent/did/indy/routes.py
@@ -13,8 +13,8 @@ from ...messaging.models.openapi import OpenAPISchema
 from ...wallet.error import WalletError
 
 
-class CreateRequestSchema(OpenAPISchema):
-    """Parameters and validators for create DID endpoint."""
+class CreateDidIndyRequestSchema(OpenAPISchema):
+    """Parameters and validators for create DID Indy endpoint."""
 
     options = fields.Dict(
         required=False,
@@ -36,8 +36,8 @@ class CreateRequestSchema(OpenAPISchema):
     )
 
 
-class CreateResponseSchema(OpenAPISchema):
-    """Response schema for create DID endpoint."""
+class CreateDidIndyResponseSchema(OpenAPISchema):
+    """Response schema for create DID Indy endpoint."""
 
     did = fields.Str(
         metadata={
@@ -54,8 +54,8 @@ class CreateResponseSchema(OpenAPISchema):
 
 
 @docs(tags=["did"], summary="Create a did:indy")
-@request_schema(CreateRequestSchema())
-@response_schema(CreateResponseSchema, HTTPStatus.OK)
+@request_schema(CreateDidIndyRequestSchema())
+@response_schema(CreateDidIndyResponseSchema, HTTPStatus.OK)
 @tenant_authentication
 async def create_indy_did(request: web.BaseRequest):
     """Create a INDY DID."""

--- a/acapy_agent/did/indy/routes.py
+++ b/acapy_agent/did/indy/routes.py
@@ -19,7 +19,11 @@ class CreateDidIndyRequestSchema(OpenAPISchema):
     options = fields.Dict(
         required=False,
         metadata={
-            "description": "Additional configuration options",
+            "description": (
+                "Additional configuration options. "
+                "Supported options: did, seed, key_type. "
+                "Default key_type is ed25519."
+            ),
             "example": {
                 "did": "did:indy:WRfXPg8dantKVubE3HX8pw",
                 "seed": "000000000000000000000000Trustee1",


### PR DESCRIPTION
The schema names `CreateRequest` and `CreateResponse` are too generic for a codebase with this many create/response objects.
Proposing to rename to `CreateDidIndyRequest` and `CreateDidIndyResponse`.

Includes additional neatening up. With some review comments to follow up on https://github.com/openwallet-foundation/acapy/pull/3253