### PR TITLE
:test_tube: Skip tests with jsonld url resolution failures

### DIFF
--- a/acapy_agent/messaging/jsonld/tests/test_credential.py
+++ b/acapy_agent/messaging/jsonld/tests/test_credential.py
@@ -3,7 +3,7 @@
 import json
 from unittest import IsolatedAsyncioTestCase
 
-from ....utils.testing import create_test_profile
+from ....utils.testing import create_test_profile, skip_on_jsonld_url_error
 from ....wallet.base import BaseWallet
 from ....wallet.key_type import ED25519
 from .. import credential as test_module
@@ -52,6 +52,7 @@ class TestOps(IsolatedAsyncioTestCase):
             self.wallet = session.inject(BaseWallet)
             await self.wallet.create_signing_key(ED25519, TEST_SEED)
 
+    @skip_on_jsonld_url_error
     async def test_verify_credential(self):
         async with self.profile.session() as session:
             for input_ in TEST_VERIFY_OBJS:
@@ -73,6 +74,7 @@ class TestOps(IsolatedAsyncioTestCase):
                 assert "proof" in result.keys()
                 assert "jws" in result.get("proof", {}).keys()
 
+    @skip_on_jsonld_url_error
     async def test_sign_dropped_attribute_exception(self):
         async with self.profile.session() as session:
             for input_ in TEST_SIGN_ERROR_OBJS:

--- a/acapy_agent/messaging/jsonld/tests/test_credential.py
+++ b/acapy_agent/messaging/jsonld/tests/test_credential.py
@@ -99,6 +99,7 @@ class TestOps(IsolatedAsyncioTestCase):
                         TEST_VERKEY,
                     )
 
+    @skip_on_jsonld_url_error
     async def test_invalid_jws_header(self):
         with self.assertRaises(BadJWSHeaderError):
             async with self.profile.session() as session:

--- a/acapy_agent/messaging/jsonld/tests/test_routes.py
+++ b/acapy_agent/messaging/jsonld/tests/test_routes.py
@@ -12,7 +12,7 @@ from ....config.base import InjectionError
 from ....resolver.base import DIDMethodNotSupported, DIDNotFound, ResolverError
 from ....resolver.did_resolver import DIDResolver
 from ....tests import mock
-from ....utils.testing import create_test_profile
+from ....utils.testing import create_test_profile, skip_on_jsonld_url_error
 from ....wallet.base import BaseWallet
 from ....wallet.did_method import SOV, DIDMethods
 from ....wallet.error import WalletError
@@ -308,6 +308,7 @@ class TestJSONLDRoutes(IsolatedAsyncioTestCase):
         # Ensure the event loop is closed
         await self.profile.close()
 
+    @skip_on_jsonld_url_error
     async def test_verify_credential(self):
         POSTED_REQUEST = {  # posted json
             "verkey": (
@@ -439,6 +440,7 @@ class TestJSONLDRoutes(IsolatedAsyncioTestCase):
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.verify(self.request)
 
+    @skip_on_jsonld_url_error
     async def test_sign_credential(self):
         POSTED_REQUEST = {  # posted json
             "verkey": self.did_info.verkey,

--- a/acapy_agent/messaging/v2_agent_message.py
+++ b/acapy_agent/messaging/v2_agent_message.py
@@ -1,6 +1,6 @@
 """DIDComm V2 Agent message base class and schema."""
 
-from uuid import uuid4
+from uuid_utils import uuid4
 
 from .base_message import BaseMessage, DIDCommVersion
 

--- a/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -11,7 +11,7 @@ from .....resolver.default.key import KeyDIDResolver
 from .....resolver.did_resolver import DIDResolver
 from .....storage.vc_holder.vc_record import VCRecord
 from .....tests import mock
-from .....utils.testing import create_test_profile
+from .....utils.testing import create_test_profile, skip_on_jsonld_url_error
 from .....vc.ld_proofs import BbsBlsSignature2020
 from .....vc.ld_proofs.constants import SECURITY_CONTEXT_BBS_URL
 from .....vc.ld_proofs.document_loader import DocumentLoader
@@ -82,6 +82,7 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
             creds, pds = get_test_data()
             return creds, pds
 
+    @skip_on_jsonld_url_error
     async def test_load_cred_json_a(self):
         cred_list, pd_list = await self.setup_tuple(self.profile)
         dif_pres_exch_handler = DIFPresExchHandler(self.profile)
@@ -103,6 +104,7 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
                 assert len(tmp_vp.get("verifiableCredential")) == tmp_pd[1]
 
     @pytest.mark.ursa_bbs_signatures
+    @skip_on_jsonld_url_error
     async def test_load_cred_json_b(self):
         cred_list, pd_list = await self.setup_tuple(self.profile)
         dif_pres_exch_handler = DIFPresExchHandler(
@@ -346,6 +348,7 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
             )
 
     @pytest.mark.ursa_bbs_signatures
+    @skip_on_jsonld_url_error
     async def test_subject_is_issuer_check(self):
         cred_list, _ = await self.setup_tuple(self.profile)
         dif_pres_exch_handler = DIFPresExchHandler(self.profile)
@@ -1246,6 +1249,7 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
         assert len(tmp_vp.get("verifiableCredential")) == 3
 
     @pytest.mark.ursa_bbs_signatures
+    @skip_on_jsonld_url_error
     async def test_filter_string(self):
         cred_list, _ = await self.setup_tuple(self.profile)
         dif_pres_exch_handler = DIFPresExchHandler(self.profile)
@@ -1864,6 +1868,7 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
         )
         assert len(tmp_vp.get("verifiableCredential")) == 6
 
+    @skip_on_jsonld_url_error
     def test_create_vc_record_with_graph_struct(self):
         dif_pres_exch_handler = DIFPresExchHandler(self.profile)
         test_credential_dict_a = {
@@ -2639,6 +2644,7 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
         )
 
     @pytest.mark.ursa_bbs_signatures
+    @skip_on_jsonld_url_error
     async def test_derive_cred_missing_credsubjectid(self):
         dif_pres_exch_handler = DIFPresExchHandler(self.profile)
         test_pd = """

--- a/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -715,6 +715,7 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
         assert tmp_reveal_doc
 
     @pytest.mark.ursa_bbs_signatures
+    @skip_on_jsonld_url_error
     async def test_filter_number_type_check(self):
         await self.setup_tuple(self.profile)
         dif_pres_exch_handler = DIFPresExchHandler(self.profile)

--- a/acapy_agent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -10,7 +10,7 @@ from .......resolver.did_resolver import DIDResolver
 from .......storage.vc_holder.base import VCHolder
 from .......storage.vc_holder.vc_record import VCRecord
 from .......tests import mock
-from .......utils.testing import create_test_profile
+from .......utils.testing import create_test_profile, skip_on_jsonld_url_error
 from .......vc.ld_proofs import DocumentLoader
 from .......vc.vc_di.manager import VcDiManager
 from .......vc.vc_ld.manager import VcLdpManager
@@ -2025,6 +2025,7 @@ class TestDIFFormatHandler(IsolatedAsyncioTestCase):
             await self.handler.receive_pres(message=dif_pres, pres_ex_record=record)
             mock_log_err.assert_called_once()
 
+    @skip_on_jsonld_url_error
     async def test_verify_received_pres_no_match_b(self):
         dif_proof_req = deepcopy(DIF_PRES_REQUEST_B)
         dif_proof_req["presentation_definition"]["input_descriptors"][0]["constraints"][
@@ -2128,6 +2129,7 @@ class TestDIFFormatHandler(IsolatedAsyncioTestCase):
             await self.handler.receive_pres(message=dif_pres, pres_ex_record=record)
             mock_log_err.assert_called_once()
 
+    @skip_on_jsonld_url_error
     async def test_verify_received_pres_limit_disclosure_fail_b(self):
         dif_proof = deepcopy(DIF_PRES)
         dif_proof["verifiableCredential"][0]["credentialSubject"]["test"] = "Test"

--- a/acapy_agent/utils/testing.py
+++ b/acapy_agent/utils/testing.py
@@ -1,6 +1,11 @@
 """Utilities for testing."""
 
+import functools
+import inspect
 from typing import Optional
+
+import pytest
+from pyld.jsonld import JsonLdError
 from uuid import uuid4
 
 from ..askar.profile import AskarProfile
@@ -46,3 +51,71 @@ async def create_test_profile(
         opened=opened,
         context=context,
     )
+
+
+def skip_on_jsonld_url_error(test_func):
+    """Decorator to skip tests when they fail due to JSON-LD URL resolution issues.
+
+    This catches specific errors related to w3.org/w3id.org URL dereferencing failures
+    that occur when external JSON-LD context URLs are not accessible. This prevents
+    test failures due to temporary network issues or external service downtime.
+
+    Args:
+        test_func: The test function to decorate
+
+    Returns:
+        Wrapped test function that skips on JSON-LD URL resolution errors
+    """
+
+    def _handle_jsonld_error(e):
+        """Check if exception is a JSON-LD URL resolution error and skip if so."""
+        # Import here to avoid circular imports
+
+        if isinstance(e, JsonLdError):
+            error_str = str(e)
+            # Check for specific JSON-LD URL resolution error patterns
+            if any(
+                pattern in error_str
+                for pattern in [
+                    "Dereferencing a URL did not result in a valid JSON-LD object",
+                    "Could not retrieve a JSON-LD document from the URL",
+                    "loading remote context failed",
+                    "Could not process context before compaction",
+                    "Could not expand input before compaction",
+                    "Could not convert input to RDF dataset before normalization",
+                    "Could not expand input before serialization to RDF",
+                ]
+            ) and any(
+                url in error_str
+                for url in [
+                    "w3id.org/citizenship",
+                    "w3id.org/security",
+                    "w3.org/2018/credentials",
+                    "w3.org/ns/",
+                ]
+            ):
+                pytest.skip(
+                    f"Skipping test due to JSON-LD URL resolution error: {error_str}"
+                )
+        # Re-raise if it's not a URL resolution error we want to skip
+        raise
+
+    @functools.wraps(test_func)
+    async def async_wrapper(*args, **kwargs):
+        try:
+            return await test_func(*args, **kwargs)
+        except Exception as e:
+            _handle_jsonld_error(e)
+
+    @functools.wraps(test_func)
+    def sync_wrapper(*args, **kwargs):
+        try:
+            return test_func(*args, **kwargs)
+        except Exception as e:
+            _handle_jsonld_error(e)
+
+    # Return appropriate wrapper based on whether the function is async
+    if inspect.iscoroutinefunction(test_func):
+        return async_wrapper
+    else:
+        return sync_wrapper

--- a/acapy_agent/utils/testing.py
+++ b/acapy_agent/utils/testing.py
@@ -69,7 +69,6 @@ def skip_on_jsonld_url_error(test_func):
 
     def _handle_jsonld_error(e):
         """Check if exception is a JSON-LD URL resolution error and skip if so."""
-        # Import here to avoid circular imports
 
         if isinstance(e, JsonLdError):
             error_str = str(e)
@@ -97,6 +96,7 @@ def skip_on_jsonld_url_error(test_func):
                 pytest.skip(
                     f"Skipping test due to JSON-LD URL resolution error: {error_str}"
                 )
+
         # Re-raise if it's not a URL resolution error we want to skip
         raise
 

--- a/acapy_agent/utils/testing.py
+++ b/acapy_agent/utils/testing.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import pytest
 from pyld.jsonld import JsonLdError
-from uuid import uuid4
+from uuid_utils import uuid4
 
 from ..askar.profile import AskarProfile
 from ..askar.profile_anon import AskarAnonCredsProfile


### PR DESCRIPTION
The jsonld tests will always fail if w3.org is not resolvable.

This PR contributes a decorator that can be added to jsonld tests. It will automatically check if test failures matches a JsonLd error for URL resultion failure, in which case it will skip the test.
Other test failures will re-raise as normal.

Pytests are required for CICD, so this helps avoid development being blocked when w3.org is down

___
Shoutout to Cursor + claude-4-sonnet for doing this in less than 5 minutes