### PR TITLE
Remove unnecessary hash pinning

### DIFF
--- a/demo/docker-test/db/Dockerfile
+++ b/demo/docker-test/db/Dockerfile
@@ -1,3 +1,3 @@
-FROM  postgres:17@sha256:864831322bf2520e7d03d899b01b542de6de9ece6fe29c89f19dc5e1d5568ccf
+FROM  postgres:17
 COPY ./init-postgres-role.sh /docker-entrypoint-initdb.d/init-postgres-role.sh
 CMD ["docker-entrypoint.sh", "postgres"]

--- a/scenarios/Dockerfile
+++ b/scenarios/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10@sha256:d188cfc2b726fa69a76d1eaebb50a80bc61fa312a4aad6bbda145b0ec77dcf75
+FROM python:3.10
 
 WORKDIR /usr/src/app/
 


### PR DESCRIPTION
Pinning to a hashes version of these docker images isn't necessary and is causing additional dependabot maintenance.