### PR TITLE
Remove  header from http/ws responses

### DIFF
--- a/acapy_agent/admin/server.py
+++ b/acapy_agent/admin/server.py
@@ -30,6 +30,7 @@ from ..transport.outbound.status import OutboundSendStatus
 from ..transport.queue.basic import BasicMessageQueue
 from ..utils import general as general_utils
 from ..utils.extract_validation_error import extract_validation_error_message
+from ..utils.server import remove_unwanted_headers
 from ..utils.stats import Collector
 from ..utils.task_queue import TaskQueue
 from ..version import __version__
@@ -389,6 +390,8 @@ class AdminServer(BaseAdminServer):
             web.get("/ws", self.websocket_handler, allow_head=False),
         ]
         app.add_routes(server_routes)
+
+        app.on_response_prepare.append(remove_unwanted_headers)
 
         plugin_registry = self.context.inject_or(PluginRegistry)
         if plugin_registry:

--- a/acapy_agent/admin/tests/test_admin_server.py
+++ b/acapy_agent/admin/tests/test_admin_server.py
@@ -536,6 +536,20 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             assert response.status == 503
         await server.stop()
 
+    async def test_server_aiohttp_headers_removed(self):
+        settings = {
+            "admin.admin_insecure_mode": True,
+        }
+        server = await self.get_admin_server(settings)
+        await server.start()
+
+        async with self.client_session.get(
+            f"http://127.0.0.1:{self.port}/status/live", headers={}
+        ) as response:
+            assert response.headers.get("Server") is None
+
+        await server.stop()
+
     async def test_upgrade_middleware(self):
         profile = await create_test_profile()
         self.context = AdminRequestContext.test_context({}, profile)

--- a/acapy_agent/transport/inbound/http.py
+++ b/acapy_agent/transport/inbound/http.py
@@ -5,6 +5,7 @@ import logging
 from aiohttp import web
 
 from ...messaging.error import MessageParseError
+from ...utils.server import remove_unwanted_headers
 from ..error import WireFormatParseError
 from ..wire_format import DIDCOMM_V0_MIME_TYPE, DIDCOMM_V1_MIME_TYPE
 from .base import BaseInboundTransport, InboundTransportSetupError
@@ -38,6 +39,7 @@ class HttpTransport(BaseInboundTransport):
         app = web.Application(**app_args)
         app.add_routes([web.get("/", self.invite_message_handler)])
         app.add_routes([web.post("/", self.inbound_message_handler)])
+        app.on_response_prepare.append(remove_unwanted_headers)
         return app
 
     async def start(self) -> None:

--- a/acapy_agent/transport/inbound/tests/test_http_transport.py
+++ b/acapy_agent/transport/inbound/tests/test_http_transport.py
@@ -106,6 +106,8 @@ class TestHttpTransport(AioHTTPTestCase):
 
         async with self.client.post("/", json=test_message) as resp:
             assert await resp.json() == {"response": "ok"}
+            # Assert that Server header is cleared
+            assert resp.headers.get("Server") is None
 
         await self.transport.stop()
 

--- a/acapy_agent/transport/inbound/tests/test_ws_transport.py
+++ b/acapy_agent/transport/inbound/tests/test_ws_transport.py
@@ -101,4 +101,7 @@ class TestWsTransport(AioHTTPTestCase):
             result = await asyncio.wait_for(ws.receive_json(), 1.0)
             assert result == {"response": "ok"}
 
+            # Check the Server header is removed
+            assert "Server" not in ws._response.headers
+
         await self.transport.stop()

--- a/acapy_agent/transport/inbound/ws.py
+++ b/acapy_agent/transport/inbound/ws.py
@@ -7,6 +7,7 @@ from typing import Optional
 from aiohttp import WSMessage, WSMsgType, web
 
 from ...messaging.error import MessageParseError
+from ...utils.server import remove_unwanted_headers
 from ..error import WireFormatParseError
 from .base import BaseInboundTransport, InboundTransportSetupError
 
@@ -48,6 +49,7 @@ class WsTransport(BaseInboundTransport):
         """Construct the aiohttp application."""
         app = web.Application()
         app.add_routes([web.get("/", self.inbound_message_handler)])
+        app.on_response_prepare.append(remove_unwanted_headers)
         return app
 
     async def start(self) -> None:

--- a/acapy_agent/utils/server.py
+++ b/acapy_agent/utils/server.py
@@ -1,0 +1,9 @@
+"""Utility functions for server operations in an AcaPy agent."""
+
+
+async def remove_unwanted_headers(
+    request,
+    response,
+) -> None:
+    """Remove unwanted headers from the response."""
+    response.headers.pop("Server", None)


### PR DESCRIPTION
This removes the `Server` header from http/ws responses. `Server` is where the python and aiohttp are automatically added by aiohttp library.

To remain in accordance with HTTP specification we could instead override it with a custom name (https://datatracker.ietf.org/doc/html/rfc9110#name-server).

NOTE: 
 - This does not effect requests. When the agent initiates a request it has a `User-Agent` header which also contains the python and aiohttp version. I'm not sure if we'll need to remove this info as well. `User-Agent` is important from some interactions but probably not for a acapy agent. We'd need to make sure to only remove the correct info. 