### PR TITLE
Add recreate lts workflow to 0.12.lts branch

### DIFF
--- a/.github/workflows/tag-recreate-lts.yml
+++ b/.github/workflows/tag-recreate-lts.yml
@@ -1,0 +1,81 @@
+# This Action will run when a release is published from the LTS branches 
+# and create new LTS tag, release and publish the image in GHCR
+
+name: Tag and Recreate LTS Release
+
+on:
+  release:
+    types: [published]
+      
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  recreate-lts-release:
+    if: startsWith(github.event.release.tag_name, '0.12.')
+    name: Recreate LTS Release
+    runs-on: ubuntu-latest
+    outputs:
+      lts_tag: ${{ steps.vars.outputs.LTS_TAG }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git identity
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Determine LTS tag and update
+        id: vars
+        env:
+          BRANCH_REF: ${{ github.event.release.target_commitish }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          echo "Release published from branch: $BRANCH_REF"
+
+          # Creating a LTS tag from the branch name
+          SHORT_TAG=$(echo "$RELEASE_TAG" | cut -d. -f1,2)
+          LTS_TAG="${SHORT_TAG}-lts"
+          echo "LTS_TAG=$LTS_TAG" >> "$GITHUB_OUTPUT"
+
+          # Force update the tag to the current commit
+          git tag -f "$LTS_TAG" $GITHUB_SHA
+          git push origin -f "$LTS_TAG" 
+
+          # Write release notes into env (for multiline input)
+          echo "RELEASE_BODY<<EOF" >> "$GITHUB_ENV"
+          echo "${RELEASE_BODY}" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
+      - name: Delete existing LTS release (if any)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LTS_TAG: ${{ steps.vars.outputs.LTS_TAG }}
+        run: |
+          echo "Trying to delete existing release for $LTS_TAG"
+          gh release delete "$LTS_TAG" -y
+
+      - name: Create fresh LTS release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LTS_TAG: ${{ steps.vars.outputs.LTS_TAG }}
+          RELEASE_BODY: ${{ env.RELEASE_BODY }}
+        run: |
+          echo "Creating new GitHub release for $LTS_TAG"
+          gh release create "$LTS_TAG" --title "$LTS_TAG" --notes "$RELEASE_BODY"
+  
+  call-publish-image:
+    name: Publish LTS Image in GHCR
+    needs: recreate-lts-release
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.recreate-lts-release.outputs.lts_tag }}
+      ref: ${{ github.event.release.tag_name }}
+      platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
After studying this further and doing some testing. The workflow needs to be added to the lts branches because it needs to be available for the released tag. Then for main which isn't LTS yet it will need to skip this workflow.

When a new LTS is created it will need to add the if condition with the major versions to the initial commit of the LTS. 

This doesn't work for pypi packages. Deployments using the package will need to use standard python versioning management. 