### PR TITLE
Fix broken links in the aca-py.org site / documentation

### DIFF
--- a/LTS-Strategy.md
+++ b/LTS-Strategy.md
@@ -17,7 +17,7 @@ This is one of the factors which motivated setting up the LTS releases which req
 In addition to this, administrators can expect the following of a LTS release:
 
 - Stable and well-tested code
-- A list of supported RFCs and features for each LTS version from this [document](https://github.com/openwallet-foundation/acapy/blob/main/docs/features/SupportedRFCs.md).
+- A list of supported RFCs and features for each LTS version from this [Supported RFCs and features] document.
 - Minimal set of feature additions and other changes that can easily be applied, reducing the risk of functional regressions and bugs
 
 Similarly, there are benefits to ACA-Py maintainers, code contributors, and the wider community:
@@ -26,6 +26,8 @@ Similarly, there are benefits to ACA-Py maintainers, code contributors, and the 
 - Community feedback on new features can be solicited and acted upon.
 - Bug fixes only need to be backported to a small number of designated LTS releases.
 - Extra tests (e.g. upgrade tests for non-subsequent versions) only need to be executed against a small number of designated LTS releases.
+
+[Supported RFCs and features]: docs/features/SupportedRFCs.md
 
 ## ACA-Py LTS Mechanics
 
@@ -51,7 +53,7 @@ When a *new* LTS release is designated, an "end-of-life" date will be set as bei
 
 ### LTS to LTS Compatibility
 
-Features related to ACA-Py capabilities are documented in the [Supported RFCs and features](https://github.com/openwallet-foundation/acapy/blob/main/docs/features/SupportedRFCs.md), in the ACA-Py [ChangeLog](https://github.com/openwallet-foundation/acapy/blob/main/CHANGELOG.md), and in documents updated and added as part of each ACA-Py Release. LTS to LTS compatibility can be determined from reviewing those sources.
+Features related to ACA-Py capabilities are documented in the [Supported RFCs and features], in the ACA-Py [ChangeLog](./CHANGELOG.md), and in documents updated and added as part of each ACA-Py Release. LTS to LTS compatibility can be determined from reviewing those sources.
 
 ### Upgrade Testing
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -123,23 +123,22 @@ Once you have the list of PRs:
    PyPi that the version is published.
 
 11.     New images for the release are automatically published by the GitHubAction
-   Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered
-   when a release is tagged, so no manual action is needed. The images are
-   published in the [OpenWallet Foundation Package Repository under
-   acapy](https://github.com/openwallet-foundation/packages?repo_name=acapy)
-   and a link to the packages added to the repositories main page (under
-   "Packages").
+   Workflow: [publish.yml]. The action is triggered when a release is tagged, so
+   no manual action is needed. Images are published in the [OpenWallet
+   Foundation Package Repository under
+   acapy-agent](https://github.com/openwallet-foundation/acapy/pkgs/container/acapy-agent/versions?filters%5Bversion_type%5D=tagged).
 
    Additional information about the container image publication process can be
    found in the document [Container Images and Github Actions](docs/deploying/ContainerImagesAndGithubActions.md).
 
-   In addition, the published documentation site [https://aca-py.org] should be automatically updated to include the new release via the [publish-docs] GitHub Action.
-   Additional information about that process and some related maintenance activities that are needed from time to time can be found in the [Updating the ACA-Py Documentation Site] document.
+   In addition, the published documentation site [https://aca-py.org] must be
+   updated to include the new release via the [publish-docs] GitHub Action.
+   Additional information about that process and some related maintenance
+   activities that are needed from time to time can be found in the [Managing the ACA-Py Documentation Site] document.
 
 [publish.yml]: https://github.com/openwallet-foundation/acapy/blob/main/.github/workflows/publish.yml
-[publish-indy.yml]: https://github.com/openwallet-foundation/acapy/blob/main/.github/workflows/publish-indy.yml
 
-12.   When a new release is tagged, create a new branch at the same commit with
+1.    When a new release is tagged, create a new branch at the same commit with
     the branch name in the format `docs-v<version>`, for example, `docs-v1.3.0`.
     The creation of the branch triggers the execution of the [publish-docs]
     GitHub Action which generates the documentation for the new release,

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ACA-Py is a foundation for building Verifiable Credential (VC) ecosystems. It op
 
 ACA-Py includes support for the concepts and features that make up [Aries Interop Profile (AIP) 2.0](https://github.com/hyperledger/aries-rfcs/tree/main/concepts/0302-aries-interop-profile#aries-interop-profile-version-20). [ACA-Py’s supported features](./docs/features/SupportedRFCs.md) include, most importantly, protocols for issuing, verifying, and holding verifiable credentials using both [Hyperledger AnonCreds] verifiable credential format, and the [W3C Standard Verifiable Credential Data Model] format using JSON-LD with LD-Signatures and BBS+ Signatures. Coming soon -- issuing and presenting [Hyperledger AnonCreds] verifiable credentials using the [W3C Standard Verifiable Credential Data Model] format.
 
-[Hyperledger AnonCreds]: https://www.hyperledger.org/use/anoncreds
+[Hyperledger AnonCreds]: https://www.lfdecentralizedtrust.org/projects/anoncreds
 [W3C Standard Verifiable Credential Data Model]: https://www.w3.org/TR/vc-data-model/
 
 To use ACA-Py you create a business logic "controller" that talks to an ACA-Py instance (sending HTTP requests and receiving webhook notifications), and ACA-Py handles the various protocols and related functionality. Your controller can be built in any language that supports making and receiving HTTP requests; knowledge of Python is not needed. Together, this means you can focus on building VC solutions using familiar web development technologies, instead of having to learn the nuts and bolts of low-level cryptography and Trust over IP-type protocols.

--- a/docs/demo/ACA-Py-Workshop.md
+++ b/docs/demo/ACA-Py-Workshop.md
@@ -50,7 +50,7 @@ Let’s start by getting your two agents — an Aries Mobile Wallet and an Aries
 ### Lab 1: Steps to Follow
 
 1. Get a compatible Aries Mobile Wallet to use with your Aries Traction tenant. There are a number to choose from.  We suggest that you use one of these:
-    1. [BC Wallet](https://digital.gov.bc.ca/digital-trust/about/about-bc-wallet) from the [Government of British Columbia](https://digital.gov.bc.ca/digital-trust/)
+    1. [BC Wallet](https://digital.gov.bc.ca/design/digital-trust/digital-credentials/bc-wallet/) from the [Government of British Columbia](https://digital.gov.bc.ca/design/digital-trust/)
     2. [Orbit Wallet](https://northernblock.io/orbit-edge-wallet/) from [Northern Block](https://northernblock.io/)
 2. Click this [Traction Sandbox] link to go to the Sandbox login page to create your own Traction Tenant Aries agent. Once there, do the following:
     1. Click "Create Request!", fill in at least the required form fields, and click "Submit".

--- a/docs/demo/AcmeDemoWorkshop.md
+++ b/docs/demo/AcmeDemoWorkshop.md
@@ -3,7 +3,7 @@
 
 In this workshop we will add some functionality to a third participant in the Alice/Faber drama - namely, Acme Inc.  After completing her education at Faber College, Alice is going to apply for a job at Acme Inc.  To do this she must provide proof of education (once she has completed the interview and other non-Indy tasks), and then Acme will issue her an employment credential.
 
-Note that an updated Acme controller is available here: https://github.com/ianco/aries-cloudagent-python/tree/acme_workshop/demo if you just want to skip ahead ...  There is also an alternate solution with some additional functionality available here:  https://github.com/ianco/aries-cloudagent-python/tree/agent_workshop/demo
+Note that an updated Acme controller is available here: [https://github.com/openwallet-foundation/acapy/blob/acme_workshop/demo/runners/acme.py](https://github.com/openwallet-foundation/acapy/blob/acme_workshop/demo/runners/acme.py) if you just want to skip ahead ...
 
 
 ## Preview of the Acme Controller

--- a/docs/demo/Endorser.md
+++ b/docs/demo/Endorser.md
@@ -9,7 +9,7 @@ This approach runs Faber as an un-privileged agent, and starts a dedicated Endor
 Start a VON Network instance and a Tails server:
 
 - Following the [Building and Starting](https://github.com/bcgov/von-network/blob/main/docs/UsingVONNetwork.md#building-and-starting) section of the VON Network Tutorial to get ledger started. You can leave off the `--logs` option if you want to use the same terminal for running both VON Network and the Tails server. When you are finished with VON Network, follow the [Stopping And Removing a VON Network](https://github.com/bcgov/von-network/blob/main/docs/UsingVONNetwork.md#stopping-and-removing-a-von-network) instructions.
-- Run an AnonCreds revocation registry tails server in order to support revocation by following the instructions in the [Alice gets a Phone](https://github.com/openwallet-foundation/acapy/blob/master/demo/AliceGetsAPhone.md#run-an-instance-of-indy-tails-server) demo.
+- Run an AnonCreds revocation registry tails server in order to support revocation by following the instructions in the [Alice gets a Phone](https://github.com/openwallet-foundation/acapy/blob/main/docs/demo/AliceGetsAPhone.md#run-an-instance-of-indy-tails-server) demo.
 
 Start up Faber as Author (note the tails file size override, to allow testing of the revocation registry roll-over):
 
@@ -55,6 +55,6 @@ Then in the Alice shell, select option "D" and copy Faber's DID (it is the DID d
 
 This starts up the ACA-Py agents with the endorser role set (via the new command-line args) and sets up the connection between the 2 agents with appropriate configuration.
 
-Then, in the [Alice swagger page](http://localhost:8031) you can create a schema and cred def, and all the endorser steps will happen automatically.  You don't need to specify a connection id or explicitly request endorsement (ACA-Py does it all automatically based on the startup args).
+Then, on the [Alice swagger page](http://localhost:8031) you can create a schema and cred def, and all the endorser steps will happen automatically.  You don't need to specify a connection id or explicitly request endorsement (ACA-Py does it all automatically based on the startup args).
 
 If you check the endorser transaction records in either [Alice](http://localhost:8031) or [Faber](http://localhost:8021) you can see that the endorser protocol executes automatically and the appropriate endorsements were endorsed before writing the transactions to the ledger.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -120,7 +120,7 @@ docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d -p 5432
 
 #### Optional: Run a von-network ledger browser
 
-If you followed our advice and are using a VON Network instance of Hyperledger Indy, you can ignore this section, as you already have a Ledger browser running, accessible on http://localhost:9000.
+If you followed our advice and are using a VON Network instance of Hyperledger Indy, you can ignore this section, as you already have a Ledger browser running, accessible on `http://localhost:9000`.
 
  If you started the Indy ledger **without** using VON Network, and you want to be able to browse your local ledger as you run the demo, clone the [von-network](https://github.com/bcgov/von-network) repo, go into the root of the cloned instance and run the following command, replacing the `/path/to/local-genesis.txt` with a path to the same genesis file as was used in starting the ledger.
 

--- a/docs/deploying/ContainerImagesAndGithubActions.md
+++ b/docs/deploying/ContainerImagesAndGithubActions.md
@@ -15,7 +15,7 @@ Registry](https://ghcr.io).
 
 ## Image
 
-This project builds and publishes the `ghcr.io/openwallet-foundation/acapy` image.
+This project builds and publishes the `ghcr.io/openwallet-foundation/acapy-agent` image.
 Multiple variants are available; see [Tags](#tags).
 
 ### Tags
@@ -38,12 +38,13 @@ Standard image is outside of the scope of this document.
 The ACA-Py images built by this project are tagged to indicate which of the
 above variants it is. Other tags may also be generated for use by developers.
 
-Below is a table of all generated images and their tags:
+Click [here](https://github.com/openwallet-foundation/acapy/pkgs/container/acapy-agent/versions?filters%5Bversion_type%5D=tagged) to see a current list of the tagged images available for ACA-Py in.
 
-Tag                     | Variant  | Example                  | Description                                                                                     |
-------------------------|----------|--------------------------|-------------------------------------------------------------------------------------------------|
-py3.9-X.Y.Z             | Standard | py3.9-0.7.4              | Standard image variant built on Python 3.9 for ACA-Py version X.Y.Z                             |
-py3.10-X.Y.Z            | Standard | py3.10-0.7.4             | Standard image variant built on Python 3.10 for ACA-Py version X.Y.Z                            |
+The following is the ACA-Py comntainer images tagging format. In each of the following, `pyV.vv` is the base Python image being used (e.g. `py3.12`):
+
+- Regular Releases: `pyV.vv-X.Y.Z` where `X.Y.Z` is the ACA-Py release.  The `Z` component may have an `rcN` appended when the tag is for a Release Candidate.
+- Nightlies: `pyV-vv-nightly-YYYY-MM-DD` and `pyV-vv-nightly`
+- LTS ([Long Term Support](../LTS-Strategy.md)): `pyV-vv-X.Y-lts`, where the `X.Y` are the major and minor components of the LTS (e.g. `0.12`, `1.2`). This tag moves to always be on latest release of each line of LTS releases (e.g. from `0.12.4` to `0.12.5` when the latter is released).
 
 ### Image Comparison
 
@@ -65,15 +66,6 @@ variants and between the BC Gov ACA-Py images.
   - Uses container's system python environment rather than `pyenv`
   - Askar and Indy Shared libraries are installed as dependencies of ACA-Py through pip from pre-compiled binaries included in the python wrappers
   - Built from repo contents
-  - Includes Indy postgres storage plugin
-- `bcgovimages/aries-cloudagent`
-  - (Usually) based on Ubuntu
-  - Based on `von-image`
-  - Default user is `indy`
-  - Includes `libindy` and Indy CLI
-  - Uses `pyenv`
-  - Askar and Indy Shared libraries built from source
-  - Built from ACA-Py python package uploaded to PyPI
   - Includes Indy postgres storage plugin
 
 ## Github Actions

--- a/docs/deploying/UpgradingACA-Py.md
+++ b/docs/deploying/UpgradingACA-Py.md
@@ -130,5 +130,5 @@ capability will ever be needed. We expect to deprecate and remove these
 options in future (post-0.8.1) ACA-Py versions.
 
 [CHANGELOG.md]: https://github.com/openwallet-foundation/acapy/blob/main/CHANGELOG.md
-[version.py]: https://github.com/openwallet-foundation/acapy/blob/main/aries_cloudagent/version.py
+[version.py]: https://github.com/openwallet-foundation/acapy/blob/main/acapy_agent/version.py
 [Upgrade Definition YML file]: https://github.com/openwallet-foundation/acapy/blob/main/acapy_agent/commands/default_version_upgrade_config.yml

--- a/docs/features/DIDResolution.md
+++ b/docs/features/DIDResolution.md
@@ -148,9 +148,12 @@ There are 3 different errors associated with resolution in ACA-Py that could be 
 
 ### Using Resolver Plugins
 
+!!! note
+    This section is out of date, as the GitHub DID Method is no longer registered. The link below to the specification goes to a version of the specification captured by the Internet Wayback Machine. Help in updating this section to use an active DID Method and ACA-Py plugin would be appreciated.
+
 In this section, the [Github Resolver Plugin found here](https://github.com/dbluhm/acapy-resolver-github) will be used as an example plugin to work with. This resolver resolves `did:github` DIDs.
 
-The resolution algorithm is simple: for the github DID `did:github:dbluhm`, the method specific identifier `dbluhm` (a GitHub username) is used to lookup an `index.jsonld` file in the `ghdid` repository in that GitHub users profile. See [GitHub DID Method Specification](http://docs.github-did.com/did-method-spec/) for more details.
+The resolution algorithm is simple: for the github DID `did:github:dbluhm`, the method specific identifier `dbluhm` (a GitHub username) is used to lookup an `index.jsonld` file in the `ghdid` repository in that GitHub users profile. See [GitHub DID Method Specification](https://web.archive.org/web/20220420044252/https://docs.github-did.com/did-method-spec/) for more details.
 
 To use this plugin, first install it into your project's python environment:
 
@@ -191,11 +194,17 @@ docker run --rm -it -p 3000:3000 -p 3001:3001 resolver-example
 
 ### Directory of Resolver Plugins
 
+- [Cheqd](https://plugins.aca-py.org/latest/cheqd/)
+- [Hedera](https://plugins.aca-py.org/latest/hedera/)
+- [did:webvh](https://plugins.aca-py.org/latest/webvh/)
+
+Older resolver plugins:
+
 - [Github Resolver](https://github.com/dbluhm/acapy-resolver-github)
 - [Universal Resolver](https://github.com/sicpa-dlab/acapy-resolver-universal)
 - [DIDComm Resolver](https://github.com/sicpa-dlab/acapy-resolver-didcomm)
 
 ## References
 
-<https://www.w3.org/TR/did-core/>
-<https://w3c-ccg.github.io/did-resolution/>
+- [W3C DID Core Specification](https://www.w3.org/TR/did-core)
+- [W3C DID Resolution Specification](https://www.w3.org/TR/did-resolution/)

--- a/docs/features/JsonLdCredentials.md
+++ b/docs/features/JsonLdCredentials.md
@@ -24,7 +24,7 @@ By design ACA-Py is credential format agnostic. This means you can use it for an
 The rest of this guide assumes some basic understanding of W3C Verifiable Credentials, JSON-LD and Linked Data Proofs. If you're not familiar with some of these concepts, the following resources can help you get started:
 
 - [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model/)
-- [JSON-LD Articles and Presentations](https://json-ld.org/learn.html)
+- [JSON-LD Articles and Presentations](https://json-ld.org/learn/)
 - [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs)
 
 ### BBS+
@@ -33,7 +33,7 @@ BBS+ credentials offer a lot of privacy preserving features over non-ZKP credent
 
 Some other resources that can help you get started with BBS+ credentials:
 
-- [BBS+ Signatures 2020](https://w3c-ccg.github.io/ldp-bbs2020)
+- [BBS+ Signatures](https://w3c.github.io/vc-di-bbs/)
 - [Video: BBS+ Credential Exchange in Hyperledger Aries](https://www.youtube.com/watch?v=LC0OXAir3Qw)
 
 ## Preparing to Issue a Credential
@@ -75,7 +75,7 @@ Before issuing a credential you must determine a signature suite to use. ACA-Py 
 
 - [`Ed25519Signature2018`](https://w3c-ccg.github.io/lds-ed25519-2018/) - Very well supported. No zero knowledge proofs or selective disclosure.
 - [`Ed25519Signature2020`](https://w3c.github.io/vc-di-eddsa/#ed25519signature2020-0) - Updated version of 2018 suite.
-- [`BbsBlsSignature2020`](https://w3c-ccg.github.io/ldp-bbs2020/) - Newer, but supports zero knowledge proofs and selective disclosure.
+- [`BbsBlsSignature2020`](https://w3c.github.io/vc-di-bbs/) - Newer, but supports zero knowledge proofs and selective disclosure.
 
 Generally you should always use `BbsBlsSignature2020` as it allows the holder to derive a new credential during the proving, meaning it doesn't have to disclose all fields and doesn't have to reveal the signature.
 
@@ -92,7 +92,7 @@ When using `did:sov` you need to make sure to use a public did so other agents c
 
 #### `did:key`
 
-A `did:key` did is not anchored to a ledger, but embeds the key directly in the identifier part of the did. See the [did:key Method Specification](https://w3c-ccg.github.io/did-method-key/) for more information.
+A `did:key` did is not anchored to a ledger, but embeds the key directly in the identifier part of the did. See the [did:key Method Specification](https://w3c-ccg.github.io/did-key-spec/) for more information.
 
 You can create a `did:key` using the `/wallet/did/create` endpoint with the following body. Use `ed25519` for `Ed25519Signature2018`, `bls12381g2` for `BbsBlsSignature2020`.
 

--- a/docs/features/SupportedRFCs.md
+++ b/docs/features/SupportedRFCs.md
@@ -32,7 +32,7 @@ A summary of the Aries Interop Profiles and Aries RFCs supported in ACA-Py can b
 | ---------- | :----------------: | -------------------------------------------------------------------------------------------------------------------------- |
 | Server     | :white_check_mark: |                                                                                                                            |
 | Kubernetes | :white_check_mark: | BC Gov has extensive experience running ACA-Py on Red Hat's OpenShift Kubernetes Distribution.                             |
-| Docker     | :white_check_mark: | Official docker images are published to the GitHub  container repository at [https://ghcr.io/openwallet-foundation/acapy](https://ghcr.io/openwallet-foundation/acapy). |
+| Docker     | :white_check_mark: | Official docker images are published to the GitHub  container repository at [https://github.com/openwallet-foundation/acapy/pkgs/container/acapy-agent](https://github.com/openwallet-foundation/acapy/pkgs/container/acapy-agent). |
 | Desktop    |     :warning:      | Could be run as a local service on the computer                                                                            |
 | iOS        |        :x:         |                                                                                                                            |
 | Android    |        :x:         |                                                                                                                            |
@@ -69,7 +69,7 @@ A summary of the Aries Interop Profiles and Aries RFCs supported in ACA-Py can b
 | `did:web` | :white_check_mark: | Resolution only |
 | `did:key` | :white_check_mark: | |
 | `did:peer` | :white_check_mark:| Algorithms `2`/`3` and `4` |
-| Universal Resolver | :white_check_mark: | A [plug in](https://github.com/sicpa-dlab/acapy-resolver-universal) from [SICPA](https://www.sicpa.com/) is available that can be added to an ACA-Py installation to support a [universal resolver](https://dev.uniresolver.io/) capability, providing support for most DID methods in the [W3C DID Method Registry](https://w3c.github.io/did-spec-registries/#did-methods). |
+| Universal Resolver | :white_check_mark: | A [plug in](https://github.com/sicpa-dlab/acapy-resolver-universal) from [SICPA](https://www.sicpa.com/) is available that can be added to an ACA-Py installation to support a [universal resolver](https://dev.uniresolver.io/) capability, providing support for most DID methods in the [W3C DID Method Registry](https://www.w3.org/TR/did-extensions-methods/). |
 
 ## Secure Storage Types
 
@@ -94,7 +94,7 @@ A summary of the Aries Interop Profiles and Aries RFCs supported in ACA-Py can b
 | Invitations using peer dids supporting connection reuse     | :white_check_mark:        |         |
 | Implicit pickup of messages in role of mediator | :white_check_mark:        |         |
 | [Revocable AnonCreds Credentials](https://github.com/hyperledger/indy-hipe/tree/main/text/0011-cred-revocation) | :white_check_mark:        |         |
-| Multi-Tenancy      | :white_check_mark:        | [Documentation](https://github.com/openwallet-foundation/acapy/blob/main/Multitenancy.md) |
+| Multi-Tenancy      | :white_check_mark:        | [Multi-tenant Documentation] |
 | Multi-Tenant Management | :white_check_mark: | The [Traction] open source project from BC Gov is a layer on top of ACA-Py that enables the easy management of ACA-Py tenants, with an Administrative UI ("The Innkeeper") and a Tenant UI for using ACA-Py in a web UI (setting up, issuing, holding and verifying credentials) |
 | Connection-less (non OOB protocol / AIP 1.0)               | :white_check_mark:        | Only for issue credential and present proof          |
 | Connection-less (OOB protocol / AIP 2.0)               | :white_check_mark:        | Only for present proof          |
@@ -104,6 +104,7 @@ A summary of the Aries Interop Profiles and Aries RFCs supported in ACA-Py can b
 | Storage Import & Export           | :warning:        | Supported by directly interacting with the Aries Askar (e.g., no Admin API endpoint available for wallet import & export). Aries Askar support includes the ability to import storage exported from the Indy SDK's "indy-wallet" component. Documentation for migrating from Indy SDK storage to Askar can be found in the [Indy SDK to Askar Migration Guide].|
 | SD-JWTs | :white_check_mark: | Signing and verifying SD-JWTs is supported |
 
+[Multi-tenant Documentation]: ./Multitenancy.md
 [ACA-Py Plugins]: https://plugins.aca-py.org
 [Indy SDK to Askar Migration Guide]: ../deploying/IndySDKtoAskarMigration.md
 [Traction]: https://github.com/bcgov/traction

--- a/docs/features/devcontainer.md
+++ b/docs/features/devcontainer.md
@@ -140,27 +140,27 @@ For all the agents if you don't want to support revocation you need to remove or
 
 ### Faber
 
-- admin api url = http://localhost:9041
+- admin api url = `http://localhost:9041`
 - study the demo to understand the steps to have the agent in the correct state. Make your public dids and schemas, cred-defs, etc.
 
 ### Alice
 
-- admin api url = http://localhost:9011
+- admin api url = `http://localhost:9011`
 - study the demo to get a connection with faber
 
 ### Endorser
 
-- admin api url = http://localhost:9031
+- admin api url = `http://localhost:9031`
 - This config is useful if you want to develop in an environment that requires endorsement. You can run the demo with `./run_demo faber --endorser-role author` to see all the steps to become and endorser.
 
 ### Author
 
-- admin api url = http://localhost:9021
+- admin api url = `http://localhost:9021`
 - This config is useful if you want to develop in an environment that requires endorsement. You can run the demo with `./run_demo faber --endorser-role author` to see all the steps to become and author. You need to uncomment the configurations for automating the connection to endorser.
 
 ### Multitenant-Admin
 
-- admin api url = http://localhost:9051
+- admin api url = `http://localhost:9051`
 - This is for a multitenant environment where you can create multiple tenants with subwallets with one agent. See [Multitenancy](./Multitenancy.md)
 
 ### Try running Faber and Alice at the same time and add break points and recreate the demo
@@ -169,7 +169,7 @@ To run your ACA-Py code in debug mode, go to the `Run and Debug` view, select th
 
 This will start your source code as a running ACA-Py instance, all configuration is in the `*.yml` files. This is just a sample of a configuration. Note that we are not using a database and are joining to a local VON Network (by default, it would be `http://localhost:9000`). You could change this or another ledger such as `http://test.bcovrin.vonx.io`. These are purposefully, very simple configurations.
 
-For example, open `acapy_agent/admin/server.py` and set a breakpoint in `async def status_handler(self, request: web.BaseRequest):`, then call [`GET /status`](http://localhost:9061/api/doc#/server/get_status) in the Admin Console and hit your breakpoint.
+For example, open `acapy_agent/admin/server.py` and set a breakpoint in `async def status_handler(self, request: web.BaseRequest):`, then call `GET /status` at `http://localhost:9061/api/doc#/server/get_status` in the Admin Console and hit your breakpoint.
 
 ## Pytest
 

--- a/docs/gettingStarted/IndyBasics.md
+++ b/docs/gettingStarted/IndyBasics.md
@@ -2,7 +2,7 @@
 
 > **NOTE:** If you are developer building apps on top of ACA-Py and Indy, you **DO NOT** need to know the nuts and bolts of Indy to build applications. You need to know about verifiable credentials and the concepts of self-sovereign identity. But as an app developer, you don't need to do the Indy getting started pieces. ACA-Py takes care of those details for you. The introduction linked here should be sufficient.
 
-If you are new to Indy and verifiable credentials and want to learn the core concepts, this [link](https://github.com/hyperledger/education/blob/master/LFS171x/docs/introduction-to-hyperledger-indy.md) provides a solid foundation into the goals and purpose of Indy including verifiable credentials, DIDs, decentralized/self-sovereign identity, the Sovrin Foundation and more. The document is the content of the Indy chapter of the Hyperledger edX [Blockchain for Business](https://www.edx.org/course/blockchain-for-business-an-introduction-to-hyperledger-technologies) course (which you could also go through).
+If you are new to Indy and verifiable credentials and want to learn the core concepts, this [link](https://github.com/hyperledger-archives/education/blob/master/LFS171x/docs/introduction-to-hyperledger-indy.md) provides a solid foundation into the goals and purpose of Indy including verifiable credentials, DIDs, decentralized/self-sovereign identity, the Sovrin Foundation and more.
 
 Feel free to do the demo that is referenced in the material, but we recommend that you **not** dig into that codebase. It's pretty old now - year old!  We've got much more relevant examples later in this guide.
 

--- a/docs/testing/Logging.md
+++ b/docs/testing/Logging.md
@@ -21,9 +21,9 @@ Supports writing of log messages to a file with `wallet_id` as the tenant identi
 Example:
 
 ```sh
-./bin/aca-py start --log-level debug --log-file acapy.log --log-config acapy_agent.config:default_per_tenant_logging_config.ini
+./bin/aca-py start --log-level debug --log-file acapy.log --log-config acapy_agent.config:default_multitenant_logging_config.ini
 
-./bin/aca-py start --log-level debug --log-file --multitenant --log-config ./acapy_agent/config/default_per_tenant_logging_config.yml
+./bin/aca-py start --log-level debug --log-file --multitenant --log-config ./acapy_agent/config/default_multitenant_logging_config.yml
 ```
 
 ## Environment Variables
@@ -56,11 +56,11 @@ Also if log-level is set to WARNING, connections and presentations will be logge
 
 The path to config file is provided via `--log-config`.
 
-Find an example in [default_logging_config.ini](https://github.com/openwallet-foundation/acapy/tree/main/acapy_agent/config/default_logging_config.ini).
+Find an example in [default_logging_config.ini](https://github.com/openwallet-foundation/acapy/tree/main/acapy_agent/config/logging/default_logging_config.ini).
 
 You can find more detail description in the [logging documentation](https://docs.python.org/3/howto/logging.html#configuring-logging).
 
-For per tenant logging, find an example in [default_per_tenant_logging_config.ini](https://github.com/openwallet-foundation/acapy/tree/main/acapy_agent/config/default_per_tenant_logging_config.ini), which sets up `TimedRotatingFileMultiProcessHandler` and `StreamHandler` handlers. Custom `TimedRotatingFileMultiProcessHandler` handler supports the ability to cleanup logs by time and maintain backup logs and a custom JSON formatter for logs. The arguments for it such as `file name`, `when`, `interval` and `backupCount` can be passed as `args=('acapy.log', 'd', 7, 1,)` (also shown below). Note: `backupCount` of 0 will mean all backup log files will be retained and not deleted at all. More details about these attributes can be found [here](https://docs.python.org/3/library/logging.handlers.html#timedrotatingfilehandler)
+For per tenant logging, find an example in [default_multitenant_logging_config.ini](https://github.com/openwallet-foundation/acapy/tree/main/acapy_agent/config/logging/default_multitenant_logging_config.ini), which sets up `TimedRotatingFileMultiProcessHandler` and `StreamHandler` handlers. Custom `TimedRotatingFileMultiProcessHandler` handler supports the ability to cleanup logs by time and maintain backup logs and a custom JSON formatter for logs. The arguments for it such as `file name`, `when`, `interval` and `backupCount` can be passed as `args=('acapy.log', 'd', 7, 1,)` (also shown below). Note: `backupCount` of 0 will mean all backup log files will be retained and not deleted at all. More details about these attributes can be found [here](https://docs.python.org/3/library/logging.handlers.html#timedrotatingfilehandler)
 
 ```ini
 [loggers]
@@ -92,7 +92,7 @@ args=('acapy.log', 'd', 7, 1,)
 format=%(asctime)s %(wallet_id)s %(levelname)s %(pathname)s:%(lineno)d %(message)s
 ```
 
-For `DictConfig` (`dict` logging config file), find an example in [default_per_tenant_logging_config.yml](https://github.com/openwallet-foundation/acapy/tree/main/aries_cloudagent/config/default_per_tenant_logging_config.yml) with same attributes as `default_per_tenant_logging_config.ini` file.
+For `DictConfig` (`dict` logging config file), find an example in [default_multitenant_logging_config.yml](https://github.com/openwallet-foundation/acapy/blob/main/acapy_agent/config/logging/default_multitenant_logging_config.yml) with same attributes as `default_multitenant_logging_config.ini` file.
 
 ```yaml
 version: 1


### PR DESCRIPTION
in addressing #3741, I ran a link checker over [https://aca-py.org](https://aca-py.org) and got a list of all broken links. This PR fixes the vast majority.

Notes:

- The Security and Code of Conduct files were not changed -- I'm leaving that to another PR.
- In some places in the demo/tutorial files, I left in `localhost` links that are helpful when running the demos.
- A few old specs were removed and I either removed the reference or found a suitable alternative. For example the Linked Data Proof BBS2020 is no longer available, so I used the Data Integrity BBS Cryptosuite spec instead.
- I ignored the warnings on this pass -- most notably to the Aries RFCs. Again -- a follow up PR will address that issue.
- I'll take another pass after this PR is merged to verify all.
- For the link highlighted in #3741 that goes to a completely unrelated website, I decided to keep the link as still (somewhat useful) and used the Internet Wayback Machine to get the desired content.  That document (DID Resolution) could use an update with modern examples using published plugins.


