### PR TITLE
:loud_sound: Improve logging related to public DIDs and routing keys

### DIFF
--- a/acapy_agent/anoncreds/verifier.py
+++ b/acapy_agent/anoncreds/verifier.py
@@ -199,9 +199,11 @@ class AnonCredsVerifier:
                                 f"{uuid}"
                             )
                             LOGGER.info(
-                                f"Timestamp {timestamp} from ledger for item"
-                                f"{uuid} falls outside non-revocation interval "
-                                f"{non_revoc_intervals[uuid]}"
+                                "Timestamp %s from ledger for item %s falls outside "
+                                "non-revocation interval %s",
+                                timestamp,
+                                uuid,
+                                non_revoc_intervals[uuid],
                             )
                 elif uuid in unrevealed_attrs:
                     # nothing to do, attribute value is not revealed
@@ -236,10 +238,12 @@ class AnonCredsVerifier:
                         msgs.append(
                             f"{PresVerifyMsg.TSTMP_OUT_NON_REVOC_INTRVAL.value}::{uuid}"
                         )
-                        LOGGER.warning(
-                            f"Timestamp {timestamp} from ledger for item"
-                            f"{uuid} falls outside non-revocation interval "
-                            f"{non_revoc_intervals[uuid]}"
+                        LOGGER.info(
+                            "Timestamp %s from ledger for item %s falls outside "
+                            "non-revocation interval %s",
+                            timestamp,
+                            uuid,
+                            non_revoc_intervals[uuid],
                         )
 
         for uuid, req_pred in pres_req["requested_predicates"].items():

--- a/acapy_agent/connections/base_manager.py
+++ b/acapy_agent/connections/base_manager.py
@@ -510,7 +510,7 @@ class BaseConnectionManager:
             )
         first_didcomm_service, *_ = didcomm_services
         self._logger.debug(
-            "DIDComm service found for DID %s: %s", did, first_didcomm_service.id
+            "DIDComm service (id %s) found for DID %s", first_didcomm_service.id, did
         )
 
         endpoint = str(first_didcomm_service.service_endpoint)
@@ -518,7 +518,7 @@ class BaseConnectionManager:
             doc, first_didcomm_service
         )
         self._logger.debug(
-            "Recipient and routing keys for DID %s: %s, %s",
+            "DID %s has recipient keys %s and routing keys %s",
             did,
             recipient_keys,
             routing_keys,

--- a/acapy_agent/connections/base_manager.py
+++ b/acapy_agent/connections/base_manager.py
@@ -788,8 +788,8 @@ class BaseConnectionManager:
                         await entry.set_result([row.serialize() for row in targets], 3600)
                     else:
                         self._logger.debug(
-                            "Not caching connection targets for connection in "
-                            f"state ({connection.state})"
+                            "Not caching connection targets for connection in state %s",
+                            connection.state,
                         )
         else:
             if not connection:

--- a/acapy_agent/core/conductor.py
+++ b/acapy_agent/core/conductor.py
@@ -209,9 +209,9 @@ class Conductor:
             self.root_profile, self.setup_public_did and self.setup_public_did.did
         )
         if not ledger_configured:
-            LOGGER.warning("No ledger configured.")
+            LOGGER.info("No ledger configured.")
         else:
-            LOGGER.debug("Ledger configured successfully.")
+            LOGGER.info("Ledger configured successfully.")
 
         if not context.settings.get("transport.disabled"):
             # Register all inbound transports if enabled

--- a/acapy_agent/core/conductor.py
+++ b/acapy_agent/core/conductor.py
@@ -399,7 +399,7 @@ class Conductor:
                     from_version_storage,
                 )
             except StorageNotFoundError:
-                LOGGER.warning("Wallet version storage record not found.")
+                LOGGER.info("Wallet version storage record not found.")
 
         from_version_config = self.root_profile.settings.get("upgrade.from_version")
         force_upgrade_flag = (
@@ -429,12 +429,10 @@ class Conductor:
             LOGGER.debug("Determined from_version: %s", from_version)
 
         if not from_version:
-            LOGGER.warning(
-                (
-                    "No upgrade from version was found from wallet or via"
-                    " --from-version startup argument. Defaulting to %s.",
-                    DEFAULT_ACAPY_VERSION,
-                )
+            LOGGER.info(
+                "No upgrade from version was found from wallet or via"
+                " --from-version startup argument. Defaulting to %s.",
+                DEFAULT_ACAPY_VERSION,
             )
             from_version = DEFAULT_ACAPY_VERSION
             self.root_profile.settings.set_value("upgrade.from_version", from_version)
@@ -872,7 +870,7 @@ class Conductor:
                 storage_type_record = None
 
             if not storage_type_record:
-                LOGGER.warning("Wallet type record not found.")
+                LOGGER.info("Wallet type record not found.")
                 try:
                     acapy_version = await storage.find_record(
                         type_filter=RECORD_TYPE_ACAPY_VERSION, tag_query={}

--- a/acapy_agent/indy/verifier.py
+++ b/acapy_agent/indy/verifier.py
@@ -205,9 +205,11 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
                                 f"{uuid}"
                             )
                             LOGGER.info(
-                                f"Timestamp {timestamp} from ledger for item"
-                                f"{uuid} falls outside non-revocation interval "
-                                f"{non_revoc_intervals[uuid]}"
+                                "Timestamp %s from ledger for item %s falls outside "
+                                "non-revocation interval %s",
+                                timestamp,
+                                uuid,
+                                non_revoc_intervals[uuid],
                             )
                 elif uuid in unrevealed_attrs:
                     # nothing to do, attribute value is not revealed
@@ -242,10 +244,12 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
                         msgs.append(
                             f"{PresVerifyMsg.TSTMP_OUT_NON_REVOC_INTRVAL.value}::{uuid}"
                         )
-                        LOGGER.warning(
-                            f"Timestamp {timestamp} from ledger for item"
-                            f"{uuid} falls outside non-revocation interval "
-                            f"{non_revoc_intervals[uuid]}"
+                        LOGGER.info(
+                            "Timestamp %s from ledger for item %s falls outside "
+                            "non-revocation interval %s",
+                            timestamp,
+                            uuid,
+                            non_revoc_intervals[uuid],
                         )
 
         for uuid, req_pred in pres_req["requested_predicates"].items():

--- a/acapy_agent/multitenant/route_manager.py
+++ b/acapy_agent/multitenant/route_manager.py
@@ -140,18 +140,17 @@ class MultitenantRouteManager(RouteManager):
             "Getting routing info for profile %s", profile.settings.get("wallet.id", "")
         )
         routing_keys = []
+
+        base_mediation_record = await self.get_base_wallet_mediator()
+
         my_endpoint = None
+        if base_mediation_record:
+            routing_keys = base_mediation_record.routing_keys
+            my_endpoint = base_mediation_record.endpoint
 
         if mediation_record:
             routing_keys = [*routing_keys, *mediation_record.routing_keys]
             my_endpoint = mediation_record.endpoint
-        else:
-            base_mediation_record = await self.get_base_wallet_mediator()
-            if base_mediation_record:
-                routing_keys = base_mediation_record.routing_keys
-                my_endpoint = base_mediation_record.endpoint
-            else:
-                LOGGER.debug("No mediator info found")
 
         routing_keys = [normalize_to_did_key(key).key_id for key in routing_keys] or None
 

--- a/acapy_agent/multitenant/route_manager.py
+++ b/acapy_agent/multitenant/route_manager.py
@@ -7,6 +7,7 @@ from ..connections.models.conn_record import ConnRecord
 from ..core.profile import Profile
 from ..messaging.responder import BaseResponder
 from ..protocols.coordinate_mediation.v1_0.manager import MediationManager
+from ..protocols.coordinate_mediation.v1_0.messages.keylist_update import KeylistUpdate
 from ..protocols.coordinate_mediation.v1_0.models.mediation_record import MediationRecord
 from ..protocols.coordinate_mediation.v1_0.normalization import (
     normalize_from_did_key,
@@ -47,7 +48,7 @@ class MultitenantRouteManager(RouteManager):
         *,
         skip_if_exists: bool = False,
         replace_key: Optional[str] = None,
-    ):
+    ) -> Optional[KeylistUpdate]:
         wallet_id = profile.settings["wallet.id"]
         LOGGER.info(
             f"Add route record for recipient {recipient_key} to wallet {wallet_id}"

--- a/acapy_agent/protocols/out_of_band/v1_0/manager.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/manager.py
@@ -731,8 +731,8 @@ class OutOfBandManager(BaseConnectionManager):
                 search_public_did = public_did
 
             LOGGER.debug(
-                "Trying to find existing connection for oob invitation with "
-                f"did {search_public_did}"
+                "Trying to find existing connection for oob invitation with did %s",
+                search_public_did,
             )
 
             async with self._profile.session() as session:
@@ -755,7 +755,7 @@ class OutOfBandManager(BaseConnectionManager):
             )
 
             LOGGER.warning(
-                f"Connection reuse request finished with state {oob_record.state}"
+                "Connection reuse request finished with state %s", oob_record.state
             )
 
             if oob_record.state == OobRecord.STATE_ACCEPTED:
@@ -776,7 +776,7 @@ class OutOfBandManager(BaseConnectionManager):
                 service_accept=service_accept,
             )
             LOGGER.debug(
-                f"Performed handshake with connection {oob_record.connection_id}"
+                "Performed handshake with connection %s", oob_record.connection_id
             )
             # re-fetch connection record
             async with self.profile.session() as session:
@@ -800,8 +800,9 @@ class OutOfBandManager(BaseConnectionManager):
         # Handle any attachments
         if invitation.requests_attach:
             LOGGER.debug(
-                f"Process attached messages for oob exchange {oob_record.oob_id} "
-                f"(connection_id {oob_record.connection_id})"
+                "Process attached messages for oob exchange %s (connection_id %s)",
+                oob_record.oob_id,
+                oob_record.connection_id,
             )
 
             # FIXME: this should ideally be handled using an event handler. Once the
@@ -942,7 +943,7 @@ class OutOfBandManager(BaseConnectionManager):
                     ]:
                         return oob_record
 
-                LOGGER.debug(f"Wait for oob {oob_id} to receive reuse accepted message")
+                LOGGER.debug("Wait for oob %s to receive reuse accepted message", oob_id)
                 event = await await_event
                 LOGGER.debug("Received reuse response message")
                 return OobRecord.deserialize(event.payload)
@@ -966,7 +967,7 @@ class OutOfBandManager(BaseConnectionManager):
             "^acapy::record::connections::(active|completed|response)$"
         )
 
-        LOGGER.debug(f"Wait for connection {connection_id} to become active")
+        LOGGER.debug("Wait for connection %s to become active", connection_id)
 
         async def _wait_for_state() -> ConnRecord:
             event = self.profile.inject(EventBus)
@@ -983,7 +984,7 @@ class OutOfBandManager(BaseConnectionManager):
                     if conn_record.is_ready:
                         return conn_record
 
-                LOGGER.debug(f"Wait for connection {connection_id} to become active")
+                LOGGER.debug("Wait for connection %s to become active", connection_id)
                 # Wait for connection record to be in state
                 event = await await_event
                 return ConnRecord.deserialize(event.payload)
@@ -995,7 +996,7 @@ class OutOfBandManager(BaseConnectionManager):
             )
 
         except asyncio.TimeoutError:
-            LOGGER.warning(f"Connection for connection_id {connection_id} not ready")
+            LOGGER.warning("Connection for connection_id %s not ready", connection_id)
             return None
 
     async def _handle_handshake_reuse(
@@ -1009,8 +1010,10 @@ class OutOfBandManager(BaseConnectionManager):
         # Wait for the reuse accepted message
         oob_record = await self._wait_for_reuse_response(oob_record.oob_id)
         LOGGER.debug(
-            f"Oob reuse for oob id {oob_record.oob_id} with connection "
-            f"{oob_record.connection_id} finished with state {oob_record.state}"
+            "Oob reuse for oob id %s with connection %s finished with state %s",
+            oob_record.oob_id,
+            oob_record.connection_id,
+            oob_record.state,
         )
 
         if oob_record.state != OobRecord.STATE_ACCEPTED:
@@ -1095,9 +1098,9 @@ class OutOfBandManager(BaseConnectionManager):
             )
 
         if public_did:
-            LOGGER.debug(f"Creating connection with public did {public_did}")
+            LOGGER.debug("Creating connection with public did %s", public_did)
         else:
-            LOGGER.debug(f"Creating connection with service {service}")
+            LOGGER.debug("Creating connection with service %s", service)
 
         conn_record = None
         for protocol in supported_handshake_protocols:

--- a/acapy_agent/protocols/routing/v1_0/manager.py
+++ b/acapy_agent/protocols/routing/v1_0/manager.py
@@ -55,20 +55,22 @@ class RoutingManager:
         record = None
         while not record:
             try:
-                LOGGER.info(">>> fetching routing record for verkey: " + recip_verkey)
+                LOGGER.debug("Fetching routing record for verkey: %s", recip_verkey)
                 async with self._profile.session() as session:
                     record = await RouteRecord.retrieve_by_recipient_key(
                         session, recip_verkey
                     )
-                LOGGER.info(">>> FOUND routing record for verkey: " + recip_verkey)
+                LOGGER.info("Found routing record for verkey: %s", recip_verkey)
                 return record
             except StorageDuplicateError:
-                LOGGER.info(">>> DUPLICATE routing record for verkey: " + recip_verkey)
+                LOGGER.info(
+                    "Duplicate routing records found for verkey: %s", recip_verkey
+                )
                 raise RouteNotFoundError(
                     f"More than one route record found with recipient key: {recip_verkey}"
                 )
             except StorageNotFoundError:
-                LOGGER.info(">>> NOT FOUND routing record for verkey: " + recip_verkey)
+                LOGGER.info("No routing record found for verkey: %s", recip_verkey)
                 i += 1
                 if i > RECIP_ROUTE_RETRY:
                     raise RouteNotFoundError(
@@ -142,7 +144,7 @@ class RoutingManager:
             )
         if not recipient_key:
             raise RoutingManagerError("Missing recipient_key")
-        LOGGER.info(">>> creating routing record for verkey: " + recipient_key)
+        LOGGER.debug("Creating routing record for verkey: %s", recipient_key)
         route = RouteRecord(
             connection_id=client_connection_id,
             wallet_id=internal_wallet_id,
@@ -150,5 +152,5 @@ class RoutingManager:
         )
         async with self._profile.session() as session:
             await route.save(session, reason="Created new route")
-        LOGGER.info(">>> CREATED routing record for verkey: " + recipient_key)
+        LOGGER.info("Created routing record for verkey: %s", recipient_key)
         return route

--- a/acapy_agent/protocols/routing/v1_0/manager.py
+++ b/acapy_agent/protocols/routing/v1_0/manager.py
@@ -60,7 +60,7 @@ class RoutingManager:
                     record = await RouteRecord.retrieve_by_recipient_key(
                         session, recip_verkey
                     )
-                LOGGER.info("Found routing record for verkey: %s", recip_verkey)
+                LOGGER.debug("Found routing record for verkey: %s", recip_verkey)
                 return record
             except StorageDuplicateError:
                 LOGGER.info(
@@ -70,7 +70,7 @@ class RoutingManager:
                     f"More than one route record found with recipient key: {recip_verkey}"
                 )
             except StorageNotFoundError:
-                LOGGER.info("No routing record found for verkey: %s", recip_verkey)
+                LOGGER.debug("No routing record found for verkey: %s", recip_verkey)
                 i += 1
                 if i > RECIP_ROUTE_RETRY:
                     raise RouteNotFoundError(

--- a/acapy_agent/resolver/__init__.py
+++ b/acapy_agent/resolver/__init__.py
@@ -42,7 +42,7 @@ async def setup(context: InjectionContext):
         await indy_resolver.setup(context)
         registry.register_resolver(indy_resolver)
     else:
-        LOGGER.warning("Ledger is not configured, not loading IndyDIDResolver")
+        LOGGER.info("Ledger is not configured, not loading IndyDIDResolver")
 
     web_resolver = ClassProvider(
         "acapy_agent.resolver.default.web.WebDIDResolver"

--- a/acapy_agent/wallet/askar.py
+++ b/acapy_agent/wallet/askar.py
@@ -516,9 +516,9 @@ class AskarWallet(BaseWallet):
                     public_info = await self.get_local_did(public_did)
                     LOGGER.debug("Public DID found in wallet: %s", public_did)
                 except WalletNotFoundError:
-                    LOGGER.warning("Public DID not found in wallet")
+                    LOGGER.debug("Public DID not found in wallet: %s", public_did)
             else:
-                LOGGER.warning("Expected did not found in public DID storage record")
+                LOGGER.debug("DID not found in public DID storage record: %s", public_did)
 
         return public_info
 

--- a/acapy_agent/wallet/askar.py
+++ b/acapy_agent/wallet/askar.py
@@ -251,6 +251,13 @@ class AskarWallet(BaseWallet):
             WalletError: If there is another backend error
 
         """
+        LOGGER.debug(
+            "Creating local %s %s DID %s%s",
+            method.method_name,
+            key_type.key_type,
+            did or "",
+            " from seed" if seed else "",
+        )
         did_validation = DIDParametersValidation(self._session.context.inject(DIDMethods))
         did_validation.validate_key_type(method, key_type)
 
@@ -328,6 +335,7 @@ class AskarWallet(BaseWallet):
         Returns:
             The stored `DIDInfo`
         """
+        LOGGER.debug("Storing DID %s", did_info.did)
         try:
             item = await self._session.handle.fetch(
                 CATEGORY_DID, did_info.did, for_update=True
@@ -367,7 +375,7 @@ class AskarWallet(BaseWallet):
             A list of locally stored DIDs as `DIDInfo` instances
 
         """
-
+        LOGGER.debug("Getting local DIDs")
         ret = []
         for item in await self._session.handle.fetch_all(CATEGORY_DID):
             ret.append(self._load_did_entry(item))
@@ -387,7 +395,7 @@ class AskarWallet(BaseWallet):
             WalletError: If there is another backend error
 
         """
-
+        LOGGER.debug("Getting local DID for DID %s", did)
         if not did:
             raise WalletNotFoundError("No identifier provided")
         try:
@@ -411,7 +419,7 @@ class AskarWallet(BaseWallet):
             WalletNotFoundError: If the verkey is not found
 
         """
-
+        LOGGER.debug("Getting local DID for verkey %s", verkey)
         try:
             dids = await self._session.handle.fetch_all(CATEGORY_DID, {"verkey": verkey})
         except AskarError as err:
@@ -437,10 +445,12 @@ class AskarWallet(BaseWallet):
             metadata: The new metadata
 
         """
+        LOGGER.debug("Replacing metadata for DID %s with %s", did, metadata)
 
         try:
             item = await self._session.handle.fetch(CATEGORY_DID, did, for_update=True)
             if not item:
+                LOGGER.warning("DID %s not found when replacing metadata", did)
                 raise WalletNotFoundError("Unknown DID: {}".format(did)) from None
             entry_val = item.value_json
             if entry_val["metadata"] != metadata:
@@ -449,6 +459,7 @@ class AskarWallet(BaseWallet):
                     CATEGORY_DID, did, value_json=entry_val, tags=item.tags
                 )
         except AskarError as err:
+            LOGGER.error("Error updating DID metadata: %s", err)
             raise WalletError("Error updating DID metadata") from err
 
     async def get_public_did(self) -> DIDInfo | None:
@@ -458,6 +469,7 @@ class AskarWallet(BaseWallet):
             The currently public `DIDInfo`, if any
 
         """
+        LOGGER.debug("Retrieving public DID")
         public_did = None
         public_info = None
         public_item = None
@@ -470,15 +482,18 @@ class AskarWallet(BaseWallet):
             # populate public DID record
             # this should only happen once, for an upgraded wallet
             # the 'public' metadata flag is no longer used
+            LOGGER.debug("No %s found, retrieving local DIDs", RECORD_NAME_PUBLIC_DID)
             dids = await self.get_local_dids()
             for info in dids:
                 if info.metadata.get("public"):
                     public_did = info.did
                     public_info = info
+                    LOGGER.debug("Public DID found: %s", public_did)
                     break
             try:
                 # even if public is not set, store a record
                 # to avoid repeated queries
+                LOGGER.debug("Adding %s record", RECORD_NAME_PUBLIC_DID)
                 await storage.add_record(
                     StorageRecord(
                         type=CATEGORY_CONFIG,
@@ -487,17 +502,23 @@ class AskarWallet(BaseWallet):
                     )
                 )
             except StorageDuplicateError:
-                # another process stored the record first
+                LOGGER.debug(
+                    "Another process stored the %s record first", RECORD_NAME_PUBLIC_DID
+                )
                 public_item = await storage.get_record(
                     CATEGORY_CONFIG, RECORD_NAME_PUBLIC_DID
                 )
         if public_item:
+            LOGGER.debug("Public DID storage record found")
             public_did = json.loads(public_item.value)["did"]
             if public_did:
                 try:
                     public_info = await self.get_local_did(public_did)
+                    LOGGER.debug("Public DID found in wallet: %s", public_did)
                 except WalletNotFoundError:
-                    pass
+                    LOGGER.warning("Public DID not found in wallet")
+            else:
+                LOGGER.warning("Expected did not found in public DID storage record")
 
         return public_info
 
@@ -527,6 +548,7 @@ class AskarWallet(BaseWallet):
         if not public or public.did != info.did:
             storage = AskarStorage(self._session)
             if not info.metadata.get("posted"):
+                LOGGER.debug("Setting posted flag for DID %s", info.did)
                 metadata = {**info.metadata, "posted": True}
                 if item:
                     entry_val = item.value_json
@@ -539,6 +561,7 @@ class AskarWallet(BaseWallet):
                 info = info._replace(
                     metadata=metadata,
                 )
+            LOGGER.debug("Updating public DID to %s", info.did)
             await storage.update_record(
                 StorageRecord(
                     type=CATEGORY_CONFIG,
@@ -549,6 +572,8 @@ class AskarWallet(BaseWallet):
                 tags=None,
             )
             public = info
+        else:
+            LOGGER.warning("Public DID is already set to %s", public.did)
 
         return public
 
@@ -585,6 +610,7 @@ class AskarWallet(BaseWallet):
             dict: The attribute definition if write_ledger is False, otherwise None.
 
         """
+        LOGGER.debug("Setting endpoint for DID %s to %s", did, endpoint)
         did_info = await self.get_local_did(did)
         if did_info.method not in (SOV, INDY):
             raise WalletError(
@@ -602,10 +628,12 @@ class AskarWallet(BaseWallet):
         ) or did_info.metadata.get("posted"):
             # if DID on ledger, set endpoint there first
             if not ledger:
+                LOGGER.error("No ledger available but DID %s is public", did)
                 raise LedgerConfigError(
                     f"No ledger available but DID {did} is public: missing wallet-type?"
                 )
             if not ledger.read_only:
+                LOGGER.debug("Updating endpoint for DID %s on ledger", did)
                 async with ledger:
                     attrib_def = await ledger.update_endpoint_for_did(
                         did,

--- a/acapy_agent/wallet/routes.py
+++ b/acapy_agent/wallet/routes.py
@@ -909,7 +909,7 @@ async def promote_wallet_public_did(
 
             if not endorser_info:
                 LOGGER.info(
-                    "Cannot promote DID %s; endorser info not set up in connection metadata",
+                    "Cannot promote %s; endorser info not set up in connection metadata",
                     did,
                 )
                 raise web.HTTPForbidden(


### PR DESCRIPTION
General addition of debug / info / warning / error logs throughout the steps related to promoting public DIDs and routing verkeys, with some improvements to surrounding methods.

Improved logging = happier developers

These logs would've saved me 10 hours of debugging 😅

___
Developer notes (to share some of the thinking behind these changes):
- Any method that does important work should debug/info log when it is entered.
- Log-lines improve readability / reduce complexity (e.g. in if-else blocks), and reduce cognitive load when debugging.
- Don't use `pass`; rather debug-log the intention, so that if/else/exceptions don't pass silently.
- It's good practice to always log in the line before an exception is raised, because sometimes a parent method will silently swallow that exception, and tracing code becomes much harder.
  - Therefore not all exceptions will need error/warning logs, some are just informative.

___
Includes some test coverage, just to resolve the sonarcloud quality gate (thank you GPT 4o)