### PR TITLE
:bug: Fix reading expected key in TAA

### DIFF
--- a/acapy_agent/config/ledger.py
+++ b/acapy_agent/config/ledger.py
@@ -158,7 +158,11 @@ async def ledger_config(
             if taa_info["taa_required"] and public_did:
                 LOGGER.debug("TAA acceptance required")
                 taa_accepted = await ledger.get_latest_txn_author_acceptance()
-                digest_match = taa_info["taa_record"]["digest"] == taa_accepted["digest"]
+
+                taa_record_digest = taa_info["taa_record"]["digest"]  # keys exist
+                taa_accepted_digest = taa_accepted.get("digest")  # key might not exist
+
+                digest_match = taa_record_digest == taa_accepted_digest
                 if not taa_accepted or not digest_match:
                     LOGGER.info("TAA acceptance needed - performing acceptance")
                     if not await accept_taa(ledger, profile, taa_info, provision):

--- a/acapy_agent/ledger/base.py
+++ b/acapy_agent/ledger/base.py
@@ -179,11 +179,11 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         """Fetch the public DID from the wallet."""
 
     @abstractmethod
-    async def get_txn_author_agreement(self, reload: bool = False):
+    async def get_txn_author_agreement(self, reload: bool = False) -> dict:
         """Get the current transaction author agreement, fetching it if necessary."""
 
     @abstractmethod
-    async def fetch_txn_author_agreement(self):
+    async def fetch_txn_author_agreement(self) -> dict:
         """Fetch the current AML and TAA from the ledger."""
 
     @abstractmethod
@@ -193,7 +193,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         """Save a new record recording the acceptance of the TAA."""
 
     @abstractmethod
-    async def get_latest_txn_author_acceptance(self):
+    async def get_latest_txn_author_acceptance(self) -> dict:
         """Look up the latest TAA acceptance."""
 
     def taa_digest(self, version: str, text: str):

--- a/acapy_agent/ledger/indy_vdr.py
+++ b/acapy_agent/ledger/indy_vdr.py
@@ -101,7 +101,7 @@ class IndyVdrLedgerPool:
         self.genesis_hash_cache: Optional[str] = None
         self.genesis_txns_cache = genesis_transactions
         self.init_config = bool(genesis_transactions)
-        self.taa_cache: Optional[str] = None
+        self.taa_cache: Optional[dict] = None
         self.read_only: bool = read_only
         self.socks_proxy: str = socks_proxy
 


### PR DESCRIPTION
The recent refactor (https://github.com/openwallet-foundation/acapy/pull/3664)  modified:

```py
                taa_accepted = await ledger.get_latest_txn_author_acceptance()
                if (
                    not taa_accepted
                    or taa_info["taa_record"]["digest"] != taa_accepted["digest"]
                ):
```
to
```py
                taa_accepted = await ledger.get_latest_txn_author_acceptance()
                digest_match = taa_info["taa_record"]["digest"] == taa_accepted["digest"]
                if not taa_accepted or not digest_match:
```

This had the unintended change of reading "digest" from a potentially empty dict, which was previously prevented with the `if not taa_accepted or ...` clause.

This PR fixes that, by using `.get("digest")` instead.