### PR TITLE
Remove by_format from standard webhook payloads

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -27,6 +27,7 @@ runs:
         PUBLIC_TAILS_URL: ${{ inputs.IN_PUBLIC_TAILS_URL }}
         LOG_LEVEL: warning
         NO_TTY: "1"
+        ACAPY_DEBUG_WEBHOOKS: true
       working-directory: ./demo
 branding:
   icon: "mic"

--- a/acapy_agent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
@@ -23,7 +23,6 @@ class V20CredExRecordWebhook:
         "credential_definition_id",
         "schema_id",
         "credential_id",
-        "by_format",
         "trace",
         "public_did",
         "cred_id_stored",

--- a/acapy_agent/protocols/present_proof/v2_0/messages/pres_webhook.py
+++ b/acapy_agent/protocols/present_proof/v2_0/messages/pres_webhook.py
@@ -15,7 +15,6 @@ class V20PresExRecordWebhook:
         "thread_id",
         "state",
         "trace",
-        "by_format",
         "verified",
         "verified_msgs",
         "created_at",


### PR DESCRIPTION
***Note***: This will be a breaking change. 

Webhooks shouldn't be sending detailed credential and presentation information. https://github.com/openwallet-foundation/acapy/issues/3803. To enable the full payload, applications will still have the `ACAPY_DEBUG_WEBHOOKS` configuration. However, any applications using webhooks in this way should consider coming up with another approach such as saving the exchange records and querying them through the admin api. Sending information like this out via webhooks and without an api-key is a vulnerability. Only applications that have a `webhook-url` configured are affected by this.

As far as I know, only the https://github.com/openwallet-foundation/acapy-vc-authn-oidc project is using webhook information in this way and will need to use DEBUG_WEBHOOKS until another solution is created.