### PR TITLE
:construction_worker: Skip sonar-merge-main workflow if github actor is dependabot

### DIFF
--- a/.github/workflows/sonar-merge-main.yml
+++ b/.github/workflows/sonar-merge-main.yml
@@ -12,7 +12,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
-    if: github.repository == 'openwallet-foundation/acapy'
+    if: github.repository == 'openwallet-foundation/acapy' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
This is because GitHub Actions does not provide repository secrets (such as SONAR_TOKEN) to workflows triggered by dependabot[bot] for security reasons. As a result, the SonarCloud scan step fails when dependabot merges to main (i.e., using `@dependabot squash and merge`, instead of manually merging oneself). By skipping the scan when the actor is dependabot, we avoid unnecessary workflow failures.

Signed-off-by: ff137 <ff137@proton.me>