### PR TITLE
Change ghcr token to hyperledger scoped

### DIFF
--- a/.github/workflows/tag-recreate-lts.yml
+++ b/.github/workflows/tag-recreate-lts.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Delete existing LTS release (if any)
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HYPERLEDGER_GHCR_PAT }}
           LTS_TAG: ${{ steps.vars.outputs.LTS_TAG }}
         run: |
           echo "Trying to delete existing release for $LTS_TAG"
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create fresh LTS release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HYPERLEDGER_GHCR_PAT }}
           LTS_TAG: ${{ steps.vars.outputs.LTS_TAG }}
           RELEASE_BODY: ${{ env.RELEASE_BODY }}
         run: |


### PR DESCRIPTION
The 0.12.lts needs to delete and recreate images on the hyperledger registry. Unfortunately it was using the root github token for openwallet-foundation and hence why this failed.

This workflow runs on a release so annoyingly we will need to create yet another one.