### PR TITLE
fix: multiuse invite derived conns should have msg id

### DIFF
--- a/acapy_agent/protocols/didexchange/v1_0/manager.py
+++ b/acapy_agent/protocols/didexchange/v1_0/manager.py
@@ -756,6 +756,7 @@ class DIDXManager(BaseConnectionManager):
         """
         new_conn_rec = ConnRecord(
             invitation_key=conn_rec.invitation_key,
+            invitation_msg_id=conn_rec.invitation_msg_id,
             state=ConnRecord.State.INIT.rfc160,
             accept=conn_rec.accept,
             their_role=conn_rec.their_role,

--- a/scenarios/examples/multiuse_invitations/docker-compose.yml
+++ b/scenarios/examples/multiuse_invitations/docker-compose.yml
@@ -1,0 +1,91 @@
+ services:
+  alice:
+    image: acapy-test
+    ports:
+      - "3001:3001"
+    environment:
+      RUST_LOG: 'aries-askar::log::target=error'
+    command: >
+      start
+        --label Alice
+        --inbound-transport http 0.0.0.0 3000
+        --outbound-transport http
+        --endpoint http://alice:3000
+        --admin 0.0.0.0 3001
+        --admin-insecure-mode
+        --tails-server-base-url http://tails:6543
+        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --wallet-type askar
+        --wallet-name alice
+        --wallet-key insecure
+        --auto-provision
+        --log-level debug
+        --debug-webhooks
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      tails:
+        condition: service_started
+
+  bob:
+    image: acapy-test
+    ports:
+      - "3002:3001"
+    environment:
+      RUST_LOG: 'aries-askar::log::target=error'
+    command: >
+      start
+        --label Bob
+        --inbound-transport http 0.0.0.0 3000
+        --outbound-transport http
+        --endpoint http://bob:3000
+        --admin 0.0.0.0 3001
+        --admin-insecure-mode
+        --tails-server-base-url http://tails:6543
+        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --wallet-type askar
+        --wallet-name bob
+        --wallet-key insecure
+        --auto-provision
+        --log-level debug
+        --debug-webhooks
+        --monitor-revocation-notification
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
+      timeout: 5s
+      retries: 5
+
+  tails:
+    image: ghcr.io/bcgov/tails-server:latest
+    ports:
+      - 6543:6543
+    environment:
+      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+    command: >
+      tails-server
+      --host 0.0.0.0
+      --port 6543
+      --storage-path /tmp/tails-files
+      --log-level INFO
+
+  example:
+    container_name: controller
+    build:
+      context: ../..
+    environment:
+      - ALICE=http://alice:3001
+      - BOB=http://bob:3001
+    volumes:
+      - ./example.py:/usr/src/app/example.py:ro,z
+    command: python -m example
+    depends_on:
+      alice:
+        condition: service_healthy
+      bob:
+        condition: service_healthy

--- a/scenarios/examples/multiuse_invitations/example.py
+++ b/scenarios/examples/multiuse_invitations/example.py
@@ -1,0 +1,34 @@
+"""Minimal reproducible example script.
+
+This script is for you to use to reproduce a bug or demonstrate a feature.
+"""
+
+import asyncio
+from os import getenv
+
+from acapy_controller import Controller
+from acapy_controller.logging import logging_to_stdout, section
+from acapy_controller.protocols import didexchange, oob_invitation
+
+ALICE = getenv("ALICE", "http://alice:3001")
+BOB = getenv("BOB", "http://bob:3001")
+
+
+async def main():
+    """Test Controller protocols."""
+    async with Controller(base_url=ALICE) as alice, Controller(base_url=BOB) as bob:
+        invite = await oob_invitation(alice, multi_use=True)
+        with section("first"):
+            a1, _ = await didexchange(alice, bob, invite=invite)
+            a1 = a1.serialize()
+            assert a1["invitation_msg_id"]
+        with section("second"):
+            a2, _ = await didexchange(alice, bob, invite=invite)
+            a2 = a2.serialize()
+            assert a2["invitation_msg_id"]
+            assert a1["invitation_msg_id"] == a2["invitation_msg_id"]
+
+
+if __name__ == "__main__":
+    logging_to_stdout()
+    asyncio.run(main())


### PR DESCRIPTION
The connection completed webhook for connections created from multi-use public invitations (and probably other multi-use configurations) were lacking `invitation_msg_id` for the inviter role. This made it difficult to determine if a connection originated from a particular invitation. For too long, we've relied on the `invitation_key` value, which did happen to be properly populated. But, especially with the move to did:key representations, this became increasingly burdensome in some cases where only the base58 representation of the key was known. Additionally, it meant that different multi-use invitations for the same public DID would be indistinguishable from each other since the key of the DID was used as the invitation key.

I added a scenario to demonstrate the issue.