### PR TITLE
Add unsecure credential storage option

### DIFF
--- a/acapy_agent/vc/vc_ld/models/options.py
+++ b/acapy_agent/vc/vc_ld/models/options.py
@@ -165,3 +165,33 @@ class LDProofVCOptionsSchema(BaseModelSchema):
             )
         },
     )
+
+
+class CredentialStoreOptionsSchema(Schema):
+    """Verifiable Credential store options schema."""
+
+    class Meta:
+        """Accept parameter overload."""
+
+        unknown = INCLUDE
+
+    credentialId = fields.Str(
+        required=False,
+        metadata={
+            "description": ("Credential ID to use in storage & api calls."),
+            "example": "257d68ae-2b9c-406c-bc00-8e205d1abd44",
+        },
+    )
+
+    verify = fields.Bool(
+        required=False,
+        metadata={
+            "description": (
+                "Store a Verifiable Credential without verifying any of the proofs."
+                "This is an unsecured option to be used for development "
+                "and experimentation of new unsupported cryptosuites."
+            ),
+            "example": True,
+        },
+        default=True,
+    )

--- a/acapy_agent/vc/vc_ld/models/web_schemas.py
+++ b/acapy_agent/vc/vc_ld/models/web_schemas.py
@@ -5,7 +5,7 @@ from marshmallow import fields
 from ....messaging.models.openapi import OpenAPISchema
 from ..validation_result import PresentationVerificationResultSchema
 from .credential import CredentialSchema, VerifiableCredentialSchema
-from .options import LDProofVCOptionsSchema
+from .options import LDProofVCOptionsSchema, CredentialStoreOptionsSchema
 from .presentation import PresentationSchema, VerifiablePresentationSchema
 
 
@@ -51,6 +51,7 @@ class StoreCredentialRequest(OpenAPISchema):
     """Request schema for verifying an LDP VP."""
 
     verifiableCredential = fields.Nested(VerifiableCredentialSchema)
+    options = fields.Nested(CredentialStoreOptionsSchema)
 
 
 class StoreCredentialResponse(OpenAPISchema):


### PR DESCRIPTION
This adds an option to store a W3C VC without verifying it's proof on the `/vc/credentials/store` endpoint.

This option will default to true, and can be turned off (unsecured) for experimenting with unsupported cryptosuites and/or did methods.

The DataModel will still be validated, this only affects the proof verification step.