### PR TITLE
Add websocket outbound debug log

### DIFF
--- a/acapy_agent/transport/inbound/ws.py
+++ b/acapy_agent/transport/inbound/ws.py
@@ -135,6 +135,7 @@ class WsTransport(BaseInboundTransport):
                 if outbound.done() and not ws.closed:
                     # response would be None if session was closed
                     response = outbound.result()
+                    LOGGER.debug("Sending outbound websocket message %s", response)
                     if isinstance(response, bytes):
                         await ws.send_bytes(response)
                     else:

--- a/acapy_agent/transport/outbound/ws.py
+++ b/acapy_agent/transport/outbound/ws.py
@@ -49,6 +49,7 @@ class WsTransport(BaseOutboundTransport):
         """
         # aiohttp should automatically handle websocket sessions
         async with self.client_session.ws_connect(endpoint, headers=metadata) as ws:
+            self.logger.debug("Sending outbound websocket message %s", payload)
             if isinstance(payload, bytes):
                 await ws.send_bytes(payload)
             else:


### PR DESCRIPTION
There was no logging for when the agent is sending outbound websocket messages. This makes it easier to understand when the agent is sending over ws as opposed to http transport.