### PR TITLE
:bug: Fix permissions in nightly publish job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,6 +60,7 @@ jobs:
       matrix:
         tag: ["nightly-${{needs.setup_and_check_pub.outputs.date}}", nightly]
     permissions:
+      contents: read
       packages: write
     with:
       tag: ${{ matrix.tag }}


### PR DESCRIPTION
After the token permission changes in #3678, the nightly workflow has the following error:
```
The workflow is not valid. .github/workflows/nightly.yml (Line: 54, Col: 3): 
Error calling workflow 'openwallet-foundation/acapy/.github/workflows/publish.yml@4898cce1b28fc619a5c6a2b8126f29f183cac622'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'. .github/workflows/nightly.yml (Line: 54, Col: 3): 
Error calling workflow 'openwallet-foundation/acapy/.github/workflows/publish.yml@4898cce1b28fc619a5c6a2b8126f29f183cac622'. The nested job 'build-image' is requesting 'contents: read', but is only allowed 'contents: none'.
```

This PR adds `contents: read` to the publish job permissions to resolve the issue.
Tested here: https://github.com/didx-xyz/acapy/actions/runs/14680057464