### PR TITLE
:lock: Update Token Permissions in GitHub Actions

### DIFF
--- a/.github/workflows/bdd-integration-tests.yml
+++ b/.github/workflows/bdd-integration-tests.yml
@@ -9,6 +9,11 @@ on:
       - main
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -9,6 +9,11 @@ on:
       - main
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,11 @@ name: Ruff Code Formatter and Linting Check
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,6 @@ permissions:
   contents: read
   pull-requests: read
   checks: write
-  packages: write
 
 jobs:
   tests:
@@ -60,5 +59,7 @@ jobs:
     strategy:
       matrix:
         tag: ["nightly-${{needs.setup_and_check_pub.outputs.date}}", nightly]
+    permissions:
+      packages: write
     with:
       tag: ${{ matrix.tag }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,12 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+  packages: write
+
 jobs:
   tests:
     if: github.repository_owner == 'openwallet-foundation' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -3,6 +3,11 @@ name: PR Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,11 +8,13 @@ on:
       - docs-v*
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/scenario-integration-tests.yml
+++ b/.github/workflows/scenario-integration-tests.yml
@@ -9,6 +9,11 @@ on:
       - main
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sonar-merge-main.yml
+++ b/.github/workflows/sonar-merge-main.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   sonarcloud:
     name: SonarCloud

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -6,6 +6,11 @@ on:
     types: 
       - completed
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 jobs:
   SonarCloud:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempts to resolve the following Token Permission warnings from the OpenSSF Scorecard:
```
Warn: no topLevel permission defined: .github/workflows/bdd-integration-tests.yml:1
Warn: no topLevel permission defined: .github/workflows/bdd-interop-tests.yml:1
Warn: no topLevel permission defined: .github/workflows/format.yml:1
Warn: no topLevel permission defined: .github/workflows/nightly.yml:1
Warn: no topLevel permission defined: .github/workflows/pr-tests.yml:1
Warn: topLevel 'contents' permission set to 'write': .github/workflows/publish-docs.yml:11
Warn: no topLevel permission defined: .github/workflows/scenario-integration-tests.yml:1
Warn: no topLevel permission defined: .github/workflows/sonar-merge-main.yml:1
Warn: no topLevel permission defined: .github/workflows/sonar-pr.yml:1
```
___
Most of them get the following added:
```yml
permissions:
  contents: read
  pull-requests: read
  checks: write
```

and the publish-docs one just moves the write permission from top-level to job-level
___
This aligns with security best practices, to explicitly define the permissions that the workflow needs. It'll hopefully bump the OpenSSF score to ~8.5