### PR TITLE
Upgrade rust version for indy-build to 1.56

### DIFF
--- a/docker/Dockerfile.indy
+++ b/docker/Dockerfile.indy
@@ -1,5 +1,5 @@
 ARG python_version=3.9.18
-ARG rust_version=1.46
+ARG rust_version=1.56
 
 # This image could be replaced with an "indy" image from another repo,
 # such as the indy-sdk


### PR DESCRIPTION
I believe this should fix the build issues for the indy image. The previous rust image version 1.46 used `debian-buster` which has been EOL'd. Upgrading to 1.56 doesn't cause any typing issues but uses `debian-bullseye` which is still available.