### PR TITLE
Add additional error handling for wrong filter

### DIFF
--- a/acapy_agent/protocols/present_proof/v2_0/formats/anoncreds/handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/anoncreds/handler.py
@@ -153,6 +153,11 @@ class AnonCredsPresExchangeHandler(V20PresFormatHandler):
                 AnonCredsPresExchangeHandler.format.api in request_data
                 or IndyPresExchangeHandler.format.api in request_data
             ):
+                if not request_data.get("anoncreds"):
+                    raise V20PresFormatHandlerError(
+                        """AnonCreds request data is missing. Are you sure the
+                        request is using the AnonCreds format?"""
+                    )
                 spec = request_data.get(
                     AnonCredsPresExchangeHandler.format.api
                 ) or request_data.get(IndyPresExchangeHandler.format.api)

--- a/acapy_agent/protocols/present_proof/v2_0/formats/indy/handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/indy/handler.py
@@ -151,6 +151,11 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
                 )
         else:
             if IndyPresExchangeHandler.format.api in request_data:
+                if not request_data.get("indy"):
+                    raise V20PresFormatHandlerError(
+                        """Indy request data is missing. Are you sure the
+                        request is using the Indy format?"""
+                    )
                 indy_spec = request_data.get(IndyPresExchangeHandler.format.api)
                 requested_credentials = {
                     "self_attested_attributes": indy_spec["self_attested_attributes"],


### PR DESCRIPTION
Just adds a couple checks when the wrong filter is used for the active issuance/presentation handler.