### PR TITLE
Update README with latest on LTS Release Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ supported version within that release series.
 
 **Current LTS releases:**
 
-- Release [1.2](https://github.com/openwallet-foundation/acapy/releases/tag/1.2.4) **Current LTS Release**
-- Release [0.12](https://github.com/openwallet-foundation/acapy/releases/tag/0.12.6) **End of Life: October 2025**
+- Release [1.3](https://github.com/openwallet-foundation/acapy/releases/tag/1.3.1) **Current LTS Release**
+- Release [1.2](https://github.com/openwallet-foundation/acapy/releases/tag/1.2.5) **End of Life: April 2026**
+- Release [0.12](https://github.com/openwallet-foundation/acapy/releases/tag/0.12.7) **End of Life: October 2025**
 
 **Past LTS releases:**
 


### PR DESCRIPTION
Announces 1.3 as an LTS, sets the end of life for 1.2 (April, 2026), and updates the current LTS releases for each branch.
