### PR TITLE
(fix) VM resolution strategy correction for embedded VMs

### DIFF
--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Literal, Optional
 
-from pydid import DIDDocument
+from pydid import DIDDocument, VerificationMethod
 
 from ..core.error import BaseError
 from ..core.profile import Profile
@@ -68,6 +68,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         self.key_types_mapping = {
             "Ed25519Signature2018": ["Ed25519VerificationKey2018"],
             "Ed25519Signature2020": ["Ed25519VerificationKey2020", "Multikey"],
+            "BbsBlsSignature2020": ["Bls12381G2Key2020"],
         }
 
     async def get_verification_method_id_for_did(
@@ -109,7 +110,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         methods = [
             await resolver.dereference_verification_method(profile, method, document=doc)
             if isinstance(method, str)
-            else method
+            else VerificationMethod.deserialize(method)
             for method in methods_or_refs
         ]
 

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -133,7 +133,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
                 (
                     "More than 1 verification method matched for did %s with proof "
                     "type %s and purpose %s; returning the first: %s"
-                ), 
+                ),
                 did,
                 proof_type,
                 proof_purpose,

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -133,7 +133,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
                 (
                     "More than 1 verification method matched for did %s with proof "
                     "type %s and purpose %s; returning the first: %s"
-                ),
+                ), 
                 did,
                 proof_type,
                 proof_purpose,

--- a/acapy_agent/wallet/tests/test_default_verification_key_strategy.py
+++ b/acapy_agent/wallet/tests/test_default_verification_key_strategy.py
@@ -47,7 +47,16 @@ class TestDefaultVerificationKeyStrategy(IsolatedAsyncioTestCase):
                         },
                     ],
                     "authentication": ["did:example:123#key-1"],
-                    "assertionMethod": ["did:example:123#key-2", "did:example:123#key-3"],
+                    "assertionMethod": [
+                        "did:example:123#key-2",
+                        "did:example:123#key-3",
+                        {
+                            "id": "did:example:123#key-4",
+                            "type": "Bls12381G2Key2020",
+                            "controller": "did:example:123",
+                            "publicKeyBase58": "25EEkQtcLKsEzQ6JTo9cg4W7NHpaurn4Wg6LaNPFq6JQXnrP91SDviUz7KrJVMJd76CtAZFsRLYzvgX2JGxo2ccUHtuHk7ELCWwrkBDfrXCFVfqJKDootee9iVaF6NpdJtBE",
+                        },
+                    ],
                 },
             )
         )
@@ -86,6 +95,15 @@ class TestDefaultVerificationKeyStrategy(IsolatedAsyncioTestCase):
                 proof_purpose="assertionMethod",
             )
             == "did:example:123#key-3"
+        )
+        assert (
+            await strategy.get_verification_method_id_for_did(
+                "did:example:123",
+                self.profile,
+                proof_type="BbsBlsSignature2020",
+                proof_purpose="assertionMethod",
+            )
+            == "did:example:123#key-4"
         )
 
     async def test_unsupported_did_method(self):


### PR DESCRIPTION
fixes a mistake in the original PR for: https://github.com/openwallet-foundation/acapy/pull/3622

in the original fix, if the VM was inline/embedded (e.g. embedded directly in the `assertionMethod`) of the DID Doc, then it would fail due to some typing oversight

This is because when it reaches this line:
```python
methods = [vm for vm in methods if vm.type in method_types]
```
, the `vm` is still a `dict` (when it should be a `VerificationMethod` class), so `.type` causes a typing fail. Easy fix is to just deserialize it into the correct type. Added an extra test case which fails with the original code.

I also added in the `"BbsBlsSignature2020": ["Bls12381G2Key2020"],` proof-type<->VM-type mapping in the VM strategy - i'm not actually personally using that code path (yet), but the new test is using it and i see no reason it shouldn't be there. 

^ Also note, i would've added `"BbsBlsSignature2020": ["Bls12381G2Key2020", "Multikey"]` to match `"Ed25519Signature2020": ["Ed25519VerificationKey2020", "Multikey"],`, however I'm not the biggest fan of how the `DefaultVerificationKeyStrategy` is handling this currently - just because it's a `Multikey`, doesn't mean it's suitable for `Ed25519Signature2020`, likewise for bbs. Realistically the VM strategy should be taking an extra step to check what the **actual** key type of the `Multikey` VM is, not assuming it's ed25519. Didn't want to increase the scope of this PR trying to refactor that though.