### PR TITLE
Logging message interpolation update

### DIFF
--- a/acapy_agent/admin/tests/test_admin_server.py
+++ b/acapy_agent/admin/tests/test_admin_server.py
@@ -132,10 +132,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             with self.assertRaises(web.HTTPUnauthorized):
                 await test_module.ready_middleware(request, handler)
             mock_logger.info.assert_called_with(
-                "Unauthorized access during %s %s: %s",
-                request.method,
-                request.path,
-                handler.side_effect,
+                f"Unauthorized access during {request.method} {request.path} {handler.side_effect}"
             )
 
             # Test jwt.InvalidTokenError
@@ -145,10 +142,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             with self.assertRaises(web.HTTPUnauthorized):
                 await test_module.ready_middleware(request, handler)
             mock_logger.info.assert_called_with(
-                "Unauthorized access during %s %s: %s",
-                request.method,
-                request.path,
-                handler.side_effect,
+                f"Unauthorized access during {request.method} {request.path} {handler.side_effect}"
             )
 
             # Test InvalidTokenError
@@ -158,10 +152,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             with self.assertRaises(web.HTTPUnauthorized):
                 await test_module.ready_middleware(request, handler)
             mock_logger.info.assert_called_with(
-                "Unauthorized access during %s %s: %s",
-                request.method,
-                request.path,
-                handler.side_effect,
+                f"Unauthorized access during {request.method} {request.path} {handler.side_effect}"
             )
 
     async def test_ready_middleware_http_bad_request(self):
@@ -182,10 +173,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             with self.assertRaises(web.HTTPBadRequest):
                 await test_module.ready_middleware(request, handler)
             mock_logger.info.assert_called_with(
-                "Bad request during %s %s: %s",
-                request.method,
-                request.path,
-                handler.side_effect,
+                f"Bad request during {request.method} {request.path} {handler.side_effect}"
             )
 
             # Test MultitenantManagerError
@@ -195,10 +183,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             with self.assertRaises(web.HTTPBadRequest):
                 await test_module.ready_middleware(request, handler)
             mock_logger.info.assert_called_with(
-                "Bad request during %s %s: %s",
-                request.method,
-                request.path,
-                handler.side_effect,
+                f"Bad request during {request.method} {request.path} {handler.side_effect}"
             )
 
     async def test_ready_middleware_http_not_found(self):
@@ -217,10 +202,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             with self.assertRaises(web.HTTPNotFound):
                 await test_module.ready_middleware(request, handler)
             mock_logger.info.assert_called_with(
-                "Not Found error occurred during %s %s: %s",
-                request.method,
-                request.path,
-                handler.side_effect,
+                f"Not Found error occurred during {request.method} {request.path} {handler.side_effect}"
             )
 
             # Test StorageNotFoundError
@@ -230,10 +212,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             with self.assertRaises(web.HTTPNotFound):
                 await test_module.ready_middleware(request, handler)
             mock_logger.info.assert_called_with(
-                "Not Found error occurred during %s %s: %s",
-                request.method,
-                request.path,
-                handler.side_effect,
+                f"Not Found error occurred during {request.method} {request.path} {handler.side_effect}"
             )
 
     async def test_ready_middleware_http_unprocessable_entity(self):
@@ -262,10 +241,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
                     await test_module.ready_middleware(request, handler)
                 mock_extract.assert_called_once_with(http_error)
                 mock_logger.info.assert_called_with(
-                    "Unprocessable Entity occurred during %s %s: %s",
-                    request.method,
-                    request.path,
-                    mock_extract.return_value,
+                    f"Unprocessable Entity occurred during {request.method} {request.path} {mock_extract.return_value}"
                 )
 
     async def get_admin_server(

--- a/acapy_agent/anoncreds/default/legacy_indy/recover.py
+++ b/acapy_agent/anoncreds/default/legacy_indy/recover.py
@@ -31,7 +31,7 @@ class RevocRecoveryException(Exception):
 
 async def _check_tails_hash_for_inconsistency(tails_location: str, tails_hash: str):
     async with aiohttp.ClientSession() as session:
-        LOGGER.debug("Tails URL: %s", tails_location)
+        LOGGER.debug(f"Tails URL: {tails_location}")
         tails_data_http_response = await session.get(tails_location)
         tails_data = await tails_data_http_response.read()
         remote_tails_hash = base58.b58encode(hashlib.sha256(tails_data).digest()).decode(
@@ -85,7 +85,7 @@ async def fetch_txns(
     registry_from_ledger = result["data"]["value"]["accum_to"]
     registry_from_ledger["ver"] = "1.0"
     revoked = set(result["data"]["value"]["revoked"])
-    LOGGER.debug("Ledger revoked indexes: %s", revoked)
+    LOGGER.debug(f"Ledger revoked indexes: {revoked}")
 
     return registry_from_ledger, revoked
 
@@ -103,8 +103,7 @@ async def generate_ledger_rrrecovery_txn(genesis_txns: str, rev_list: RevList) -
     mismatch = prev_revoked - set_revoked
     if mismatch:
         LOGGER.warning(
-            "Credential index(es) revoked on the ledger, but not in wallet: %s",
-            mismatch,
+            f"Credential index(es) revoked on the ledger, but not in wallet: {mismatch}"
         )
 
     updates = set_revoked - prev_revoked
@@ -112,7 +111,7 @@ async def generate_ledger_rrrecovery_txn(genesis_txns: str, rev_list: RevList) -
         LOGGER.debug("No updates to perform")
         return {}
     else:
-        LOGGER.debug("New revoked indexes: %s", updates)
+        LOGGER.debug(f"New revoked indexes: {updates}")
 
         # Prepare the transaction to write to the ledger
         registry = RevocationRegistry.load(registry_from_ledger)

--- a/acapy_agent/anoncreds/default/legacy_indy/registry.py
+++ b/acapy_agent/anoncreds/default/legacy_indy/registry.py
@@ -234,7 +234,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             raise AnonCredsRegistrationError(NO_LEDGER_AVAILABLE_MSG)
 
         # Translate schema into format expected by Indy
-        LOGGER.debug("Registering schema: %s", schema_id)
+        LOGGER.debug(f"Registering schema: {schema_id}")
         indy_schema = {
             "ver": "1.0",
             "id": schema_id,
@@ -243,7 +243,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             "attrNames": schema.attr_names,
             "seqNo": None,
         }
-        LOGGER.debug("schema value: %s", indy_schema)
+        LOGGER.debug(f"schema value: {indy_schema}")
 
         endorser_did = None
         create_transaction = options.get("create_transaction_for_endorser", False)
@@ -403,7 +403,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                 ) from err
 
         # Translate anoncreds object to indy object
-        LOGGER.debug("Registering credential definition: %s", cred_def_id)
+        LOGGER.debug(f"Registering credential definition: {cred_def_id}")
         indy_cred_def = {
             "id": cred_def_id,
             "schemaId": str(schema.schema_metadata["seqNo"]),
@@ -412,7 +412,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             "value": credential_definition.value.serialize(),
             "ver": "1.0",
         }
-        LOGGER.debug("Cred def value: %s", indy_cred_def)
+        LOGGER.debug(f"Cred def value: {indy_cred_def}")
 
         endorser_did = None
         create_transaction = options.get("create_transaction_for_endorser", False)
@@ -545,7 +545,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                     {"ledger_id": ledger_id},
                 )
 
-            LOGGER.debug("Retrieved revocation registry definition: %s", rev_reg_def)
+            LOGGER.debug(f"Retrieved revocation registry definition: {rev_reg_def}")
             rev_reg_def_value = RevRegDefValue.deserialize(rev_reg_def["value"])
             anoncreds_rev_reg_def = RevRegDef(
                 issuer_id=rev_reg_def["id"].split(":")[0],
@@ -752,7 +752,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                     f"Revocation list not found for rev reg def: {rev_reg_def_id}",
                     {"ledger_id": ledger_id},
                 )
-        LOGGER.debug("Retrieved delta: %s", delta)
+        LOGGER.debug(f"Retrieved delta: {delta}")
         return delta, timestamp
 
     async def get_revocation_list(
@@ -777,7 +777,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                 delta["value"]["revoked"], max_cred_num
             )
             LOGGER.debug(
-                "Index list to full state bit array: %s", revocation_list_from_indexes
+                f"Index list to full state bit array: {revocation_list_from_indexes}"
             )
             rev_list = RevList(
                 issuer_id=rev_reg_def_id.split(":")[0],

--- a/acapy_agent/anoncreds/holder.py
+++ b/acapy_agent/anoncreds/holder.py
@@ -165,9 +165,7 @@ class AnonCredsHolder:
 
         LOGGER.debug(
             "Created credential request. "
-            "credential_request_json=%s credential_request_metadata_json=%s",
-            cred_req_json,
-            cred_req_metadata_json,
+            f"credential_request_json={cred_req_json} credential_request_metadata_json={cred_req_metadata_json}"
         )
 
         return cred_req_json, cred_req_metadata_json

--- a/acapy_agent/anoncreds/revocation.py
+++ b/acapy_agent/anoncreds/revocation.py
@@ -623,8 +623,7 @@ class AnonCredsRevocation:
     async def retrieve_tails(self, rev_reg_def: RevRegDef) -> str:
         """Retrieve tails file from server."""
         LOGGER.info(
-            "Downloading the tails file with hash: %s",
-            rev_reg_def.value.tails_hash,
+            f"Downloading the tails file with hash: {rev_reg_def.value.tails_hash}",
         )
 
         tails_file_path = Path(self.get_local_tails_path(rev_reg_def))
@@ -783,11 +782,8 @@ class AnonCredsRevocation:
                 max_cred_num=active_rev_reg_def.value_json["value"]["maxCredNum"],
             )
             LOGGER.debug(
-                "Previous rev_reg_def_id = %s.\nCurrent rev_reg_def_id = %s.\n"
-                "Backup reg = %s",
-                rev_reg_def_id,
-                backup_rev_reg_def_id,
-                backup_reg.rev_reg_def_id,
+                f"Previous rev_reg_def_id = {rev_reg_def_id}.\nCurrent rev_reg_def_id = {backup_rev_reg_def_id}.\n"
+                f"Backup reg = {backup_reg.rev_reg_def_id}",
             )
 
     async def decommission_registry(self, cred_def_id: str) -> list:
@@ -843,10 +839,7 @@ class AnonCredsRevocation:
         )
 
         LOGGER.debug(
-            "New registry = %s.\nBackup registry = %s.\nDecommissioned registries = %s",
-            new_reg,
-            backup_reg,
-            recs,
+            f"New registry = {new_reg}.\nBackup registry = {backup_reg}.\nDecommissioned registries = {recs}"
         )
         return recs
 
@@ -1139,8 +1132,7 @@ class AnonCredsRevocation:
         for attempt in range(max(retries, 1)):
             if attempt > 0:
                 LOGGER.info(
-                    "Waiting 2s before retrying credential issuance for cred def '%s'",
-                    cred_def_id,
+                    f"Waiting 2s before retrying credential issuance for cred def '{cred_def_id}'"
                 )
                 await asyncio.sleep(2)
 
@@ -1214,11 +1206,8 @@ class AnonCredsRevocation:
 
         """
         LOGGER.info(
-            "Starting revocation process for registry %s with "
-            "additional_crids=%s, limit_crids=%s",
-            revoc_reg_id,
-            additional_crids,
-            limit_crids,
+            f"Starting revocation process for registry {revoc_reg_id} with "
+            f"additional_crids={additional_crids}, limit_crids={limit_crids}"
         )
         updated_list = None
         failed_crids = set()
@@ -1227,19 +1216,17 @@ class AnonCredsRevocation:
 
         while True:
             attempt += 1
-            LOGGER.debug("Revocation attempt %d/%d", attempt, max_attempt)
+            LOGGER.debug(f"Revocation attempt {attempt}/{max_attempt}")
             if attempt >= max_attempt:
                 LOGGER.error(
-                    "Max attempts (%d) reached while trying to update registry %s",
-                    max_attempt,
-                    revoc_reg_id,
+                    f"Max attempts ({max_attempt}) reached while trying to update registry {revoc_reg_id}"
                 )
                 raise AnonCredsRevocationError(
                     "Repeated conflict attempting to update registry"
                 )
             try:
                 async with self.profile.session() as session:
-                    LOGGER.debug("Fetching revocation registry data for %s", revoc_reg_id)
+                    LOGGER.debug(f"Fetching revocation registry data for {revoc_reg_id}")
                     rev_reg_def_entry = await session.handle.fetch(
                         CATEGORY_REV_REG_DEF, revoc_reg_id
                     )
@@ -1251,9 +1238,7 @@ class AnonCredsRevocation:
                     )
             except AskarError as err:
                 LOGGER.error(
-                    "Failed to retrieve revocation registry data for %s: %s",
-                    revoc_reg_id,
-                    str(err),
+                    f"Failed to retrieve revocation registry data for {revoc_reg_id}: {str(err)}"
                 )
                 raise AnonCredsRevocationError(
                     "Error retrieving revocation registry"
@@ -1272,9 +1257,7 @@ class AnonCredsRevocation:
                 if not rev_reg_def_private_entry:
                     missing_data.append("revocation registry private definition")
                 LOGGER.error(
-                    "Missing required revocation registry data for %s: %s",
-                    revoc_reg_id,
-                    ", ".join(missing_data),
+                    f"Missing required revocation registry data for {revoc_reg_id}: {", ".join(missing_data)}"
                 )
                 raise AnonCredsRevocationError(
                     f"Missing required revocation registry data: {' '.join(missing_data)}"
@@ -1283,15 +1266,13 @@ class AnonCredsRevocation:
             try:
                 async with self.profile.session() as session:
                     cred_def_id = rev_reg_def_entry.value_json["credDefId"]
-                    LOGGER.debug("Fetching credential definition %s", cred_def_id)
+                    LOGGER.debug(f"Fetching credential definition {cred_def_id}")
                     cred_def_entry = await session.handle.fetch(
                         CATEGORY_CRED_DEF, cred_def_id
                     )
             except AskarError as err:
                 LOGGER.error(
-                    "Failed to retrieve credential definition %s: %s",
-                    cred_def_id,
-                    str(err),
+                    f"Failed to retrieve credential definition {cred_def_id}: {str(err)}"
                 )
                 raise AnonCredsRevocationError(
                     f"Error retrieving cred def {cred_def_id}"
@@ -1309,7 +1290,7 @@ class AnonCredsRevocation:
                 )
             except AnoncredsError as err:
                 LOGGER.error(
-                    "Failed to load revocation registry definition: %s", str(err)
+                    f"Failed to load revocation registry definition: {str(err)}"
                 )
                 raise AnonCredsRevocationError(
                     "Error loading revocation registry definition"
@@ -1323,36 +1304,26 @@ class AnonCredsRevocation:
             rev_list = RevList.deserialize(rev_info["rev_list"])
 
             LOGGER.info(
-                "Processing %d credential revocation IDs for registry %s",
-                len(cred_revoc_ids),
-                revoc_reg_id,
+                f"Processing {len(cred_revoc_ids)} credential revocation IDs for registry {revoc_reg_id}"
             )
 
             for rev_id in cred_revoc_ids:
                 if rev_id < 1 or rev_id > max_cred_num:
                     LOGGER.error(
                         "Skipping requested credential revocation "
-                        "on rev reg id %s, cred rev id=%s not in range (1-%d)",
-                        revoc_reg_id,
-                        rev_id,
-                        max_cred_num,
+                        f"on rev reg id {revoc_reg_id}, cred rev id={rev_id} not in range (1-{max_cred_num})"
                     )
                     failed_crids.add(rev_id)
                 elif rev_id >= rev_info["next_index"]:
                     LOGGER.warning(
                         "Skipping requested credential revocation "
-                        "on rev reg id %s, cred rev id=%s not yet issued (next_index=%d)",
-                        revoc_reg_id,
-                        rev_id,
-                        rev_info["next_index"],
+                        f"on rev reg id {revoc_reg_id}, cred rev id={rev_id} not yet issued (next_index={rev_info["next_index"]})"
                     )
                     failed_crids.add(rev_id)
                 elif rev_list.revocation_list[rev_id] == 1:
                     LOGGER.warning(
                         "Skipping requested credential revocation "
-                        "on rev reg id %s, cred rev id=%s already revoked",
-                        revoc_reg_id,
-                        rev_id,
+                        f"on rev reg id {revoc_reg_id}, cred rev id={rev_id} already revoked"
                     )
                     failed_crids.add(rev_id)
                 else:
@@ -1360,7 +1331,7 @@ class AnonCredsRevocation:
 
             if not rev_crids:
                 LOGGER.info(
-                    "No valid credentials to revoke for registry %s", revoc_reg_id
+                    f"No valid credentials to revoke for registry {revoc_reg_id}"
                 )
                 break
 
@@ -1371,10 +1342,7 @@ class AnonCredsRevocation:
             rev_crids = rev_crids - skipped_crids
 
             LOGGER.info(
-                "Revoking %d credentials, skipping %d credentials for registry %s",
-                len(rev_crids),
-                len(skipped_crids),
-                revoc_reg_id,
+                f"Revoking {len(rev_crids)} credentials, skipping {len(skipped_crids)} credentials for registry {revoc_reg_id}"
             )
 
             try:
@@ -1391,7 +1359,7 @@ class AnonCredsRevocation:
                     ),
                 )
             except AnoncredsError as err:
-                LOGGER.error("Failed to update revocation registry: %s", str(err))
+                LOGGER.error(f"Failed to update revocation registry: {str(err)}")
                 raise AnonCredsRevocationError(
                     "Error updating revocation registry"
                 ) from err
@@ -1404,8 +1372,7 @@ class AnonCredsRevocation:
                     )
                     if not rev_info_upd:
                         LOGGER.warning(
-                            "Revocation registry %s missing during update, skipping",
-                            revoc_reg_id,
+                            f"Revocation registry {revoc_reg_id} missing during update, skipping"
                         )
                         updated_list = None
                         break
@@ -1413,8 +1380,7 @@ class AnonCredsRevocation:
                     rev_info_upd = rev_info_upd.value_json
                     if rev_info_upd != rev_info:
                         LOGGER.debug(
-                            "Concurrent update detected for registry %s, retrying",
-                            revoc_reg_id,
+                            f"Concurrent update detected for registry {revoc_reg_id}, retrying"
                         )
                         continue
                     rev_info_upd["rev_list"] = updated_list.to_dict()
@@ -1430,11 +1396,10 @@ class AnonCredsRevocation:
                     )
                     await txn.commit()
                     LOGGER.info(
-                        "Successfully updated revocation list for registry %s",
-                        revoc_reg_id,
+                        f"Successfully updated revocation list for registry {revoc_reg_id}",
                     )
             except AskarError as err:
-                LOGGER.error("Failed to save revocation registry: %s", str(err))
+                LOGGER.error(f"Failed to save revocation registry: {str(err)}")
                 raise AnonCredsRevocationError(
                     "Error saving revocation registry"
                 ) from err
@@ -1450,10 +1415,7 @@ class AnonCredsRevocation:
             failed=failed,
         )
         LOGGER.info(
-            "Completed revocation process for registry %s: %d revoked, %d failed",
-            revoc_reg_id,
-            len(revoked),
-            len(failed),
+            f"Completed revocation process for registry {revoc_reg_id}: {len(revoked)} revoked, {len(failed)} failed"
         )
         return result
 

--- a/acapy_agent/anoncreds/routes.py
+++ b/acapy_agent/anoncreds/routes.py
@@ -715,7 +715,7 @@ async def rev_list_post(request: web.BaseRequest):
                 options,
             )
         )
-        LOGGER.debug("published revocation list for: %s", rev_reg_def_id)
+        LOGGER.debug(f"published revocation list for: {rev_reg_def_id}")
         return web.json_response(result.serialize())
     except ValueError as e:
         handle_value_error(e)

--- a/acapy_agent/anoncreds/verifier.py
+++ b/acapy_agent/anoncreds/verifier.py
@@ -75,13 +75,10 @@ class AnonCredsVerifier:
                         )
                         LOGGER.info(
                             (
-                                "Amended presentation request (nonce=%s): removed "
-                                "non-revocation interval at %s referent "
-                                "%s; corresponding credential in proof is irrevocable"
-                            ),
-                            pres_req["nonce"],
-                            pres_key,
-                            uuid,
+                                f"Amended presentation request (nonce={pres_req["nonce"]}): removed "
+                                f"non-revocation interval at {pres_key} referent "
+                                f"{uuid}; corresponding credential in proof is irrevocable"
+                            )
                         )
 
         if all(
@@ -95,10 +92,9 @@ class AnonCredsVerifier:
             msgs.append(PresVerifyMsg.RMV_GLOBAL_NON_REVOC_INTERVAL.value)
             LOGGER.warning(
                 (
-                    "Amended presentation request (nonce=%s); removed global "
+                    f"Amended presentation request (nonce={pres_req["nonce"]}); removed global "
                     "non-revocation interval; no revocable credentials in proof"
-                ),
-                pres_req["nonce"],
+                )
             )
         return msgs
 
@@ -199,11 +195,8 @@ class AnonCredsVerifier:
                                 f"{uuid}"
                             )
                             LOGGER.info(
-                                "Timestamp %s from ledger for item %s falls outside "
-                                "non-revocation interval %s",
-                                timestamp,
-                                uuid,
-                                non_revoc_intervals[uuid],
+                                f"Timestamp {timestamp} from ledger for item {uuid} falls outside "
+                                f"non-revocation interval {non_revoc_intervals[uuid]}"
                             )
                 elif uuid in unrevealed_attrs:
                     # nothing to do, attribute value is not revealed
@@ -239,11 +232,8 @@ class AnonCredsVerifier:
                             f"{PresVerifyMsg.TSTMP_OUT_NON_REVOC_INTRVAL.value}::{uuid}"
                         )
                         LOGGER.info(
-                            "Timestamp %s from ledger for item %s falls outside "
-                            "non-revocation interval %s",
-                            timestamp,
-                            uuid,
-                            non_revoc_intervals[uuid],
+                            f"Timestamp {timestamp} from ledger for item {uuid} falls outside "
+                            f"non-revocation interval {non_revoc_intervals[uuid]}"
                         )
 
         for uuid, req_pred in pres_req["requested_predicates"].items():

--- a/acapy_agent/config/argparse.py
+++ b/acapy_agent/config/argparse.py
@@ -919,10 +919,10 @@ class LedgerGroup(ArgumentGroup):
 
             single_configured = True
             if args.genesis_url:
-                LOGGER.debug("Setting ledger.genesis_url = %s", args.genesis_url)
+                LOGGER.debug(f"Setting ledger.genesis_url = {args.genesis_url}")
                 settings["ledger.genesis_url"] = args.genesis_url
             elif args.genesis_file:
-                LOGGER.debug("Setting ledger.genesis_file = %s", args.genesis_file)
+                LOGGER.debug(f"Setting ledger.genesis_file = {args.genesis_file}")
                 settings["ledger.genesis_file"] = args.genesis_file
             elif args.genesis_transactions:
                 LOGGER.debug("Setting ledger.genesis_transactions")

--- a/acapy_agent/config/default_context.py
+++ b/acapy_agent/config/default_context.py
@@ -43,7 +43,7 @@ class DefaultContextBuilder(ContextBuilder):
 
         if context.settings.get("timing.enabled"):
             timing_log = context.settings.get("timing.log_file")
-            LOGGER.debug("Enabling timing collector with log file: %s", timing_log)
+            LOGGER.debug(f"Enabling timing collector with log file: {timing_log}")
             collector = Collector(log_path=timing_log)
             context.injector.bind_instance(Collector, collector)
 
@@ -182,7 +182,7 @@ class DefaultContextBuilder(ContextBuilder):
 
         # Register external plugins
         for plugin_path in self.settings.get("external_plugins", []):
-            LOGGER.debug("Registering external plugin: %s", plugin_path)
+            LOGGER.debug(f"Registering external plugin: {plugin_path}")
             plugin_registry.register_plugin(plugin_path)
 
         # Register message protocols

--- a/acapy_agent/config/ledger.py
+++ b/acapy_agent/config/ledger.py
@@ -185,7 +185,7 @@ async def ledger_config(
             profile_endpoint = session.settings.get("profile_endpoint")
             if profile_endpoint and not ledger.read_only:
                 LOGGER.debug(
-                    "Publishing profile endpoint: {profile_endpoint} for DID: {public_did}"
+                    f"Publishing profile endpoint: {profile_endpoint} for DID: {public_did}"
                 )
                 await ledger.update_endpoint_for_did(
                     public_did, profile_endpoint, EndpointType.PROFILE

--- a/acapy_agent/config/logging/configurator.py
+++ b/acapy_agent/config/logging/configurator.py
@@ -58,7 +58,7 @@ def load_resource(path: str, encoding: Optional[str] = None):
                 return io.TextIOWrapper(bstream, encoding=encoding)
             return bstream
     except IOError:
-        LOGGER.warning("Resource not found: %s", path)
+        LOGGER.warning(f"Resource not found: {path}")
         return None
 
 

--- a/acapy_agent/config/wallet.py
+++ b/acapy_agent/config/wallet.py
@@ -107,9 +107,7 @@ async def _replace_public_did_if_seed_mismatch(
     )
     await wallet.set_public_did(replace_did_info.did)
     LOGGER.info(
-        "Created new public DID: %s, with verkey: %s",
-        replace_did_info.did,
-        replace_did_info.verkey,
+        f"Created new public DID: {replace_did_info.did}, with verkey: {replace_did_info.verkey}"
     )
     return replace_did_info
 
@@ -144,10 +142,7 @@ async def _initialize_with_seed(
         did_info = await wallet.create_public_did(method=SOV, key_type=ED25519, seed=seed)
 
     LOGGER.info(
-        "Created new %s DID: %s, Verkey: %s",
-        "local" if create_local_did else "public",
-        did_info.did,
-        did_info.verkey,
+        f"Created new {"local" if create_local_did else "public"} DID: {did_info.did}, Verkey: {did_info.verkey}"
     )
     return did_info
 
@@ -172,10 +167,7 @@ async def wallet_config(
         )
 
     LOGGER.info(
-        "%s Profile name: %s, backend: %s",
-        "Created new profile -" if profile.created else "Opened existing profile -",
-        profile.name,
-        profile.backend,
+        f"{"Created new profile -" if profile.created else "Opened existing profile -"} Profile name: {profile.name}, backend: {profile.backend}"
     )
 
     txn = await profile.transaction()

--- a/acapy_agent/connections/base_manager.py
+++ b/acapy_agent/connections/base_manager.py
@@ -370,7 +370,7 @@ class BaseConnectionManager:
         if did.startswith("did:sov:"):
             did = did[8:]
 
-        self._logger.debug("Storing DID document for %s: %s", did, doc)
+        self._logger.debug(f"Storing DID document for {did}: {doc}")
 
         try:
             stored_doc, record = await self.fetch_did_document(did)
@@ -403,9 +403,8 @@ class BaseConnectionManager:
                 await storage.add_record(record)
             except StorageDuplicateError:
                 self._logger.warning(
-                    "Key already associated with DID: %s; this is likely caused by "
-                    "routing keys being erroneously stored in the past",
-                    key,
+                    f"Key already associated with DID: {key}; this is likely caused by "
+                    "routing keys being erroneously stored in the past"
                 )
 
     async def find_did_for_key(self, key: str) -> str:
@@ -467,7 +466,7 @@ class BaseConnectionManager:
         key material.
         """
         self._logger.debug(
-            "Getting recipient and routing keys for service %s", service.id
+            f"Getting recipient and routing keys for service {service.id}"
         )
         resolver = self._profile.inject(DIDResolver)
         recipient_keys: List[VerificationMethod] = [
@@ -501,16 +500,16 @@ class BaseConnectionManager:
             BaseConnectionManagerError: If the public DID has no associated
                 DIDComm services.
         """
-        self._logger.debug("Resolving invitation for DID %s", did)
+        self._logger.debug(f"Resolving invitation for DID {did}")
         doc, didcomm_services = await self.resolve_didcomm_services(did, service_accept)
         if not didcomm_services:
-            self._logger.warning("No DIDComm services found for DID %s", did)
+            self._logger.warning(f"No DIDComm services found for DID {did}")
             raise BaseConnectionManagerError(
                 "Cannot connect via public DID that has no associated DIDComm services"
             )
         first_didcomm_service, *_ = didcomm_services
         self._logger.debug(
-            "DIDComm service (id %s) found for DID %s", first_didcomm_service.id, did
+            f"DIDComm service (id {first_didcomm_service.id}) found for DID {did}"
         )
 
         endpoint = str(first_didcomm_service.service_endpoint)
@@ -518,10 +517,7 @@ class BaseConnectionManager:
             doc, first_didcomm_service
         )
         self._logger.debug(
-            "DID %s has recipient keys %s and routing keys %s",
-            did,
-            recipient_keys,
-            routing_keys,
+            f"DID {did} has recipient keys {recipient_keys} and routing keys {routing_keys}"
         )
         return (
             endpoint,
@@ -549,10 +545,10 @@ class BaseConnectionManager:
         their_label: Optional[str] = None,
     ) -> List[ConnectionTarget]:
         """Resolve connection targets for a DID."""
-        self._logger.debug("Resolving connection targets for DID %s", did)
+        self._logger.debug(f"Resolving connection targets for DID {did}")
         doc, didcomm_services = await self.resolve_didcomm_services(did)
-        self._logger.debug("Resolved DID document: %s", doc)
-        self._logger.debug("Resolved DIDComm services: %s", didcomm_services)
+        self._logger.debug(f"Resolved DID document: {doc}")
+        self._logger.debug(f"Resolved DIDComm services: {didcomm_services}")
         targets = []
         for service in didcomm_services:
             try:
@@ -615,7 +611,7 @@ class BaseConnectionManager:
             codec, key = multicodec.unwrap(multibase.decode(method.material))
             if codec != multicodec.multicodec("ed25519-pub"):
                 raise BaseConnectionManagerError(
-                    "Expected ed25519 multicodec, got: %s", codec
+                    f"Expected ed25519 multicodec, got: {codec}"
                 )
             return bytes_to_b58(key)
         else:
@@ -800,8 +796,7 @@ class BaseConnectionManager:
                         await entry.set_result([row.serialize() for row in targets], 3600)
                     else:
                         self._logger.debug(
-                            "Not caching connection targets for connection in state %s",
-                            connection.state,
+                            f"Not caching connection targets for connection in state {connection.state}",
                         )
         else:
             if not connection:
@@ -1020,13 +1015,11 @@ class BaseConnectionManager:
                     receipt.recipient_did_public = True
             except InjectionError:
                 self._logger.warning(
-                    "Cannot resolve recipient verkey, no wallet defined by context: %s",
-                    receipt.recipient_verkey,
+                    f"Cannot resolve recipient verkey, no wallet defined by context: {receipt.recipient_verkey}"
                 )
             except WalletNotFoundError:
                 self._logger.debug(
-                    "No corresponding DID found for recipient verkey: %s",
-                    receipt.recipient_verkey,
+                    f"No corresponding DID found for recipient verkey: {receipt.recipient_verkey}"
                 )
 
         return await self.find_connection(

--- a/acapy_agent/connections/models/diddoc/diddoc.py
+++ b/acapy_agent/connections/models/diddoc/diddoc.py
@@ -201,7 +201,7 @@ class DIDDoc:
                         pubkey = self.pubkey[canon_key]
                     else:  # service key refers to another DID doc
                         LOGGER.debug(
-                            "DID document %s has no public key %s", self.did, svc_key
+                            f"DID document {self.did} has no public key {svc_key}"
                         )
                         raise ValueError(
                             "DID document {} has no public key {}".format(

--- a/acapy_agent/core/conductor.py
+++ b/acapy_agent/core/conductor.py
@@ -165,7 +165,7 @@ class Conductor:
             if not context.settings.get("ledger.genesis_transactions"):
                 ledger = context.injector.inject(BaseLedger)
                 LOGGER.debug(
-                    "Ledger backend: {ledger.BACKEND_NAME}, Profile backend: {self.root_profile.BACKEND_NAME}"
+                    f"Ledger backend: {ledger.BACKEND_NAME}, Profile backend: {self.root_profile.BACKEND_NAME}"
                 )
                 if (
                     self.root_profile.BACKEND_NAME == "askar"

--- a/acapy_agent/core/conductor.py
+++ b/acapy_agent/core/conductor.py
@@ -165,9 +165,7 @@ class Conductor:
             if not context.settings.get("ledger.genesis_transactions"):
                 ledger = context.injector.inject(BaseLedger)
                 LOGGER.debug(
-                    "Ledger backend: %s, Profile backend: %s",
-                    ledger.BACKEND_NAME,
-                    self.root_profile.BACKEND_NAME,
+                    "Ledger backend: {ledger.BACKEND_NAME}, Profile backend: {self.root_profile.BACKEND_NAME}"
                 )
                 if (
                     self.root_profile.BACKEND_NAME == "askar"
@@ -287,7 +285,7 @@ class Conductor:
                     self.get_stats,
                 )
                 context.injector.bind_instance(BaseAdminServer, self.admin_server)
-                LOGGER.debug("Admin server registered on %s:%s", admin_host, admin_port)
+                LOGGER.debug(f"Admin server registered on {admin_host}:{admin_port}")
             except Exception:
                 LOGGER.exception("Unable to register admin server.")
                 raise
@@ -361,7 +359,7 @@ class Conductor:
 
         # Get agent label
         default_label = context.settings.get("default_label")
-        LOGGER.debug("Agent label: %s", default_label)
+        LOGGER.debug(f"Agent label: {default_label}")
 
         if context.settings.get("transport.disabled"):
             LoggingConfigurator.print_banner(
@@ -396,8 +394,7 @@ class Conductor:
                 )
                 from_version_storage = record.value
                 LOGGER.info(
-                    "Existing acapy_version storage record found, version set to %s",
-                    from_version_storage,
+                    f"Existing acapy_version storage record found, version set to {from_version_storage}"
                 )
             except StorageNotFoundError:
                 LOGGER.info("Wallet version storage record not found.")
@@ -407,9 +404,7 @@ class Conductor:
             self.root_profile.settings.get("upgrade.force_upgrade") or False
         )
         LOGGER.debug(
-            "Force upgrade flag: %s, From version config: %s",
-            force_upgrade_flag,
-            from_version_config,
+            f"Force upgrade flag: {force_upgrade_flag}, From version config: {from_version_config}"
         )
 
         if force_upgrade_flag and from_version_config:
@@ -423,27 +418,26 @@ class Conductor:
             else:
                 from_version = from_version_config
             LOGGER.debug(
-                "Determined from_version based on force_upgrade: %s", from_version
+                f"Determined from_version based on force_upgrade: {from_version}"
             )
         else:
             from_version = from_version_storage or from_version_config
-            LOGGER.debug("Determined from_version: %s", from_version)
+            LOGGER.debug(f"Determined from_version: {from_version}")
 
         if not from_version:
             LOGGER.info(
                 "No upgrade from version was found from wallet or via"
-                " --from-version startup argument. Defaulting to %s.",
-                DEFAULT_ACAPY_VERSION,
+                f" --from-version startup argument. Defaulting to {DEFAULT_ACAPY_VERSION}."
             )
             from_version = DEFAULT_ACAPY_VERSION
             self.root_profile.settings.set_value("upgrade.from_version", from_version)
-            LOGGER.debug("Set upgrade.from_version to default: %s", from_version)
+            LOGGER.debug(f"Set upgrade.from_version to default: {from_version}")
 
         config_available_list = get_upgrade_version_list(
             config_path=self.root_profile.settings.get("upgrade.config_path"),
             from_version=from_version,
         )
-        LOGGER.debug("Available upgrade versions: %s", config_available_list)
+        LOGGER.debug(f"Available upgrade versions: {config_available_list}")
 
         if len(config_available_list) >= 1:
             LOGGER.info("Upgrade configurations available. Initiating upgrade.")
@@ -468,12 +462,9 @@ class Conductor:
             )
             LOGGER.info(
                 "Created static connection for test suite\n"
-                " - My DID: %s\n"
-                " - Their DID: %s\n"
-                " - Their endpoint: %s\n",
-                test_conn.my_did,
-                test_conn.their_did,
-                their_endpoint,
+                f" - My DID: {test_conn.my_did}\n"
+                f" - Their DID: {test_conn.their_did}\n"
+                f" - Their endpoint: {their_endpoint}\n"
             )
             del mgr
             LOGGER.debug("Static connection for test suite created and manager deleted.")
@@ -488,11 +479,11 @@ class Conductor:
         # Set default mediator by id
         default_mediator_id = context.settings.get("mediation.default_id")
         if default_mediator_id:
-            LOGGER.debug("Setting default mediator to ID: %s", default_mediator_id)
+            LOGGER.debug(f"Setting default mediator to ID: {default_mediator_id}")
             mediation_mgr = MediationManager(self.root_profile)
             try:
                 await mediation_mgr.set_default_mediator_by_id(default_mediator_id)
-                LOGGER.info("Default mediator set to %s", default_mediator_id)
+                LOGGER.info(f"Default mediator set to {default_mediator_id}")
             except Exception:
                 LOGGER.exception("Error updating default mediator.")
 
@@ -514,7 +505,7 @@ class Conductor:
                 )
                 base_url = context.settings.get("invite_base_url")
                 invite_url = invi_rec.invitation.to_url(base_url)
-                LOGGER.info("Invitation URL:\n%s", invite_url)
+                LOGGER.info(f"Invitation URL:\n{invite_url}")
                 qr = QRCode(border=1)
                 qr.add_data(invite_url)
                 qr.print_ascii(invert=True)
@@ -524,7 +515,7 @@ class Conductor:
 
         # mediation connection establishment
         provided_invite: str = context.settings.get("mediation.invite")
-        LOGGER.debug("Mediation invite provided: %s", provided_invite)
+        LOGGER.debug(f"Mediation invite provided: {provided_invite}")
 
         try:
             async with self.root_profile.session() as session:
@@ -629,12 +620,12 @@ class Conductor:
             if multitenant_mgr:
                 LOGGER.debug("Closing multitenant profiles.")
                 for profile in multitenant_mgr.open_profiles:
-                    LOGGER.debug("Closing profile: %s", profile.name)
+                    LOGGER.debug(f"Closing profile: {profile.name}")
                     shutdown.run(profile.close())
             LOGGER.debug("Closing root profile.")
             shutdown.run(self.root_profile.close())
 
-        LOGGER.debug("Waiting for shutdown tasks to complete with timeout=%f.", timeout)
+        LOGGER.debug(f"Waiting for shutdown tasks to complete with timeout={timeout}.")
         await shutdown.complete(timeout)
         LOGGER.info("Conductor agent stopped successfully.")
 
@@ -655,8 +646,7 @@ class Conductor:
 
         if message.receipt.direct_response_requested and not can_respond:
             LOGGER.warning(
-                "Direct response requested, but not supported by transport: %s",
-                message.transport_type,
+                f"Direct response requested, but not supported by transport: {message.transport_type}"
             )
 
         # Note: at this point we could send the message to a shared queue
@@ -670,7 +660,7 @@ class Conductor:
                 lambda completed: self.dispatch_complete(message, completed),
             )
         except (LedgerConfigError, LedgerTransactionError) as e:
-            LOGGER.error("Ledger error occurred in message handler: %s", str(e))
+            LOGGER.error(f"Ledger error occurred in message handler: {str(e)}")
             raise
 
     def dispatch_complete(self, message: InboundMessage, completed: CompletedTask):
@@ -679,15 +669,12 @@ class Conductor:
             exc_class, exc, _ = completed.exc_info
             if isinstance(exc, (LedgerConfigError, LedgerTransactionError)):
                 LOGGER.error(
-                    "Ledger error occurred in message handler: %s",
-                    str(exc),
+                    f"Ledger error occurred in message handler: {str(exc)}",
                     exc_info=completed.exc_info,
                 )
             elif isinstance(exc, (ProfileError, StorageNotFoundError)):
                 LOGGER.error(
-                    "Storage error occurred in message handler: %s: %s",
-                    exc_class.__name__,
-                    str(exc),
+                    f"Storage error occurred in message handler: {exc_class.__name__}: {str(exc)}",
                     exc_info=completed.exc_info,
                 )
             else:
@@ -768,7 +755,7 @@ class Conductor:
             self.dispatcher.run_task(self.queue_outbound(profile, outbound))
         except (LedgerConfigError, LedgerTransactionError) as e:
             LOGGER.error(
-                "Ledger error occurred while handling failed delivery: %s", str(e)
+                f"Ledger error occurred while handling failed delivery: {str(e)}"
             )
             raise
 
@@ -800,7 +787,7 @@ class Conductor:
                 return OutboundSendStatus.UNDELIVERABLE
             except (LedgerConfigError, LedgerTransactionError) as e:
                 LOGGER.error(
-                    "Ledger error occurred while preparing outbound message: %s", str(e)
+                    f"Ledger error occurred while preparing outbound message: {str(e)}"
                 )
                 raise
             del conn_mgr
@@ -886,8 +873,7 @@ class Conductor:
                 if acapy_version:
                     storage_type_from_storage = STORAGE_TYPE_VALUE_ASKAR
                     LOGGER.info(
-                        "Existing agent found. Setting wallet type to %s.",
-                        storage_type_from_storage,
+                        f"Existing agent found. Setting wallet type to {storage_type_from_storage}."
                     )
                     await storage.add_record(
                         StorageRecord(
@@ -898,7 +884,7 @@ class Conductor:
                 else:
                     storage_type_from_storage = storage_type_from_config
                     LOGGER.info(
-                        "New agent. Setting wallet type to %s.", storage_type_from_config
+                        f"New agent. Setting wallet type to {storage_type_from_config}."
                     )
                     await storage.add_record(
                         StorageRecord(

--- a/acapy_agent/core/dispatcher.py
+++ b/acapy_agent/core/dispatcher.py
@@ -85,7 +85,7 @@ class Dispatcher:
         if task.exc_info and not issubclass(task.exc_info[0], HTTPException):
             # skip errors intentionally returned to HTTP clients
             self.logger.exception(
-                "Handler error: %s", task.ident or "", exc_info=task.exc_info
+                f"Handler error: {task.ident or ""}", exc_info=task.exc_info
             )
         if self.collector:
             timing = task.timing

--- a/acapy_agent/core/event_bus.py
+++ b/acapy_agent/core/event_bus.py
@@ -98,7 +98,7 @@ class EventBus:
         # TODO trigger each processor but don't await?
         # TODO log errors but otherwise ignore?
 
-        LOGGER.debug("Notifying subscribers: %s", event)
+        LOGGER.debug(f"Notifying subscribers: {event}")
 
         partials = []
         for pattern, subscribers in self.topic_patterns_to_subscribers.items():
@@ -130,7 +130,7 @@ class EventBus:
             processor (Callable): async callable accepting profile and event
 
         """
-        LOGGER.debug("Subscribed: topic %s, processor %s", pattern, processor)
+        LOGGER.debug(f"Subscribed: topic {pattern}, processor {processor}")
         if pattern not in self.topic_patterns_to_subscribers:
             self.topic_patterns_to_subscribers[pattern] = []
         self.topic_patterns_to_subscribers[pattern].append(processor)
@@ -154,7 +154,7 @@ class EventBus:
             del self.topic_patterns_to_subscribers[pattern][index]
             if not self.topic_patterns_to_subscribers[pattern]:
                 del self.topic_patterns_to_subscribers[pattern]
-            LOGGER.debug("Unsubscribed: topic %s, processor %s", pattern, processor)
+            LOGGER.debug(f"Unsubscribed: topic {pattern}, processor {processor}")
 
     @contextmanager
     def wait_for_event(
@@ -169,9 +169,7 @@ class EventBus:
         async def _handle_single_event(profile, event):
             """Handle the single event."""
             LOGGER.debug(
-                "wait_for_event event listener with event %s and profile %s",
-                event,
-                profile,
+                f"wait_for_event event listener with event {event} and profile {profile}"
             )
             if cond is not None and not cond(event):
                 return

--- a/acapy_agent/core/oob_processor.py
+++ b/acapy_agent/core/oob_processor.py
@@ -82,8 +82,7 @@ class OobMessageProcessor:
                 )
 
                 LOGGER.debug(
-                    "extracting their service from oob record %s",
-                    oob_record.their_service,
+                    f"extracting their service from oob record {oob_record.their_service}"
                 )
 
                 their_service = oob_record.their_service
@@ -94,8 +93,7 @@ class OobMessageProcessor:
                 message = json.loads(outbound_message.payload)
                 if not message.get("~service") and oob_record.our_service:
                     LOGGER.debug(
-                        "Setting our service on the message ~service %s",
-                        oob_record.our_service,
+                        f"Setting our service on the message ~service {oob_record.our_service}"
                     )
                     message["~service"] = oob_record.our_service.serialize()
 
@@ -106,7 +104,7 @@ class OobMessageProcessor:
 
                 outbound_message.payload = json.dumps(message)
 
-                LOGGER.debug("Sending oob message payload %s", outbound_message.payload)
+                LOGGER.debug(f"Sending oob message payload {outbound_message.payload}")
 
                 return ConnectionTarget(
                     endpoint=their_service.endpoint,
@@ -273,8 +271,7 @@ class OobMessageProcessor:
         # can reply to this message
         if context._message._service:
             LOGGER.debug(
-                "Storing service decorator in oob record %s",
-                context.message._service.serialize(),
+                f"Storing service decorator in oob record {context.message._service.serialize()}",
             )
             oob_record.their_service = context.message._service.serialize()
 
@@ -340,7 +337,7 @@ class OobMessageProcessor:
             if not oob_record.connection_id:
                 oob_record.attach_thread_id = self.get_thread_id(message)
                 if their_service:
-                    LOGGER.debug("Storing their service in oob record %s", their_service)
+                    LOGGER.debug(f"Storing their service in oob record {their_service}")
                     oob_record.their_service = their_service
 
                 await oob_record.save(session)

--- a/acapy_agent/core/plugin_registry.py
+++ b/acapy_agent/core/plugin_registry.py
@@ -385,7 +385,7 @@ class PluginRegistry:
                     try:
                         mod = ClassLoader.load_module(version_path)
                     except ModuleLoadError as e:
-                        LOGGER.error("Error loading routes from {version_path}: {e}")
+                        LOGGER.error(f"Error loading routes from {version_path}: {e}")
                         continue
 
                     if mod and hasattr(mod, "post_process_routes"):
@@ -396,7 +396,7 @@ class PluginRegistry:
                 try:
                     mod = ClassLoader.load_module(routes_path)
                 except ModuleLoadError as e:
-                    LOGGER.error("Error loading routes from {routes_path}: {e}")
+                    LOGGER.error(f"Error loading routes from {routes_path}: {e}")
                     continue
 
                 if mod and hasattr(mod, "post_process_routes"):

--- a/acapy_agent/core/profile.py
+++ b/acapy_agent/core/profile.py
@@ -371,7 +371,7 @@ class ProfileManagerProvider(BaseProvider):
         mgr_class = self.MANAGER_TYPES.get(mgr_type.lower(), mgr_type)
 
         if mgr_class not in self._inst:
-            LOGGER.info("Create profile manager: %s", mgr_type)
+            LOGGER.info(f"Create profile manager: {mgr_type}")
             try:
                 self._inst[mgr_class] = ClassLoader.load_class(mgr_class)()
             except ClassNotFoundError as err:

--- a/acapy_agent/didcomm_v2/adapters.py
+++ b/acapy_agent/didcomm_v2/adapters.py
@@ -63,7 +63,7 @@ class SecretsAdapter(SecretsManager[AskarSecretKey]):
                 "ACA-Py's implementation of DMP only supports an Askar backend"
             )
 
-        LOGGER.debug("GETTING SECRET BY KID: %s", kid)
+        LOGGER.debug(f"GETTING SECRET BY KID: {kid}")
         key_entries = await self.session.handle.fetch_all_keys(
             tag_filter={"kid": kid}, limit=2
         )

--- a/acapy_agent/indy/credx/holder.py
+++ b/acapy_agent/indy/credx/holder.py
@@ -76,7 +76,7 @@ class IndyCredxHolder(IndyHolder):
                         CATEGORY_LINK_SECRET, IndyCredxHolder.LINK_SECRET_ID
                     )
                 except AskarError as err:
-                    LOGGER.error("Error fetching link secret: %s", err)
+                    LOGGER.error(f"Error fetching link secret: {err}")
                     raise IndyHolderError("Error fetching link secret") from err
 
                 if record:
@@ -86,8 +86,7 @@ class IndyCredxHolder(IndyHolder):
                         LOGGER.debug("Loaded existing link secret.")
                     except CredxError as err:
                         LOGGER.info(
-                            "Attempt fallback method after error loading link secret: %s",
-                            err,
+                            f"Attempt fallback method after error loading link secret: {err}"
                         )
                         try:
                             ms_string = record.value.decode("ascii")
@@ -95,7 +94,7 @@ class IndyCredxHolder(IndyHolder):
                             secret = LinkSecret.load(link_secret_dict)
                             LOGGER.debug("Loaded LinkSecret from AnonCreds secret.")
                         except CredxError as decode_err:
-                            LOGGER.error("Error loading link secret: %s", decode_err)
+                            LOGGER.error(f"Error loading link secret: {decode_err}")
                             raise IndyHolderError("Error loading link secret") from err
                     break
                 else:
@@ -103,7 +102,7 @@ class IndyCredxHolder(IndyHolder):
                         secret = LinkSecret.create()
                         LOGGER.debug("Created new link secret.")
                     except CredxError as err:
-                        LOGGER.error("Error creating link secret: %s", err)
+                        LOGGER.error(f"Error creating link secret: {err}")
                         raise IndyHolderError("Error creating link secret") from err
 
                     try:
@@ -115,7 +114,7 @@ class IndyCredxHolder(IndyHolder):
                         LOGGER.debug("Saved new link secret.")
                     except AskarError as err:
                         if err.code != AskarErrorCode.DUPLICATE:
-                            LOGGER.error("Error saving link secret: %s", err)
+                            LOGGER.error(f"Error saving link secret: {err}")
                             raise IndyHolderError("Error saving link secret") from err
                         # else: lost race to create record, retry
                     else:
@@ -160,9 +159,7 @@ class IndyCredxHolder(IndyHolder):
 
         LOGGER.debug(
             "Created credential request. "
-            "credential_request_json=%s credential_request_metadata_json=%s",
-            cred_req_json,
-            cred_req_metadata_json,
+            f"credential_request_json={cred_req_json} credential_request_metadata_json={cred_req_metadata_json}"
         )
 
         return cred_req_json, cred_req_metadata_json

--- a/acapy_agent/indy/credx/issuer.py
+++ b/acapy_agent/indy/credx/issuer.py
@@ -454,25 +454,19 @@ class IndyCredxIssuer(IndyIssuer):
                 if rev_id < 1 or rev_id > max_cred_num:
                     LOGGER.error(
                         "Skipping requested credential revocation"
-                        "on rev reg id %s, cred rev id=%s not in range",
-                        revoc_reg_id,
-                        rev_id,
+                        f"on rev reg id {revoc_reg_id}, cred rev id={rev_id} not in range"
                     )
                     failed_crids.add(rev_id)
                 elif rev_id > rev_info["curr_id"]:
                     LOGGER.warning(
                         "Skipping requested credential revocation"
-                        "on rev reg id %s, cred rev id=%s not yet issued",
-                        revoc_reg_id,
-                        rev_id,
+                        f"on rev reg id {revoc_reg_id}, cred rev id={rev_id} not yet issued"
                     )
                     failed_crids.add(rev_id)
                 elif rev_id in used_ids:
                     LOGGER.warning(
                         "Skipping requested credential revocation"
-                        "on rev reg id %s, cred rev id=%s already revoked",
-                        revoc_reg_id,
-                        rev_id,
+                        f"on rev reg id {revoc_reg_id}, cred rev id={rev_id} already revoked"
                     )
                     failed_crids.add(rev_id)
                 else:

--- a/acapy_agent/indy/verifier.py
+++ b/acapy_agent/indy/verifier.py
@@ -76,13 +76,10 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
                         )
                         LOGGER.info(
                             (
-                                "Amended presentation request (nonce=%s): removed "
-                                "non-revocation interval at %s referent "
-                                "%s; corresponding credential in proof is irrevocable"
-                            ),
-                            pres_req["nonce"],
-                            pres_key,
-                            uuid,
+                                f"Amended presentation request (nonce={pres_req["nonce"]}): removed "
+                                f"non-revocation interval at {pres_key} referent "
+                                f"{uuid}; corresponding credential in proof is irrevocable"
+                            )
                         )
 
         if all(
@@ -96,10 +93,9 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
             msgs.append(PresVerifyMsg.RMV_GLOBAL_NON_REVOC_INTERVAL.value)
             LOGGER.warning(
                 (
-                    "Amended presentation request (nonce=%s); removed global "
+                    f"Amended presentation request (nonce={pres_req["nonce"]}); removed global "
                     "non-revocation interval; no revocable credentials in proof"
-                ),
-                pres_req["nonce"],
+                )
             )
         return msgs
 
@@ -205,11 +201,8 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
                                 f"{uuid}"
                             )
                             LOGGER.info(
-                                "Timestamp %s from ledger for item %s falls outside "
-                                "non-revocation interval %s",
-                                timestamp,
-                                uuid,
-                                non_revoc_intervals[uuid],
+                                f"Timestamp {timestamp} from ledger for item {uuid} falls outside "
+                                f"non-revocation interval {non_revoc_intervals[uuid]}",
                             )
                 elif uuid in unrevealed_attrs:
                     # nothing to do, attribute value is not revealed
@@ -245,11 +238,8 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
                             f"{PresVerifyMsg.TSTMP_OUT_NON_REVOC_INTRVAL.value}::{uuid}"
                         )
                         LOGGER.info(
-                            "Timestamp %s from ledger for item %s falls outside "
-                            "non-revocation interval %s",
-                            timestamp,
-                            uuid,
-                            non_revoc_intervals[uuid],
+                            "Timestamp {timestamp} from ledger for item {uuid} falls outside "
+                            "non-revocation interval {non_revoc_intervals[uuid]}"
                         )
 
         for uuid, req_pred in pres_req["requested_predicates"].items():

--- a/acapy_agent/indy/verifier.py
+++ b/acapy_agent/indy/verifier.py
@@ -238,8 +238,8 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
                             f"{PresVerifyMsg.TSTMP_OUT_NON_REVOC_INTRVAL.value}::{uuid}"
                         )
                         LOGGER.info(
-                            "Timestamp {timestamp} from ledger for item {uuid} falls outside "
-                            "non-revocation interval {non_revoc_intervals[uuid]}"
+                            f"Timestamp {timestamp} from ledger for item {uuid} falls outside "
+                            f"non-revocation interval {non_revoc_intervals[uuid]}"
                         )
 
         for uuid, req_pred in pres_req["requested_predicates"].items():

--- a/acapy_agent/ledger/base.py
+++ b/acapy_agent/ledger/base.py
@@ -362,8 +362,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
                     if schema_info:
                         LOGGER.warning(
                             "Schema already exists on ledger. Returning details."
-                            " Error: %s",
-                            e,
+                            f" Error: {e}"
                         )
                         schema_id, schema_def = schema_info
                 else:
@@ -464,9 +463,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
             )
             if ledger_cred_def:
                 LOGGER.warning(
-                    "Credential definition %s already exists on ledger %s",
-                    credential_definition_id,
-                    self.pool_name,
+                    f"Credential definition {credential_definition_id} already exists on ledger {self.pool_name}"
                 )
 
                 try:
@@ -693,8 +690,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
                 )
                 if schema_info:
                     LOGGER.warning(
-                        "Schema already exists on ledger. Returning details. Error: %s",
-                        e,
+                        f"Schema already exists on ledger. Returning details. Error: {e}"
                     )
                     raise LedgerObjectAlreadyExistsError(
                         f"Schema already exists on ledger (Error: {e})", *schema_info

--- a/acapy_agent/ledger/indy_vdr.py
+++ b/acapy_agent/ledger/indy_vdr.py
@@ -127,7 +127,7 @@ class IndyVdrLedgerPool:
                 path = self.cfg_path.joinpath(self.name, "genesis")
                 self.genesis_txns_cache = _normalize_txns(open(path).read())
             except FileNotFoundError:
-                raise LedgerConfigError("Pool config '%s' not found", self.name) from None
+                raise LedgerConfigError(f"Pool config '{self.name}' not found") from None
         return self.genesis_txns_cache
 
     async def create_pool_config(self, genesis_transactions: str, recreate: bool = False):
@@ -144,8 +144,7 @@ class IndyVdrLedgerPool:
             cmp_genesis = open(genesis_path).read()
             if _normalize_txns(cmp_genesis) == genesis:
                 LOGGER.debug(
-                    "Pool ledger config '%s' is consistent, skipping write",
-                    self.name,
+                    f"Pool ledger config '{self.name}' is consistent, skipping write",
                 )
                 return
             elif not recreate:
@@ -160,7 +159,7 @@ class IndyVdrLedgerPool:
             _write_safe(genesis_path, genesis)
         except OSError as err:
             raise LedgerConfigError("Error writing genesis transactions") from err
-        LOGGER.debug("Wrote pool ledger config '%s'", self.name)
+        LOGGER.debug(f"Wrote pool ledger config '{self.name}'")
 
         self.genesis_txns_cache = genesis
 

--- a/acapy_agent/ledger/multiple_ledger/manager_provider.py
+++ b/acapy_agent/ledger/multiple_ledger/manager_provider.py
@@ -50,7 +50,7 @@ class MultiIndyLedgerManagerProvider(BaseProvider):
             manager_class = self.MANAGER_TYPES.get(manager_type)
             pool_class = self.LEDGER_TYPES[manager_type]["pool"]
             ledger_class = self.LEDGER_TYPES[manager_type]["ledger"]
-            LOGGER.info("Create multiple Indy ledger manager: %s", manager_type)
+            LOGGER.info(f"Create multiple Indy ledger manager: {manager_type}")
             try:
                 indy_vdr_production_ledgers = OrderedDict()
                 indy_vdr_non_production_ledgers = OrderedDict()

--- a/acapy_agent/ledger/routes.py
+++ b/acapy_agent/ledger/routes.py
@@ -656,7 +656,7 @@ async def ledger_accept_taa(request: web.BaseRequest):
             raise web.HTTPForbidden(reason=reason)
 
     accept_input = await request.json()
-    LOGGER.info(">>> accepting TAA with: %s", accept_input)
+    LOGGER.info(f">>> accepting TAA with: {accept_input}")
     async with ledger:
         try:
             taa_info = await ledger.get_txn_author_agreement()
@@ -684,7 +684,7 @@ async def ledger_accept_taa(request: web.BaseRequest):
                 ),
             }
             taa_record_digest = taa_record["digest"]
-            LOGGER.info(">>> accepting with digest: %s", taa_record_digest)
+            LOGGER.info(f">>> accepting with digest: {taa_record_digest}")
             await ledger.accept_txn_author_agreement(
                 taa_record, accept_input["mechanism"]
             )

--- a/acapy_agent/multitenant/manager_provider.py
+++ b/acapy_agent/multitenant/manager_provider.py
@@ -41,7 +41,7 @@ class MultitenantManagerProvider(BaseProvider):
         manager_class = self.MANAGER_TYPES.get(manager_type, manager_type)
 
         if manager_class not in self._inst:
-            LOGGER.info("Create multitenant manager: %s", manager_type)
+            LOGGER.info(f"Create multitenant manager: {manager_type}")
             try:
                 self._inst[manager_class] = ClassLoader.load_class(manager_class)(
                     self.root_profile

--- a/acapy_agent/multitenant/route_manager.py
+++ b/acapy_agent/multitenant/route_manager.py
@@ -51,7 +51,7 @@ class MultitenantRouteManager(RouteManager):
     ) -> Optional[KeylistUpdate]:
         wallet_id = profile.settings["wallet.id"]
         LOGGER.debug(
-            "Add route record for recipient %s to wallet %s", recipient_key, wallet_id
+            f"Add route record for recipient {recipient_key} to wallet {wallet_id}"
         )
         routing_mgr = RoutingManager(self.root_profile)
         mediation_mgr = MediationManager(self.root_profile)
@@ -67,16 +67,12 @@ class MultitenantRouteManager(RouteManager):
 
                 # If no error is thrown, it means there is already a record
                 LOGGER.debug(
-                    "Route record already exists for recipient %s to wallet %s. Skipping",
-                    recipient_key,
-                    wallet_id,
+                    "Route record already exists for recipient {recipient_key} to wallet {wallet_id}. Skipping"
                 )
                 return None
             except StorageNotFoundError:
                 LOGGER.debug(
-                    "Route record does not exist for recipient %s to wallet %s. Creating",
-                    recipient_key,
-                    wallet_id,
+                    "Route record does not exist for recipient {recipient_key} to wallet {wallet_id}. Creating"
                 )
 
         await routing_mgr.create_route_record(
@@ -86,11 +82,11 @@ class MultitenantRouteManager(RouteManager):
         # External mediation
         keylist_updates = None
         if mediation_record:
-            LOGGER.debug("Adding key to mediation record for recipient %s", recipient_key)
+            LOGGER.debug("Adding key to mediation record for recipient {recipient_key}")
             keylist_updates = await mediation_mgr.add_key(recipient_key)
             if replace_key:
                 LOGGER.debug(
-                    "Replacing key %s in mediation record %s", replace_key, recipient_key
+                    f"Replacing key {replace_key} in mediation record {recipient_key}"
                 )
                 keylist_updates = await mediation_mgr.remove_key(
                     replace_key, keylist_updates
@@ -104,7 +100,7 @@ class MultitenantRouteManager(RouteManager):
             profile = self.root_profile if base_mediation_record else profile
             responder = profile.inject(BaseResponder)
             LOGGER.debug(
-                "Sending keylist updates to mediator %s", mediation_record.connection_id
+                f"Sending keylist updates to mediator {mediation_record.connection_id}"
             )
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
@@ -137,7 +133,7 @@ class MultitenantRouteManager(RouteManager):
     ) -> RoutingInfo:
         """Return routing info."""
         LOGGER.debug(
-            "Getting routing info for profile %s", profile.settings.get("wallet.id", "")
+            f"Getting routing info for profile {profile.settings.get("wallet.id", "")}"
         )
         routing_keys = []
 

--- a/acapy_agent/multitenant/route_manager.py
+++ b/acapy_agent/multitenant/route_manager.py
@@ -67,12 +67,12 @@ class MultitenantRouteManager(RouteManager):
 
                 # If no error is thrown, it means there is already a record
                 LOGGER.debug(
-                    "Route record already exists for recipient {recipient_key} to wallet {wallet_id}. Skipping"
+                    f"Route record already exists for recipient {recipient_key} to wallet {wallet_id}. Skipping"
                 )
                 return None
             except StorageNotFoundError:
                 LOGGER.debug(
-                    "Route record does not exist for recipient {recipient_key} to wallet {wallet_id}. Creating"
+                    f"Route record does not exist for recipient {recipient_key} to wallet {wallet_id}. Creating"
                 )
 
         await routing_mgr.create_route_record(

--- a/acapy_agent/protocols/actionmenu/v1_0/handlers/menu_handler.py
+++ b/acapy_agent/protocols/actionmenu/v1_0/handlers/menu_handler.py
@@ -20,18 +20,17 @@ class MenuHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("MenuHandler called with context %s", context)
+        self._logger.debug(f"MenuHandler called with context {context}")
         assert isinstance(context.message, Menu)
 
         if not context.connection_ready:
             raise HandlerException("No connection established")
 
-        self._logger.info("Received action menu: %s", context.message)
+        self._logger.info(f"Received action menu: {context.message}")
 
         await save_connection_menu(
             context.message, context.connection_record.connection_id, context
         )
         self._logger.debug(
-            "Updated action menu on connection: %s",
-            context.connection_record.connection_id,
+            f"Updated action menu on connection: {context.connection_record.connection_id}"
         )

--- a/acapy_agent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
+++ b/acapy_agent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
@@ -20,7 +20,7 @@ class MenuRequestHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("MenuRequestHandler called with context %s", context)
+        self._logger.debug(f"MenuRequestHandler called with context {context}")
         assert isinstance(context.message, MenuRequest)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/actionmenu/v1_0/handlers/perform_handler.py
+++ b/acapy_agent/protocols/actionmenu/v1_0/handlers/perform_handler.py
@@ -20,7 +20,7 @@ class PerformHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("PerformHandler called with context %s", context)
+        self._logger.debug(f"PerformHandler called with context {context}")
         assert isinstance(context.message, Perform)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/actionmenu/v1_0/routes.py
+++ b/acapy_agent/protocols/actionmenu/v1_0/routes.py
@@ -187,7 +187,7 @@ async def actionmenu_request(request: web.BaseRequest):
         async with context.profile.session() as session:
             connection = await ConnRecord.retrieve_by_id(session, connection_id)
     except StorageNotFoundError as err:
-        LOGGER.debug("Connection not found for action menu request: %s", connection_id)
+        LOGGER.debug(f"Connection not found for action menu request: {connection_id}")
         raise web.HTTPNotFound(reason=err.roll_up) from err
 
     if connection.is_ready:
@@ -214,11 +214,11 @@ async def actionmenu_send(request: web.BaseRequest):
     connection_id = request.match_info["conn_id"]
     outbound_handler = request["outbound_message_router"]
     menu_json = await request.json()
-    LOGGER.debug("Received send-menu request: %s %s", connection_id, menu_json)
+    LOGGER.debug(f"Received send-menu request: {connection_id} {menu_json}")
     try:
         msg = Menu.deserialize(menu_json["menu"])
     except BaseModelError as err:
-        LOGGER.exception("Exception deserializing menu: %s", err.roll_up)
+        LOGGER.exception(f"Exception deserializing menu: {err.roll_up}")
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     try:
@@ -226,7 +226,7 @@ async def actionmenu_send(request: web.BaseRequest):
             connection = await ConnRecord.retrieve_by_id(session, connection_id)
     except StorageNotFoundError as err:
         LOGGER.debug(
-            "Connection not found for action menu send request: %s", connection_id
+            f"Connection not found for action menu send request: {connection_id}"
         )
         raise web.HTTPNotFound(reason=err.roll_up) from err
 

--- a/acapy_agent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
+++ b/acapy_agent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
@@ -19,13 +19,13 @@ class BasicMessageHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("BasicMessageHandler called with context %s", context)
+        self._logger.debug(f"BasicMessageHandler called with context {context}")
         assert isinstance(context.message, BasicMessage)
 
         if not context.connection_ready:
             raise HandlerException("No connection established")
 
-        self._logger.debug("Received basic message: %s", context.message.content)
+        self._logger.debug(f"Received basic message: {context.message.content}")
 
         body = context.message.content
         meta = {"content": body}

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_handler.py
@@ -17,7 +17,7 @@ class KeylistHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle keylist message."""
-        self._logger.debug("%s called with context %s", self.__class__.__name__, context)
+        self._logger.debug(f"{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, Keylist)
 
         if not context.connection_ready:
@@ -30,10 +30,9 @@ class KeylistHandler(BaseHandler):
                 )
         except StorageNotFoundError as err:
             self._logger.warning(
-                "Received keylist from connection that is not acting as mediator: %s",
-                err,
+                f"Received keylist from connection that is not acting as mediator: {err}",
             )
             return
 
         # TODO verify our keylist matches?
-        self._logger.info("Keylist received: %s", context.message)
+        self._logger.info(f"Keylist received: {context.message}")

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_query_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_query_handler.py
@@ -15,7 +15,7 @@ class KeylistQueryHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle keylist-query message."""
-        self._logger.debug("%s called with context %s", self.__class__.__name__, context)
+        self._logger.debug(f"{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, KeylistQuery)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_handler.py
@@ -15,7 +15,7 @@ class KeylistUpdateHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle keylist-update messages."""
-        self._logger.debug("%s called with context %s", self.__class__.__name__, context)
+        self._logger.debug(f"{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, KeylistUpdate)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py
@@ -16,7 +16,7 @@ class KeylistUpdateResponseHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle keylist-update-response message."""
-        self._logger.debug("{self.__class__.__name__} called with context {context}")
+        self._logger.debug(f"{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, KeylistUpdateResponse)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py
@@ -16,7 +16,7 @@ class KeylistUpdateResponseHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle keylist-update-response message."""
-        self._logger.debug("%s called with context %s", self.__class__.__name__, context)
+        self._logger.debug("{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, KeylistUpdateResponse)
 
         if not context.connection_ready:
@@ -36,8 +36,7 @@ class KeylistUpdateResponseHandler(BaseHandler):
         """Notify of keylist update response received."""
         route_manager = profile.inject(RouteManager)
         self._logger.debug(
-            "Retrieving connection ID from route manager of type %s",
-            type(route_manager).__name__,
+            f"Retrieving connection ID from route manager of type {type(route_manager).__name__}",
         )
         try:
             key_to_connection = {

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/mediation_deny_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/mediation_deny_handler.py
@@ -14,7 +14,7 @@ class MediationDenyHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle mediate-deny message."""
-        self._logger.debug("%s called with context %s", self.__class__.__name__, context)
+        self._logger.debug(f"{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, MediationDeny)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/mediation_grant_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/mediation_grant_handler.py
@@ -15,7 +15,7 @@ class MediationGrantHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle mediate-grant message."""
-        self._logger.debug("%s called with context %s", self.__class__.__name__, context)
+        self._logger.debug(f"{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, MediationGrant)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/mediation_request_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/mediation_request_handler.py
@@ -13,7 +13,7 @@ class MediationRequestHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle mediate-request message."""
-        self._logger.debug("%s called with context %s", self.__class__.__name__, context)
+        self._logger.debug(f"{self.__class__.__name__} called with context {context}")
         assert isinstance(context.message, MediationRequest)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/problem_report_handler.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/handlers/problem_report_handler.py
@@ -19,7 +19,7 @@ class CMProblemReportHandler(BaseHandler):
             context: Request context
             responder: Responder callback
         """
-        self._logger.debug("CMProblemReportHandler called with context %s", context)
+        self._logger.debug(f"CMProblemReportHandler called with context {context}")
         assert isinstance(context.message, CMProblemReport)
         self._logger.error(
             f"Received coordinate-mediation problem report message: {context.message}"

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/manager.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/manager.py
@@ -556,10 +556,7 @@ class MediationManager:
                 if updated.result != KeylistUpdated.RESULT_SUCCESS:
                     # TODO better handle different results?
                     LOGGER.warning(
-                        "Keylist update failure: %s(%s): %s",
-                        updated.action,
-                        updated.recipient_key,
-                        updated.result,
+                        f"Keylist update failure: {updated.action}({updated.recipient_key}): {updated.result}"
                     )
                     continue
                 if updated.action == KeylistUpdateRule.RULE_ADD:
@@ -590,8 +587,7 @@ class MediationManager:
                         )
                     except StorageNotFoundError as err:
                         LOGGER.error(
-                            "No route found while processing keylist update response: %s",
-                            err,
+                            f"No route found while processing keylist update response: {err}"
                         )
                     else:
                         if len(records) > 1:

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/route_manager.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/route_manager.py
@@ -52,7 +52,7 @@ class RouteManager(ABC):
                 wallet = session.inject(BaseWallet)
 
                 LOGGER.debug(
-                    "Creating new DID for connection %s", conn_record.connection_id
+                    "Creating new DID for connection {conn_record.connection_id}"
                 )
                 my_info = await wallet.create_local_did(SOV, ED25519)
                 conn_record.my_did = my_info.did
@@ -61,7 +61,7 @@ class RouteManager(ABC):
             async with profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 LOGGER.debug(
-                    "Getting DID info for connection %s", conn_record.connection_id
+                    f"Getting DID info for connection {conn_record.connection_id}"
                 )
                 my_info = await wallet.get_local_did(conn_record.my_did)
 
@@ -71,8 +71,7 @@ class RouteManager(ABC):
         """Perform mediation state validation."""
         if mediation_record.state != MediationRecord.STATE_GRANTED:
             LOGGER.error(
-                "Mediation is not granted for mediation identified by %s",
-                mediation_record.mediation_id,
+                f"Mediation is not granted for mediation identified by {mediation_record.mediation_id}"
             )
             raise RouteManagerError(
                 "Mediation is not granted for mediation identified by "
@@ -224,7 +223,7 @@ class RouteManager(ABC):
         await self.save_mediator_for_connection(profile, conn_record, mediation_record)
 
         if conn_record.invitation_key:
-            LOGGER.debug("Routing invitation key %s", conn_record.invitation_key)
+            LOGGER.debug(f"Routing invitation key {conn_record.invitation_key}")
             return await self._route_for_key(
                 profile,
                 conn_record.invitation_key,
@@ -242,7 +241,7 @@ class RouteManager(ABC):
     ):
         """Establish routing for a public DID."""
         LOGGER.debug(
-            "Routing verkey %s%s", verkey, " with mediation" if mediation_record else ""
+            f"Routing verkey {verkey}{" with mediation" if mediation_record else ""}"
         )
         return await self._route_for_key(
             profile, verkey, mediation_record, skip_if_exists=True
@@ -331,7 +330,7 @@ class CoordinateMediationV1RouteManager(RouteManager):
         skip_if_exists: bool = False,
         replace_key: Optional[str] = None,
     ) -> Optional[KeylistUpdate]:
-        LOGGER.debug("Routing for key %s using coordinate mediation", recipient_key)
+        LOGGER.debug("Routing for key {recipient_key} using coordinate mediation")
         if not mediation_record:
             return None
 

--- a/acapy_agent/protocols/coordinate_mediation/v1_0/route_manager.py
+++ b/acapy_agent/protocols/coordinate_mediation/v1_0/route_manager.py
@@ -52,7 +52,7 @@ class RouteManager(ABC):
                 wallet = session.inject(BaseWallet)
 
                 LOGGER.debug(
-                    "Creating new DID for connection {conn_record.connection_id}"
+                    f"Creating new DID for connection {conn_record.connection_id}"
                 )
                 my_info = await wallet.create_local_did(SOV, ED25519)
                 conn_record.my_did = my_info.did
@@ -330,7 +330,7 @@ class CoordinateMediationV1RouteManager(RouteManager):
         skip_if_exists: bool = False,
         replace_key: Optional[str] = None,
     ) -> Optional[KeylistUpdate]:
-        LOGGER.debug("Routing for key {recipient_key} using coordinate mediation")
+        LOGGER.debug(f"Routing for key {recipient_key} using coordinate mediation")
         if not mediation_record:
             return None
 

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/ack_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/ack_handler.py
@@ -17,7 +17,7 @@ class RotateAckHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("RotateAckHandler called with context %s", context)
+        self._logger.debug(f"RotateAckHandler called with context {context}")
         assert isinstance(context.message, RotateAck)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/hangup_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/hangup_handler.py
@@ -17,7 +17,7 @@ class HangupHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("HangupHandler called with context %s", context)
+        self._logger.debug(f"HangupHandler called with context {context}")
         assert isinstance(context.message, Hangup)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/problem_report_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/problem_report_handler.py
@@ -17,7 +17,7 @@ class ProblemReportHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("ProblemReportHandler called with context %s", context)
+        self._logger.debug(f"ProblemReportHandler called with context {context}")
         assert isinstance(context.message, RotateProblemReport)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/did_rotate/v1_0/handlers/rotate_handler.py
+++ b/acapy_agent/protocols/did_rotate/v1_0/handlers/rotate_handler.py
@@ -17,7 +17,7 @@ class RotateHandler(BaseHandler):
             context: request context
             responder: responder callback
         """
-        self._logger.debug("RotateHandler called with context %s", context)
+        self._logger.debug(f"RotateHandler called with context {context}")
         assert isinstance(context.message, Rotate)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/complete_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/complete_handler.py
@@ -15,7 +15,7 @@ class DIDXCompleteHandler(BaseHandler):
             context: Request context
             responder: Responder callback
         """
-        self._logger.debug("DIDXCompleteHandler called with context %s", context)
+        self._logger.debug(f"DIDXCompleteHandler called with context {context}")
         assert isinstance(context.message, DIDXComplete)
 
         profile = context.profile

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/invitation_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/invitation_handler.py
@@ -16,7 +16,7 @@ class InvitationHandler(BaseHandler):
             responder: Responder callback
         """
 
-        self._logger.debug("InvitationHandler called with context %s", context)
+        self._logger.debug(f"InvitationHandler called with context {context}")
         assert isinstance(context.message, InvitationMessage)
 
         report = DIDXProblemReport(

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/problem_report_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/problem_report_handler.py
@@ -17,10 +17,10 @@ class DIDXProblemReportHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Handle problem report message."""
-        self._logger.debug("DIDXProblemReportHandler called with context %s", context)
+        self._logger.debug(f"DIDXProblemReportHandler called with context {context}")
         assert isinstance(context.message, DIDXProblemReport)
 
-        self._logger.info("Received problem report: %s", context.message.description)
+        self._logger.info(f"Received problem report: {context.message.description}")
         profile = context.profile
         mgr = DIDXManager(profile)
         try:

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/request_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/request_handler.py
@@ -18,7 +18,7 @@ class DIDXRequestHandler(BaseHandler):
             responder: Responder callback
         """
 
-        self._logger.debug("DIDXRequestHandler called with context %s", context)
+        self._logger.debug(f"DIDXRequestHandler called with context {context}")
         assert isinstance(context.message, DIDXRequest)
 
         profile = context.profile

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/response_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/response_handler.py
@@ -16,7 +16,7 @@ class DIDXResponseHandler(BaseHandler):
             context: Request context
             responder: Responder callback
         """
-        self._logger.debug("DIDXResponseHandler called with context %s", context)
+        self._logger.debug(f"DIDXResponseHandler called with context {context}")
         assert isinstance(context.message, DIDXResponse)
 
         profile = context.profile

--- a/acapy_agent/protocols/discovery/v1_0/handlers/disclose_handler.py
+++ b/acapy_agent/protocols/discovery/v1_0/handlers/disclose_handler.py
@@ -15,7 +15,7 @@ class DiscloseHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("DiscloseHandler called with context %s", context)
+        self._logger.debug(f"DiscloseHandler called with context {context}")
         assert isinstance(context.message, Disclose)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/discovery/v1_0/handlers/query_handler.py
+++ b/acapy_agent/protocols/discovery/v1_0/handlers/query_handler.py
@@ -15,7 +15,7 @@ class QueryHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("QueryHandler called with context %s", context)
+        self._logger.debug(f"QueryHandler called with context {context}")
         assert isinstance(context.message, Query)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/discovery/v1_0/models/discovery_record.py
+++ b/acapy_agent/protocols/discovery/v1_0/models/discovery_record.py
@@ -93,8 +93,7 @@ class V10DiscoveryExchangeRecord(BaseExchangeRecord):
         result = await cls.query(session, tag_filter)
         if len(result) > 1:
             LOGGER.warning(
-                "More than one disclosure record found for connection: %s",
-                connection_id,
+                f"More than one disclosure record found for connection: {connection_id}"
             )
 
         return result[0] if result else None

--- a/acapy_agent/protocols/discovery/v2_0/handlers/disclosures_handler.py
+++ b/acapy_agent/protocols/discovery/v2_0/handlers/disclosures_handler.py
@@ -15,7 +15,7 @@ class DisclosuresHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("DiscloseHandler called with context %s", context)
+        self._logger.debug(f"DiscloseHandler called with context {context}")
         assert isinstance(context.message, Disclosures)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/discovery/v2_0/handlers/queries_handler.py
+++ b/acapy_agent/protocols/discovery/v2_0/handlers/queries_handler.py
@@ -15,7 +15,7 @@ class QueriesHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("QueryHandler called with context %s", context)
+        self._logger.debug(f"QueryHandler called with context {context}")
         assert isinstance(context.message, Queries)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/endorse_transaction/v1_0/handlers/endorsed_transaction_response_handler.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/handlers/endorsed_transaction_response_handler.py
@@ -24,7 +24,7 @@ class EndorsedTransactionResponseHandler(BaseHandler):
         """
 
         self._logger.debug(
-            "EndorsedTransactionResponseHandler called with context %s", context
+            f"EndorsedTransactionResponseHandler called with context {context}"
         )
         assert isinstance(context.message, EndorsedTransactionResponse)
 

--- a/acapy_agent/protocols/endorse_transaction/v1_0/handlers/refused_transaction_response_handler.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/handlers/refused_transaction_response_handler.py
@@ -22,7 +22,7 @@ class RefusedTransactionResponseHandler(BaseHandler):
         """
 
         self._logger.debug(
-            "RefusedTransactionResponseHandler called with context %s", context
+            f"RefusedTransactionResponseHandler called with context {context}"
         )
         assert isinstance(context.message, RefusedTransactionResponse)
 

--- a/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_acknowledgement_handler.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_acknowledgement_handler.py
@@ -22,7 +22,7 @@ class TransactionAcknowledgementHandler(BaseHandler):
         """
 
         self._logger.debug(
-            "TransactionAcknowledgementHandler called with context %s", context
+            f"TransactionAcknowledgementHandler called with context {context}"
         )
         assert isinstance(context.message, TransactionAcknowledgement)
 

--- a/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_cancel_handler.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_cancel_handler.py
@@ -21,7 +21,7 @@ class TransactionCancelHandler(BaseHandler):
             responder: Responder callback
         """
 
-        self._logger.debug("TransactionCancelHandler called with context %s", context)
+        self._logger.debug(f"TransactionCancelHandler called with context {context}")
         assert isinstance(context.message, CancelTransaction)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_job_to_send_handler.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_job_to_send_handler.py
@@ -21,7 +21,7 @@ class TransactionJobToSendHandler(BaseHandler):
             responder: Responder callback
         """
 
-        self._logger.debug("TransactionJobToSendHandler called with context %s", context)
+        self._logger.debug(f"TransactionJobToSendHandler called with context {context}")
         assert isinstance(context.message, TransactionJobToSend)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_request_handler.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_request_handler.py
@@ -23,7 +23,7 @@ class TransactionRequestHandler(BaseHandler):
             responder: Responder callback
         """
 
-        self._logger.debug("TransactionRequestHandler called with context %s", context)
+        self._logger.debug(f"TransactionRequestHandler called with context {context}")
         assert isinstance(context.message, TransactionRequest)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_resend_handler.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/handlers/transaction_resend_handler.py
@@ -21,7 +21,7 @@ class TransactionResendHandler(BaseHandler):
             responder: Responder callback
         """
 
-        self._logger.debug("TransactionResendHandler called with context %s", context)
+        self._logger.debug(f"TransactionResendHandler called with context {context}")
         assert isinstance(context.message, TransactionResend)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/endorse_transaction/v1_0/manager.py
+++ b/acapy_agent/protocols/endorse_transaction/v1_0/manager.py
@@ -919,4 +919,4 @@ class TransactionManager:
             await notify_endorse_did_attrib_event(self._profile, did, meta_data)
 
         else:
-            self._logger.debug("Unhandled ledger transaction type: %s", txn_type)
+            self._logger.debug(f"Unhandled ledger transaction type: {txn_type}")

--- a/acapy_agent/protocols/introduction/v0_1/demo_service.py
+++ b/acapy_agent/protocols/introduction/v0_1/demo_service.py
@@ -120,7 +120,7 @@ class DemoIntroductionService(BaseIntroductionService):
                 init_connection_id = row.tags["init_connection_id"]
                 await outbound_handler(msg, connection_id=init_connection_id)
                 found = True
-                LOGGER.info("Forwarded fwd-invitation to %s", init_connection_id)
+                LOGGER.info(f"Forwarded fwd-invitation to {init_connection_id}")
                 break
 
         if not found:

--- a/acapy_agent/protocols/introduction/v0_1/handlers/forward_invitation_handler.py
+++ b/acapy_agent/protocols/introduction/v0_1/handlers/forward_invitation_handler.py
@@ -16,7 +16,7 @@ class ForwardInvitationHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("ForwardInvitationHandler called with context %s", context)
+        self._logger.debug(f"ForwardInvitationHandler called with context {context}")
         assert isinstance(context.message, ForwardInvitation)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/introduction/v0_1/handlers/invitation_handler.py
+++ b/acapy_agent/protocols/introduction/v0_1/handlers/invitation_handler.py
@@ -17,7 +17,7 @@ class InvitationHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("InvitationHandler called with context %s", context)
+        self._logger.debug(f"InvitationHandler called with context {context}")
         assert isinstance(context.message, IntroInvitation)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/introduction/v0_1/handlers/invitation_request_handler.py
+++ b/acapy_agent/protocols/introduction/v0_1/handlers/invitation_request_handler.py
@@ -17,7 +17,7 @@ class InvitationRequestHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("InvitationRequestHandler called with context %s", context)
+        self._logger.debug(f"InvitationRequestHandler called with context {context}")
         assert isinstance(context.message, IntroInvitationRequest)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_ack_handler.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_ack_handler.py
@@ -21,11 +21,10 @@ class CredentialAckHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("CredentialAckHandler called with context %s", context)
+        self._logger.debug(f"CredentialAckHandler called with context {context}")
         assert isinstance(context.message, CredentialAck)
         self._logger.debug(
-            "Received credential ack message: %s",
-            context.message.serialize(as_string=True),
+            f"Received credential ack message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
@@ -27,10 +27,10 @@ class CredentialIssueHandler(BaseHandler):
         """
         r_time = get_timer()
         profile = context.profile
-        self._logger.debug("CredentialHandler called with context %s", context)
+        self._logger.debug(f"CredentialHandler called with context {context}")
         assert isinstance(context.message, CredentialIssue)
         self._logger.debug(
-            "Received credential message: %s", context.message.serialize(as_string=True)
+            f"Received credential message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
@@ -29,11 +29,10 @@ class CredentialOfferHandler(BaseHandler):
         """
         r_time = get_timer()
         profile = context.profile
-        self._logger.debug("CredentialOfferHandler called with context %s", context)
+        self._logger.debug(f"CredentialOfferHandler called with context {context}")
         assert isinstance(context.message, CredentialOffer)
         self._logger.debug(
-            "Received credential offer message: %s",
-            context.message.serialize(as_string=True),
+            f"Received credential offer message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_problem_report_handler.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_problem_report_handler.py
@@ -19,8 +19,7 @@ class CredentialProblemReportHandler(BaseHandler):
             responder: responder callback
         """
         self._logger.debug(
-            "Issue-credential v1.0 problem report handler called with context %s",
-            context,
+            f"Issue-credential v1.0 problem report handler called with context {context}",
         )
         assert isinstance(context.message, CredentialProblemReport)
 

--- a/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
@@ -28,11 +28,10 @@ class CredentialProposalHandler(BaseHandler):
         r_time = get_timer()
         profile = context.profile
 
-        self._logger.debug("CredentialProposalHandler called with context %s", context)
+        self._logger.debug(f"CredentialProposalHandler called with context {context}")
         assert isinstance(context.message, CredentialProposal)
         self._logger.debug(
-            "Received credential proposal message: %s",
-            context.message.serialize(as_string=True),
+            f"Received credential proposal message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
@@ -28,11 +28,10 @@ class CredentialRequestHandler(BaseHandler):
         """
         r_time = get_timer()
         profile = context.profile
-        self._logger.debug("CredentialRequestHandler called with context %s", context)
+        self._logger.debug(f"CredentialRequestHandler called with context {context}")
         assert isinstance(context.message, CredentialRequest)
         self._logger.debug(
-            "Received credential request message: %s",
-            context.message.serialize(as_string=True),
+            f"Received credential request message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v1_0/manager.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/manager.py
@@ -438,8 +438,7 @@ class CredentialManager:
 
         if cred_ex_record.state == V10CredentialExchange.STATE_REQUEST_SENT:
             LOGGER.warning(
-                "create_request called multiple times for v1.0 credential exchange: %s",
-                cred_ex_record.credential_exchange_id,
+                f"create_request called multiple times for v1.0 credential exchange: {cred_ex_record.credential_exchange_id}",
             )
             cred_req_ser = cred_ex_record._credential_request.ser
             cred_req_meta = cred_ex_record.credential_request_metadata
@@ -549,9 +548,7 @@ class CredentialManager:
                 raise ex
             if cred_ex_record.state != V10CredentialExchange.STATE_OFFER_SENT:
                 LOGGER.error(
-                    "Skipping credential request; exchange state is %s (id=%s)",
-                    cred_ex_record.state,
-                    cred_ex_record.credential_exchange_id,
+                    f"Skipping credential request; exchange state is {cred_ex_record.state} (id={cred_ex_record.credential_exchange_id})"
                 )
                 return None
 
@@ -589,8 +586,7 @@ class CredentialManager:
 
         if cred_ex_record.credential:
             LOGGER.warning(
-                "issue_credential called multiple times for v1.0 credential exchange %s",
-                cred_ex_record.credential_exchange_id,
+                "issue_credential called multiple times for v1.0 credential exchange {cred_ex_record.credential_exchange_id}",
             )
             credential_ser = cred_ex_record._credential.ser
 
@@ -635,8 +631,7 @@ class CredentialManager:
                 if attempt > 0:
                     LOGGER.info(
                         "Waiting 2s before retrying credential issuance "
-                        "for cred def '%s'",
-                        cred_def_id,
+                        "for cred def '{cred_def_id}'",
                     )
                     await asyncio.sleep(2)
 
@@ -834,7 +829,7 @@ class CredentialManager:
                 rev_reg_def=revoc_reg_def,
             )
         except IndyHolderError as e:
-            LOGGER.error("Error storing credential: %s: %s", e.error_code, e.message)
+            LOGGER.error(f"Error storing credential: {e.error_code}: {e.message}")
             raise e
 
         credential_json = await holder.get_credential(credential_id)
@@ -889,8 +884,7 @@ class CredentialManager:
                     )
                 except StorageNotFoundError:
                     LOGGER.warning(
-                        "Skipping credential exchange ack, record not found: '%s'",
-                        cred_ex_record.credential_exchange_id,
+                        "Skipping credential exchange ack, record not found: '{cred_ex_record.credential_exchange_id}'",
                     )
                     return (cred_ex_record, None)
 
@@ -899,9 +893,7 @@ class CredentialManager:
                     != V10CredentialExchange.STATE_CREDENTIAL_RECEIVED
                 ):
                     LOGGER.warning(
-                        "Skipping credential exchange ack, state is '%s' for record '%s'",
-                        cred_ex_record.state,
-                        cred_ex_record.credential_exchange_id,
+                        f"Skipping credential exchange ack, state is '{cred_ex_record.state}' for record '{cred_ex_record.credential_exchange_id}'"
                     )
                     return (cred_ex_record, None)
 
@@ -926,8 +918,7 @@ class CredentialManager:
             )
         else:
             LOGGER.warning(
-                "Configuration has no BaseResponder: cannot ack credential on %s",
-                cred_ex_record.thread_id,
+                f"Configuration has no BaseResponder: cannot ack credential on {cred_ex_record.thread_id}",
             )
 
         return (cred_ex_record, credential_ack_message)
@@ -954,8 +945,7 @@ class CredentialManager:
                 )
             except StorageNotFoundError:
                 LOGGER.warning(
-                    "Skip ack message on credential exchange, record not found %s",
-                    message._thread_id,
+                    "Skip ack message on credential exchange, record not found {message._thread_id}",
                 )
                 return None
 
@@ -989,8 +979,7 @@ class CredentialManager:
                 )
             except StorageNotFoundError:
                 LOGGER.warning(
-                    "Skip problem report on credential exchange, record not found %s",
-                    message._thread_id,
+                    f"Skip problem report on credential exchange, record not found {message._thread_id}",
                 )
                 return None
 

--- a/acapy_agent/protocols/issue_credential/v1_0/manager.py
+++ b/acapy_agent/protocols/issue_credential/v1_0/manager.py
@@ -586,7 +586,7 @@ class CredentialManager:
 
         if cred_ex_record.credential:
             LOGGER.warning(
-                "issue_credential called multiple times for v1.0 credential exchange {cred_ex_record.credential_exchange_id}",
+                f"issue_credential called multiple times for v1.0 credential exchange {cred_ex_record.credential_exchange_id}",
             )
             credential_ser = cred_ex_record._credential.ser
 
@@ -631,7 +631,7 @@ class CredentialManager:
                 if attempt > 0:
                     LOGGER.info(
                         "Waiting 2s before retrying credential issuance "
-                        "for cred def '{cred_def_id}'",
+                        f"for cred def '{cred_def_id}'",
                     )
                     await asyncio.sleep(2)
 
@@ -884,7 +884,7 @@ class CredentialManager:
                     )
                 except StorageNotFoundError:
                     LOGGER.warning(
-                        "Skipping credential exchange ack, record not found: '{cred_ex_record.credential_exchange_id}'",
+                        f"Skipping credential exchange ack, record not found: '{cred_ex_record.credential_exchange_id}'",
                     )
                     return (cred_ex_record, None)
 
@@ -945,7 +945,7 @@ class CredentialManager:
                 )
             except StorageNotFoundError:
                 LOGGER.warning(
-                    "Skip ack message on credential exchange, record not found {message._thread_id}",
+                    f"Skip ack message on credential exchange, record not found {message._thread_id}",
                 )
                 return None
 

--- a/acapy_agent/protocols/issue_credential/v2_0/formats/anoncreds/handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/formats/anoncreds/handler.py
@@ -89,10 +89,7 @@ class AnonCredsCredFormatHandler(V20CredFormatHandler):
 
         if len(records) > 1:
             LOGGER.warning(
-                "Cred ex id %s has %d %s detail records: should be 1",
-                cred_ex_id,
-                len(records),
-                AnonCredsCredFormatHandler.format.api,
+                f"Cred ex id {cred_ex_id} has {len(records)} {AnonCredsCredFormatHandler.format.api} detail records: should be 1"
             )
         return records[0] if records else None
 

--- a/acapy_agent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -107,10 +107,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
 
         if len(records) > 1:
             LOGGER.warning(
-                "Cred ex id %s has %d %s detail records: should be 1",
-                cred_ex_id,
-                len(records),
-                IndyCredFormatHandler.format.api,
+                f"Cred ex id {cred_ex_id} has {len(records)} {IndyCredFormatHandler.format.api} detail records: should be 1"
             )
         return records[0] if records else None
 
@@ -410,8 +407,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
                 return result, rev_reg_id, cred_rev_id
 
             LOGGER.info(
-                "Waiting 2s before retrying credential issuance for cred def '%s'",
-                cred_def_id,
+                f"Waiting 2s before retrying credential issuance for cred def '{cred_def_id}'",
             )
             await asyncio.sleep(2)
 

--- a/acapy_agent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -88,10 +88,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
 
         if len(records) > 1:
             LOGGER.warning(
-                "Cred ex id %s has %d %s detail records: should be 1",
-                cred_ex_id,
-                len(records),
-                LDProofCredFormatHandler.format.api,
+                f"Cred ex id {cred_ex_id} has {len(records)} {LDProofCredFormatHandler.format.api} detail records: should be 1"
             )
         return records[0] if records else None
 

--- a/acapy_agent/protocols/issue_credential/v2_0/formats/vc_di/handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/formats/vc_di/handler.py
@@ -109,10 +109,7 @@ class VCDICredFormatHandler(V20CredFormatHandler):
 
         if len(records) > 1:
             LOGGER.warning(
-                "Cred ex id %s has %d %s detail records: should be 1",
-                cred_ex_id,
-                len(records),
-                VCDICredFormatHandler.format.api,
+                f"Cred ex id {cred_ex_id} has {len(records)} {VCDICredFormatHandler.format.api} detail records: should be 1"
             )
         return records[0] if records else None
 

--- a/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_ack_handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_ack_handler.py
@@ -21,11 +21,10 @@ class V20CredAckHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20CredAckHandler called with context %s", context)
+        self._logger.debug(f"V20CredAckHandler called with context {context}")
         assert isinstance(context.message, V20CredAck)
         self._logger.debug(
-            "Received v2.0 credential ack message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 credential ack message: {context.message.serialize(as_string=True)}",
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
@@ -28,11 +28,10 @@ class V20CredIssueHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20CredIssueHandler called with context %s", context)
+        self._logger.debug(f"V20CredIssueHandler called with context {context}")
         assert isinstance(context.message, V20CredIssue)
         self._logger.debug(
-            "Received v2.0 credential issue message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 credential issue message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_offer_handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_offer_handler.py
@@ -30,11 +30,10 @@ class V20CredOfferHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20CredOfferHandler called with context %s", context)
+        self._logger.debug(f"V20CredOfferHandler called with context {context}")
         assert isinstance(context.message, V20CredOffer)
         self._logger.debug(
-            "Received v2.0 credential offer message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 credential offer message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_problem_report_handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_problem_report_handler.py
@@ -19,8 +19,7 @@ class CredProblemReportHandler(BaseHandler):
             responder: responder callback
         """
         self._logger.debug(
-            "Issue-credential v2.0 problem report handler called with context %s",
-            context,
+            f"Issue-credential v2.0 problem report handler called with context {context}"
         )
         assert isinstance(context.message, V20CredProblemReport)
 

--- a/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_proposal_handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_proposal_handler.py
@@ -28,11 +28,10 @@ class V20CredProposalHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20CredProposalHandler called with context %s", context)
+        self._logger.debug(f"V20CredProposalHandler called with context {context}")
         assert isinstance(context.message, V20CredProposal)
         self._logger.debug(
-            "Received v2.0 credential proposal message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 credential proposal message: {context.message.serialize(as_string=True)}",
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_request_handler.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/handlers/cred_request_handler.py
@@ -29,11 +29,10 @@ class V20CredRequestHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20CredRequestHandler called with context %s", context)
+        self._logger.debug(f"V20CredRequestHandler called with context {context}")
         assert isinstance(context.message, V20CredRequest)
         self._logger.debug(
-            "Received v2.0 credential request message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 credential request message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/issue_credential/v2_0/manager.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/manager.py
@@ -695,8 +695,7 @@ class V20CredManager:
             )
         else:
             LOGGER.warning(
-                "Configuration has no BaseResponder: cannot ack credential on %s",
-                cred_ex_record.thread_id,
+                "Configuration has no BaseResponder: cannot ack credential on {cred_ex_record.thread_id}"
             )
 
         return cred_ex_record, cred_ack_message

--- a/acapy_agent/protocols/issue_credential/v2_0/manager.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/manager.py
@@ -695,7 +695,7 @@ class V20CredManager:
             )
         else:
             LOGGER.warning(
-                "Configuration has no BaseResponder: cannot ack credential on {cred_ex_record.thread_id}"
+                f"Configuration has no BaseResponder: cannot ack credential on {cred_ex_record.thread_id}"
             )
 
         return cred_ex_record, cred_ack_message

--- a/acapy_agent/protocols/notification/v1_0/handlers/ack_handler.py
+++ b/acapy_agent/protocols/notification/v1_0/handlers/ack_handler.py
@@ -19,15 +19,14 @@ class V10AckHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20PresAckHandler called with context %s", context)
+        self._logger.debug(f"V20PresAckHandler called with context {context}")
         assert isinstance(context.message, V10Ack)
 
         if not context.connection_ready:
             raise HandlerException("No connection established")
 
         self._logger.info(
-            "Received v1.0 notification ack message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v1.0 notification ack message: {context.message.serialize(as_string=True)}",
         )
 
         trace_event(

--- a/acapy_agent/protocols/out_of_band/v1_0/handlers/problem_report_handler.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/handlers/problem_report_handler.py
@@ -21,7 +21,7 @@ class OOBProblemReportMessageHandler(BaseHandler):
             responder: Responder callback
         """
         self._logger.debug(
-            "OOBProblemReportMessageHandler called with context %s", context
+            f"OOBProblemReportMessageHandler called with context {context}"
         )
         assert isinstance(context.message, OOBProblemReport)
 

--- a/acapy_agent/protocols/out_of_band/v1_0/handlers/reuse_accept_handler.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/handlers/reuse_accept_handler.py
@@ -18,7 +18,7 @@ class HandshakeReuseAcceptMessageHandler(BaseHandler):
             responder: Responder callback
         """
         self._logger.debug(
-            "HandshakeReuseAcceptMessageHandler called with context %s", context
+            f"HandshakeReuseAcceptMessageHandler called with context {context}"
         )
         assert isinstance(context.message, HandshakeReuseAccept)
 

--- a/acapy_agent/protocols/out_of_band/v1_0/handlers/reuse_handler.py
+++ b/acapy_agent/protocols/out_of_band/v1_0/handlers/reuse_handler.py
@@ -17,7 +17,7 @@ class HandshakeReuseMessageHandler(BaseHandler):
             context: Request context
             responder: Responder callback
         """
-        self._logger.debug("HandshakeReuseMessageHandler called with context %s", context)
+        self._logger.debug(f"HandshakeReuseMessageHandler called with context {context}")
         assert isinstance(context.message, HandshakeReuse)
 
         if not context.connection_ready:

--- a/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_ack_handler.py
+++ b/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_ack_handler.py
@@ -21,11 +21,10 @@ class PresentationAckHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("PresentationAckHandler called with context %s", context)
+        self._logger.debug(f"PresentationAckHandler called with context {context}")
         assert isinstance(context.message, PresentationAck)
         self._logger.debug(
-            "Received presentation ack message: %s",
-            context.message.serialize(as_string=True),
+            f"Received presentation ack message: {context.message.serialize(as_string=True)}",
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_handler.py
+++ b/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_handler.py
@@ -27,11 +27,10 @@ class PresentationHandler(BaseHandler):
         """
         r_time = get_timer()
         profile = context.profile
-        self._logger.debug("PresentationHandler called with context %s", context)
+        self._logger.debug(f"PresentationHandler called with context {context}")
         assert isinstance(context.message, Presentation)
         self._logger.debug(
-            "Received presentation message: %s",
-            context.message.serialize(as_string=True),
+            f"Received presentation message: {context.message.serialize(as_string=True)}",
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_problem_report_handler.py
+++ b/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_problem_report_handler.py
@@ -19,7 +19,7 @@ class PresentationProblemReportHandler(BaseHandler):
             responder: responder callback
         """
         self._logger.debug(
-            "Present-proof v1.0 problem report handler called with context {context}",
+            f"Present-proof v1.0 problem report handler called with context {context}",
         )
         assert isinstance(context.message, PresentationProblemReport)
 

--- a/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_problem_report_handler.py
+++ b/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_problem_report_handler.py
@@ -19,8 +19,7 @@ class PresentationProblemReportHandler(BaseHandler):
             responder: responder callback
         """
         self._logger.debug(
-            "Present-proof v1.0 problem report handler called with context %s",
-            context,
+            "Present-proof v1.0 problem report handler called with context {context}",
         )
         assert isinstance(context.message, PresentationProblemReport)
 

--- a/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_proposal_handler.py
+++ b/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_proposal_handler.py
@@ -26,11 +26,10 @@ class PresentationProposalHandler(BaseHandler):
         """
         r_time = get_timer()
         profile = context.profile
-        self._logger.debug("PresentationProposalHandler called with context %s", context)
+        self._logger.debug(f"PresentationProposalHandler called with context {context}")
         assert isinstance(context.message, PresentationProposal)
         self._logger.debug(
-            "Received presentation proposal message: %s",
-            context.message.serialize(as_string=True),
+            f"Received presentation proposal message: {context.message.serialize(as_string=True)}"
         )
 
         if not context.connection_record:

--- a/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
+++ b/acapy_agent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
@@ -32,11 +32,10 @@ class PresentationRequestHandler(BaseHandler):
         r_time = get_timer()
         profile = context.profile
 
-        self._logger.debug("PresentationRequestHandler called with context %s", context)
+        self._logger.debug(f"PresentationRequestHandler called with context {context}")
         assert isinstance(context.message, PresentationRequest)
         self._logger.debug(
-            "Received presentation request message: %s",
-            context.message.serialize(as_string=True),
+            f"Received presentation request message: {context.message.serialize(as_string=True)}",
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/present_proof/v1_0/manager.py
+++ b/acapy_agent/protocols/present_proof/v1_0/manager.py
@@ -497,8 +497,7 @@ class PresentationManager:
                     await presentation_exchange_record.delete_record(session)
         else:
             LOGGER.warning(
-                "Configuration has no BaseResponder: cannot ack presentation on %s",
-                presentation_exchange_record.thread_id,
+                f"Configuration has no BaseResponder: cannot ack presentation on {presentation_exchange_record.thread_id}",
             )
 
     async def receive_presentation_ack(

--- a/acapy_agent/protocols/present_proof/v2_0/handlers/pres_ack_handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/handlers/pres_ack_handler.py
@@ -21,11 +21,10 @@ class V20PresAckHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20PresAckHandler called with context %s", context)
+        self._logger.debug(f"V20PresAckHandler called with context {context}")
         assert isinstance(context.message, V20PresAck)
         self._logger.debug(
-            "Received v2.0 presentation ack message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 presentation ack message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/present_proof/v2_0/handlers/pres_handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/handlers/pres_handler.py
@@ -27,10 +27,10 @@ class V20PresHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20PresHandler called with context %s", context)
+        self._logger.debug(f"V20PresHandler called with context {context}")
         assert isinstance(context.message, V20Pres)
         self._logger.debug(
-            "Received presentation message: %s", context.message.serialize(as_string=True)
+            f"Received presentation message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/present_proof/v2_0/handlers/pres_problem_report_handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/handlers/pres_problem_report_handler.py
@@ -19,8 +19,7 @@ class V20PresProblemReportHandler(BaseHandler):
             responder: responder callback
         """
         self._logger.debug(
-            "Present-proof v2.0 problem report handler called with context %s",
-            context,
+            f"Present-proof v2.0 problem report handler called with context {context}",
         )
         assert isinstance(context.message, V20PresProblemReport)
 

--- a/acapy_agent/protocols/present_proof/v2_0/handlers/pres_proposal_handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/handlers/pres_proposal_handler.py
@@ -26,11 +26,10 @@ class V20PresProposalHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20PresProposalHandler called with context %s", context)
+        self._logger.debug(f"V20PresProposalHandler called with context {context}")
         assert isinstance(context.message, V20PresProposal)
         self._logger.debug(
-            "Received v2.0 presentation proposal message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 presentation proposal message: {context.message.serialize(as_string=True)}"
         )
 
         if not context.connection_record:

--- a/acapy_agent/protocols/present_proof/v2_0/handlers/pres_request_handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/handlers/pres_request_handler.py
@@ -32,11 +32,10 @@ class V20PresRequestHandler(BaseHandler):
         """
         r_time = get_timer()
 
-        self._logger.debug("V20PresRequestHandler called with context %s", context)
+        self._logger.debug(f"V20PresRequestHandler called with context {context}")
         assert isinstance(context.message, V20PresRequest)
         self._logger.debug(
-            "Received v2.0 presentation request message: %s",
-            context.message.serialize(as_string=True),
+            f"Received v2.0 presentation request message: {context.message.serialize(as_string=True)}"
         )
 
         # If connection is present it must be ready for use

--- a/acapy_agent/protocols/present_proof/v2_0/manager.py
+++ b/acapy_agent/protocols/present_proof/v2_0/manager.py
@@ -438,8 +438,7 @@ class V20PresManager:
                     await pres_ex_record.delete_record(session)
         else:
             LOGGER.warning(
-                "Configuration has no BaseResponder: cannot ack presentation on %s",
-                pres_ex_record.thread_id,
+                f"Configuration has no BaseResponder: cannot ack presentation on {pres_ex_record.thread_id}",
             )
 
     async def receive_pres_ack(self, message: V20PresAck, conn_record: ConnRecord):

--- a/acapy_agent/protocols/problem_report/v1_0/handler.py
+++ b/acapy_agent/protocols/problem_report/v1_0/handler.py
@@ -15,13 +15,11 @@ class ProblemReportHandler(BaseHandler):
             responder: Responder used to reply
 
         """
-        self._logger.debug("ProblemReportHandler called with context %s", context)
+        self._logger.debug(f"ProblemReportHandler called with context {context}")
         assert isinstance(context.message, ProblemReport)
 
         self._logger.info(
-            "Received problem report from: %s, %r",
-            context.message_receipt.sender_did,
-            context.message,
+            f"Received problem report from: {context.message_receipt.sender_did}, {context.message}"
         )
 
         await context.profile.notify("acapy::problem_report", context.message.serialize())

--- a/acapy_agent/protocols/revocation_notification/v1_0/handlers/revoke_handler.py
+++ b/acapy_agent/protocols/revocation_notification/v1_0/handlers/revoke_handler.py
@@ -20,10 +20,8 @@ class RevokeHandler(BaseHandler):
             raise HandlerException("No connection established")
 
         self._logger.debug(
-            "Received notification of revocation for cred issued in thread %s "
-            "with comment: %s",
-            context.message.thread_id,
-            context.message.comment,
+            f"Received notification of revocation for cred issued in thread {context.message.thread_id} "
+            f"with comment: {context.message.comment}"
         )
         # Emit a webhook
         if context.settings.get("revocation.monitor_notification"):

--- a/acapy_agent/protocols/revocation_notification/v1_0/routes.py
+++ b/acapy_agent/protocols/revocation_notification/v1_0/routes.py
@@ -31,7 +31,7 @@ def register_events(event_bus: EventBus):
 
 async def on_revocation_published(profile: Profile, event: Event):
     """Handle issuer revoke event."""
-    LOGGER.debug("Received notification of revocation publication: %s", event.payload)
+    LOGGER.debug(f"Received notification of revocation publication: {event.payload}")
 
     should_notify = profile.settings.get("revocation.notify", False)
     responder = profile.inject(BaseResponder)
@@ -55,8 +55,7 @@ async def on_revocation_published(profile: Profile, event: Event):
                         record.to_message(), connection_id=record.connection_id
                     )
                     LOGGER.info(
-                        "Sent revocation notification for credential to %s",
-                        record.connection_id,
+                        f"Sent revocation notification for credential to {record.connection_id}"
                     )
 
     except StorageNotFoundError:

--- a/acapy_agent/protocols/revocation_notification/v2_0/handlers/revoke_handler.py
+++ b/acapy_agent/protocols/revocation_notification/v2_0/handlers/revoke_handler.py
@@ -20,10 +20,7 @@ class RevokeHandler(BaseHandler):
             raise HandlerException("No connection established")
 
         self._logger.debug(
-            "Received notification of revocation for %s cred %s with comment: %s",
-            context.message.revocation_format,
-            context.message.credential_id,
-            context.message.comment,
+            f"Received notification of revocation for {context.message.revocation_format} cred {context.message.credential_id} with comment: {context.message.comment}"
         )
         # Emit a webhook
         if context.settings.get("revocation.monitor_notification"):

--- a/acapy_agent/protocols/revocation_notification/v2_0/routes.py
+++ b/acapy_agent/protocols/revocation_notification/v2_0/routes.py
@@ -31,7 +31,7 @@ def register_events(event_bus: EventBus):
 
 async def on_revocation_published(profile: Profile, event: Event):
     """Handle issuer revoke event."""
-    LOGGER.debug("Received notification of revocation publication: %s", event.payload)
+    LOGGER.debug(f"Received notification of revocation publication: {event.payload}")
 
     should_notify = profile.settings.get("revocation.notify", False)
     responder = profile.inject(BaseResponder)
@@ -55,8 +55,7 @@ async def on_revocation_published(profile: Profile, event: Event):
                         record.to_message(), connection_id=record.connection_id
                     )
                     LOGGER.info(
-                        "Sent revocation notification for credential to %s",
-                        record.connection_id,
+                        f"Sent revocation notification for credential to {record.connection_id}",
                     )
 
     except StorageNotFoundError:

--- a/acapy_agent/protocols/routing/v1_0/handlers/forward_handler.py
+++ b/acapy_agent/protocols/routing/v1_0/handlers/forward_handler.py
@@ -18,13 +18,13 @@ class ForwardHandler(BaseHandler):
 
     async def handle(self, context: RequestContext, responder: BaseResponder):
         """Message handler implementation."""
-        self._logger.debug("ForwardHandler called with context %s", context)
+        self._logger.debug(f"ForwardHandler called with context {context}")
         assert isinstance(context.message, Forward)
 
         if not context.message_receipt.recipient_verkey:
             raise HandlerException("Cannot forward message: unknown recipient")
         self._logger.debug(
-            "Received forward for: %s", context.message_receipt.recipient_verkey
+            f"Received forward for: {context.message_receipt.recipient_verkey}"
         )
 
         packed = context.message.msg

--- a/acapy_agent/protocols/routing/v1_0/manager.py
+++ b/acapy_agent/protocols/routing/v1_0/manager.py
@@ -55,22 +55,22 @@ class RoutingManager:
         record = None
         while not record:
             try:
-                LOGGER.debug("Fetching routing record for verkey: %s", recip_verkey)
+                LOGGER.debug(f"Fetching routing record for verkey: {recip_verkey}")
                 async with self._profile.session() as session:
                     record = await RouteRecord.retrieve_by_recipient_key(
                         session, recip_verkey
                     )
-                LOGGER.debug("Found routing record for verkey: %s", recip_verkey)
+                LOGGER.debug(f"Found routing record for verkey: {recip_verkey}")
                 return record
             except StorageDuplicateError:
                 LOGGER.info(
-                    "Duplicate routing records found for verkey: %s", recip_verkey
+                    f"Duplicate routing records found for verkey: {recip_verkey}"
                 )
                 raise RouteNotFoundError(
                     f"More than one route record found with recipient key: {recip_verkey}"
                 )
             except StorageNotFoundError:
-                LOGGER.debug("No routing record found for verkey: %s", recip_verkey)
+                LOGGER.debug(f"No routing record found for verkey: {recip_verkey}")
                 i += 1
                 if i > RECIP_ROUTE_RETRY:
                     raise RouteNotFoundError(
@@ -144,7 +144,7 @@ class RoutingManager:
             )
         if not recipient_key:
             raise RoutingManagerError("Missing recipient_key")
-        LOGGER.debug("Creating routing record for verkey: %s", recipient_key)
+        LOGGER.debug(f"Creating routing record for verkey: {recipient_key}")
         route = RouteRecord(
             connection_id=client_connection_id,
             wallet_id=internal_wallet_id,
@@ -152,5 +152,5 @@ class RoutingManager:
         )
         async with self._profile.session() as session:
             await route.save(session, reason="Created new route")
-        LOGGER.info("Created routing record for verkey: %s", recipient_key)
+        LOGGER.info(f"Created routing record for verkey: {recipient_key}")
         return route

--- a/acapy_agent/protocols/trustping/v1_0/handlers/ping_handler.py
+++ b/acapy_agent/protocols/trustping/v1_0/handlers/ping_handler.py
@@ -20,13 +20,12 @@ class PingHandler(BaseHandler):
         assert isinstance(context.message, Ping)
 
         self._logger.debug(
-            "Received trust ping from: %s", context.message_receipt.sender_did
+            f"Received trust ping from: {context.message_receipt.sender_did}"
         )
 
         if not context.connection_ready:
             self._logger.info(
-                "Connection not active, skipping ping response: %s",
-                context.message_receipt.sender_did,
+                f"Connection not active, skipping ping response: {context.message_receipt.sender_did}",
             )
             return
 

--- a/acapy_agent/protocols/trustping/v1_0/handlers/ping_response_handler.py
+++ b/acapy_agent/protocols/trustping/v1_0/handlers/ping_response_handler.py
@@ -16,11 +16,11 @@ class PingResponseHandler(BaseHandler):
 
         """
 
-        self._logger.debug("PingResponseHandler called with context: %s", context)
+        self._logger.debug(f"PingResponseHandler called with context: {context}")
         assert isinstance(context.message, PingResponse)
 
         self._logger.debug(
-            "Received trust ping response from: %s", context.message_receipt.sender_did
+            f"Received trust ping response from: {context.message_receipt.sender_did}"
         )
 
         if context.settings.get("debug.monitor_ping"):

--- a/acapy_agent/resolver/default/legacy_peer.py
+++ b/acapy_agent/resolver/default/legacy_peer.py
@@ -287,10 +287,10 @@ class LegacyPeerDIDResolver(BaseDIDResolver):
             did = did[8:]
         try:
             doc, _ = await conn_mgr.fetch_did_document(did)
-            LOGGER.debug("Fetched doc %s", doc)
+            LOGGER.debug(f"Fetched doc {doc}")
             to_cache = RetrieveResult(True, doc=doc)
         except StorageNotFoundError:
-            LOGGER.debug("Failed to fetch doc for did %s", did)
+            LOGGER.debug(f"Failed to fetch doc for did {did}")
             to_cache = RetrieveResult(False)
 
         return to_cache
@@ -333,9 +333,9 @@ class LegacyPeerDIDResolver(BaseDIDResolver):
         attempt a lookup in the wallet for a document. If found, return True.
         Else, return False.
         """
-        LOGGER.debug("Checking if resolver supports DID %s", did)
+        LOGGER.debug(f"Checking if resolver supports DID {did}")
         if IndyDID.PATTERN.match(did):
-            LOGGER.debug("DID is valid IndyDID %s", did)
+            LOGGER.debug(f"DID is valid IndyDID {did}")
             result = await self.fetch_did_document(profile, did)
             return result.is_local
         else:

--- a/acapy_agent/resolver/default/peer1.py
+++ b/acapy_agent/resolver/default/peer1.py
@@ -103,10 +103,10 @@ class PeerDID1Resolver(BaseDIDResolver):
         conn_mgr = BaseConnectionManager(profile)
         try:
             doc, _ = await conn_mgr.fetch_did_document(did)
-            LOGGER.debug("Fetched doc %s", doc)
+            LOGGER.debug(f"Fetched doc {doc}")
             return doc
         except StorageNotFoundError:
-            LOGGER.debug("Failed to fetch doc for did %s", did)
+            LOGGER.debug(f"Failed to fetch doc for did {did}")
 
         return None
 
@@ -125,7 +125,7 @@ class PeerDID1Resolver(BaseDIDResolver):
         if result:
             # Apply corrections?
             result = contextualize(did, result)
-            LOGGER.debug("Resolved %s to %s", did, result)
+            LOGGER.debug(f"Resolved {did} to {result}")
             return result
         else:
             raise DIDNotFound(f"DID not found: {did}")

--- a/acapy_agent/resolver/default/peer3.py
+++ b/acapy_agent/resolver/default/peer3.py
@@ -97,7 +97,7 @@ class PeerDID3Resolver(BaseDIDResolver):
             ),
         ]
         if dids:
-            LOGGER.debug("Removing peer 2 to 3 mapping for deleted connection: %s", dids)
+            LOGGER.debug(f"Removing peer 2 to 3 mapping for deleted connection: {dids}")
         async with profile.session() as session:
             storage = session.inject(BaseStorage)
             for did in dids:
@@ -105,4 +105,4 @@ class PeerDID3Resolver(BaseDIDResolver):
                     record = StorageRecord(self.RECORD_TYPE_3_TO_2, None, None, did)
                     await storage.delete_record(record)
                 except StorageNotFoundError:
-                    LOGGER.debug("No peer 2 to 3 mapping found for: %s", did)
+                    LOGGER.debug(f"No peer 2 to 3 mapping found for: {did}")

--- a/acapy_agent/resolver/default/universal.py
+++ b/acapy_agent/resolver/default/universal.py
@@ -90,7 +90,7 @@ class UniversalResolver(BaseDIDResolver):
                 if resp.status == 200:
                     doc = await resp.json()
                     did_doc = doc["didDocument"]
-                    LOGGER.info("Retrieved doc: %s", did_doc)
+                    LOGGER.info(f"Retrieved doc: {did_doc}")
                     return did_doc
                 if resp.status == 404:
                     raise DIDNotFound(f"{did} not found by {self.__class__.__name__}")

--- a/acapy_agent/resolver/did_resolver.py
+++ b/acapy_agent/resolver/did_resolver.py
@@ -59,7 +59,7 @@ class DIDResolver:
             DID.validate(did)
         for resolver in await self._match_did_to_resolver(profile, did):
             try:
-                LOGGER.debug("Resolving DID %s with %s", did, resolver)
+                LOGGER.debug(f"Resolving DID {did} with {resolver}")
                 document = await asyncio.wait_for(
                     resolver.resolve(
                         profile,
@@ -68,10 +68,10 @@ class DIDResolver:
                     ),
                     timeout if timeout is not None else self.DEFAULT_TIMEOUT,
                 )
-                LOGGER.debug("Resolved DID %s with %s: %s", did, resolver, document)
+                LOGGER.debug(f"Resolved DID {did} with {resolver}: {document}")
                 return resolver, document
             except DIDNotFound:
-                LOGGER.debug("DID %s not found by resolver %s", did, resolver)
+                LOGGER.debug(f"DID {did} not found by resolver {resolver}")
 
         raise DIDNotFound(f"DID {did} could not be resolved")
 
@@ -116,7 +116,7 @@ class DIDResolver:
             for resolver in self.resolvers
             if await resolver.supports(profile, did)
         ]
-        LOGGER.debug("Valid resolvers for DID %s: %s", did, valid_resolvers)
+        LOGGER.debug(f"Valid resolvers for DID {did}: {valid_resolvers}")
         native_resolvers = filter(lambda resolver: resolver.native, valid_resolvers)
         non_native_resolvers = filter(
             lambda resolver: not resolver.native, valid_resolvers

--- a/acapy_agent/revocation/models/issuer_rev_reg_record.py
+++ b/acapy_agent/revocation/models/issuer_rev_reg_record.py
@@ -203,7 +203,7 @@ class IssuerRevRegRecord(BaseRecord):
         issuer = profile.inject(IndyIssuer)
         tails_hopper_dir = indy_client_dir(join("tails", ".hopper"), create=True)
 
-        LOGGER.debug("Creating revocation registry with size: %d", self.max_cred_num)
+        LOGGER.debug(f"Creating revocation registry with size: {self.max_cred_num}")
 
         try:
             (

--- a/acapy_agent/revocation/models/revocation_registry.py
+++ b/acapy_agent/revocation/models/revocation_registry.py
@@ -160,8 +160,7 @@ class RevocationRegistry:
             raise RevocationError("Tails file public URI is empty")
 
         LOGGER.info(
-            "Downloading the tails file for the revocation registry: %s",
-            self.registry_id,
+            f"Downloading the tails file for the revocation registry: {self.registry_id}"
         )
 
         tails_file_path = Path(self.get_receiving_tails_local_path())

--- a/acapy_agent/revocation/recover.py
+++ b/acapy_agent/revocation/recover.py
@@ -39,7 +39,7 @@ async def fetch_txns(genesis_txns, registry_id):
     pool = await vdr_module.open_pool(transactions=genesis_txns)
     LOGGER.debug("Connected to pool")
 
-    LOGGER.debug("Fetch registry: %s", registry_id)
+    LOGGER.debug(f"Fetch registry: {registry_id}")
     fetch = vdr_module.ledger.build_get_revoc_reg_def_request(None, registry_id)
     result = await pool.submit_request(fetch)
     if not result["data"]:
@@ -47,7 +47,7 @@ async def fetch_txns(genesis_txns, registry_id):
     data = result["data"]
     data["ver"] = "1.0"
     defn = credx_module.RevocationRegistryDefinition.load(data)
-    LOGGER.debug("Tails URL: %s", defn.tails_location)
+    LOGGER.debug(f"Tails URL: {defn.tails_location}")
 
     async with aiohttp.ClientSession() as session:
         data = await session.get(defn.tails_location)
@@ -58,7 +58,7 @@ async def fetch_txns(genesis_txns, registry_id):
                 f"Tails hash mismatch {tails_hash} {defn.tails_hash}"
             )
         else:
-            LOGGER.debug("Checked tails hash: %s", tails_hash)
+            LOGGER.debug(f"Checked tails hash: {tails_hash}")
         tails_temp = tempfile.NamedTemporaryFile(delete=False)
         tails_temp.write(tails_data)
         tails_temp.close()
@@ -75,9 +75,9 @@ async def fetch_txns(genesis_txns, registry_id):
     accum_to["ver"] = "1.0"
     delta = credx_module.RevocationRegistryDelta.load(accum_to)
     registry = credx_module.RevocationRegistry.load(accum_to)
-    LOGGER.debug("Ledger registry state: %s", registry.to_json())
+    LOGGER.debug(f"Ledger registry state: {registry.to_json()}")
     revoked = set(result["data"]["value"]["revoked"])
-    LOGGER.debug("Ledger revoked indexes: %s", revoked)
+    LOGGER.debug(f"Ledger revoked indexes: {revoked}")
 
     return defn, registry, delta, revoked, tails_temp
 
@@ -98,17 +98,16 @@ async def generate_ledger_rrrecovery_txn(
     mismatch = prev_revoked - set_revoked
     if mismatch:
         LOGGER.warning(
-            "Credential index(es) revoked on the ledger, but not in wallet: %s",
-            mismatch,
+            f"Credential index(es) revoked on the ledger, but not in wallet: {mismatch}",
         )
 
     updates = set_revoked - prev_revoked
     if not updates:
         LOGGER.debug("No updates to perform")
     else:
-        LOGGER.debug("New revoked indexes: %s", updates)
+        LOGGER.debug(f"New revoked indexes: {updates}")
 
-        LOGGER.debug("tails_temp: %s", tails_temp.name)
+        LOGGER.debug(f"tails_temp: {tails_temp.name}")
         update_registry = registry.copy()
         new_delta = update_registry.update(
             cred_def, defn, rev_reg_def_private, [], updates

--- a/acapy_agent/revocation/routes.py
+++ b/acapy_agent/revocation/routes.py
@@ -1009,9 +1009,7 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
     rev_reg_id = request.match_info["rev_reg_id"]
     apply_ledger_update = json.loads(request.query.get("apply_ledger_update", "false"))
     LOGGER.debug(
-        "Update revocation state request for rev_reg_id = %s, apply_ledger_update = %s",
-        rev_reg_id,
-        apply_ledger_update,
+        f"Update revocation state request for rev_reg_id = {rev_reg_id}, apply_ledger_update = {apply_ledger_update}"
     )
 
     rev_reg_record = None
@@ -1031,9 +1029,9 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
             available_write_ledgers = await ledger_manager.get_write_ledgers()
             pool = write_ledger.pool
             genesis_transactions = pool.genesis_txns
-            LOGGER.debug("available write_ledgers = %s", available_write_ledgers)
-            LOGGER.debug("write_ledger = %s", write_ledger)
-            LOGGER.debug("write_ledger pool = %s", pool)
+            LOGGER.debug(f"available write_ledgers = {available_write_ledgers}")
+            LOGGER.debug(f"write_ledger = {write_ledger}")
+            LOGGER.debug(f"write_ledger pool = {pool}")
 
         if not genesis_transactions:
             raise web.HTTPInternalServerError(
@@ -1304,7 +1302,7 @@ async def send_rev_reg_def(request: web.BaseRequest):
             write_ledger=write_ledger,
             endorser_did=endorser_did,
         )
-        LOGGER.debug("published rev reg definition: %s", rev_reg_id)
+        LOGGER.debug(f"published rev reg definition: {rev_reg_id}")
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     except RevocationError as err:
@@ -1421,7 +1419,7 @@ async def send_rev_reg_entry(request: web.BaseRequest):
             write_ledger=write_ledger,
             endorser_did=endorser_did,
         )
-        LOGGER.debug("published registry entry: %s", rev_reg_id)
+        LOGGER.debug(f"published registry entry: {rev_reg_id}")
 
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
@@ -1530,7 +1528,7 @@ async def set_rev_reg_state(request: web.BaseRequest):
         async with profile.session() as session:
             await rev_reg.set_state(session, state)
 
-        LOGGER.debug("set registry %s state: %s", rev_reg_id, state)
+        LOGGER.debug(f"set registry {rev_reg_id} state: {state}")
 
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
@@ -1628,8 +1626,7 @@ async def on_revocation_registry_init_event(profile: Profile, event: Event):
                 else:
                     LOGGER.warning(
                         "Configuration has no BaseResponder: cannot update "
-                        "revocation on registry ID: %s",
-                        record_id,
+                        f"revocation on registry ID: {record_id}"
                     )
 
     record_id = meta_data["context"]["issuer_rev_id"]
@@ -1707,8 +1704,7 @@ async def on_revocation_entry_event(profile: Profile, event: Event):
             else:
                 LOGGER.warning(
                     "Configuration has no BaseResponder: cannot update "
-                    "revocation on cred def %s",
-                    meta_data["endorser"]["cred_def_id"],
+                    f"revocation on cred def {meta_data["endorser"]["cred_def_id"]}"
                 )
 
 

--- a/acapy_agent/revocation_anoncreds/manager.py
+++ b/acapy_agent/revocation_anoncreds/manager.py
@@ -336,9 +336,7 @@ class RevocationManager:
 
         """
         self._logger.debug(
-            "Setting credential revoked state for %d credentials in rev_reg_id=%s",
-            len(cred_rev_ids),
-            rev_reg_id,
+            f"Setting credential revoked state for {len(cred_rev_ids)} credentials in rev_reg_id={rev_reg_id}"
         )
         cred_rev_ids = [str(_id) for _id in cred_rev_ids]  # Method expects strings
         updated_cred_rev_ids = []  # Track updated to know if any were not found
@@ -353,13 +351,12 @@ class RevocationManager:
             for record in cred_rev_records:
                 cred_rev_id = record.cred_rev_id
                 self._logger.debug(
-                    "Updating IssuerCredRevRecord for cred_rev_id=%s", cred_rev_id
+                    f"Updating IssuerCredRevRecord for cred_rev_id={cred_rev_id}"
                 )
                 record.state = IssuerCredRevRecord.STATE_REVOKED
                 await record.save(txn, reason="revoke credential")
                 self._logger.debug(
-                    "Updated IssuerCredRevRecord state to REVOKED for cred_rev_id=%s",
-                    cred_rev_id,
+                    f"Updated IssuerCredRevRecord state to REVOKED for cred_rev_id={cred_rev_id}"
                 )
                 updated_cred_rev_ids.append(cred_rev_id)
 
@@ -371,8 +368,7 @@ class RevocationManager:
         ]
         if missing_cred_rev_ids:
             self._logger.warning(
-                "IssuerCredRevRecord not found for cred_rev_id=%s. Could not revoke.",
-                missing_cred_rev_ids,
+                f"IssuerCredRevRecord not found for cred_rev_id={missing_cred_rev_ids}. Could not revoke."
             )
 
         # Map cred_ex_version to the record type
@@ -406,9 +402,7 @@ class RevocationManager:
                         await cred_ex_record.save(txn, reason="revoke credential")
 
                         self._logger.debug(
-                            "Updated %s state to REVOKED for cred_ex_id=%s",
-                            record_type.__name__,
-                            cred_ex_id,
+                            f"Updated {record_type.__name__} state to REVOKED for cred_ex_id={cred_ex_id}"
                         )
                         await txn.commit()
                         break  # Record found, no need to check other record type

--- a/acapy_agent/revocation_anoncreds/manager.py
+++ b/acapy_agent/revocation_anoncreds/manager.py
@@ -409,11 +409,5 @@ class RevocationManager:
                     except StorageNotFoundError:
                         # Credential Exchange records may have been deleted, which is fine
                         self._logger.debug(
-                            "%s not found for cred_ex_id=%s / cred_rev_id=%s.%s",
-                            record_type.__name__,
-                            cred_ex_id,
-                            cred_rev_record.cred_rev_id,
-                            " Checking next record type."
-                            if not known_record_type
-                            else "",
+                            f"{record_type.__name__} not found for cred_ex_id={cred_ex_id} / cred_rev_id={red_rev_record.cred_rev_id}.{" Checking next record type." if not known_record_type else ""}"
                         )

--- a/acapy_agent/revocation_anoncreds/recover.py
+++ b/acapy_agent/revocation_anoncreds/recover.py
@@ -41,7 +41,7 @@ async def fetch_txns(genesis_txns, registry_id):
     pool = await vdr_module.open_pool(transactions=genesis_txns)
     LOGGER.debug("Connected to pool")
 
-    LOGGER.debug("Fetch registry: %s", registry_id)
+    LOGGER.debug(f"Fetch registry: {registry_id}")
     fetch = vdr_module.ledger.build_get_revoc_reg_def_request(None, registry_id)
     result = await pool.submit_request(fetch)
     if not result["data"]:
@@ -49,7 +49,7 @@ async def fetch_txns(genesis_txns, registry_id):
     data = result["data"]
     data["ver"] = "1.0"
     defn = credx_module.RevocationRegistryDefinition.load(data)
-    LOGGER.debug("Tails URL: %s", defn.tails_location)
+    LOGGER.debug(f"Tails URL: {defn.tails_location}")
 
     async with aiohttp.ClientSession() as session:
         data = await session.get(defn.tails_location)
@@ -60,7 +60,7 @@ async def fetch_txns(genesis_txns, registry_id):
                 f"Tails hash mismatch {tails_hash} {defn.tails_hash}"
             )
         else:
-            LOGGER.debug("Checked tails hash: %s", tails_hash)
+            LOGGER.debug(f"Checked tails hash: {tails_hash}")
         tails_temp = tempfile.NamedTemporaryFile(delete=False)
         tails_temp.write(tails_data)
         tails_temp.close()
@@ -77,9 +77,9 @@ async def fetch_txns(genesis_txns, registry_id):
     accum_to["ver"] = "1.0"
     delta = credx_module.RevocationRegistryDelta.load(accum_to)
     registry = credx_module.RevocationRegistry.load(accum_to)
-    LOGGER.debug("Ledger registry state: %s", registry.to_json())
+    LOGGER.debug(f"Ledger registry state: {registry.to_json()}")
     revoked = set(result["data"]["value"]["revoked"])
-    LOGGER.debug("Ledger revoked indexes: %s", revoked)
+    LOGGER.debug(f"Ledger revoked indexes: {revoked}")
 
     return defn, registry, delta, revoked, tails_temp
 
@@ -100,17 +100,16 @@ async def generate_ledger_rrrecovery_txn(
     mismatch = prev_revoked - set_revoked
     if mismatch:
         LOGGER.warning(
-            "Credential index(es) revoked on the ledger, but not in wallet: %s",
-            mismatch,
+            f"Credential index(es) revoked on the ledger, but not in wallet: {mismatch}"
         )
 
     updates = set_revoked - prev_revoked
     if not updates:
         LOGGER.debug("No updates to perform")
     else:
-        LOGGER.debug("New revoked indexes: %s", updates)
+        LOGGER.debug(f"New revoked indexes: {updates}")
 
-        LOGGER.debug("tails_temp: %s", tails_temp.name)
+        LOGGER.debug(f"tails_temp: {tails_temp.name}")
         update_registry = registry.copy()
         new_delta = update_registry.update(
             cred_def, defn, rev_reg_def_private, [], updates

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -879,10 +879,10 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
             ledger_manager = context.injector.inject(BaseMultipleLedgerManager)
             write_ledger = context.injector.inject(BaseLedger)
             available_write_ledgers = await ledger_manager.get_write_ledgers()
-            LOGGER.debug("available write_ledgers = {available_write_ledgers}")
-            LOGGER.debug("write_ledger = {write_ledger}")
+            LOGGER.debug(f"available write_ledgers = {available_write_ledgers}")
+            LOGGER.debug(f"write_ledger = {write_ledger}")
             pool = write_ledger.pool
-            LOGGER.debug("write_ledger pool = {pool}")
+            LOGGER.debug(f"write_ledger pool = {pool}")
 
             genesis_transactions = pool.genesis_txns
 

--- a/acapy_agent/revocation_anoncreds/routes.py
+++ b/acapy_agent/revocation_anoncreds/routes.py
@@ -858,9 +858,7 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
     rev_reg_id = request.match_info["rev_reg_id"]
     apply_ledger_update = json.loads(request.query.get("apply_ledger_update", "false"))
     LOGGER.debug(
-        "Update revocation state request for rev_reg_id = %s, apply_ledger_update = %s",
-        rev_reg_id,
-        apply_ledger_update,
+        f"Update revocation state request for rev_reg_id = {rev_reg_id}, apply_ledger_update = {apply_ledger_update}"
     )
 
     genesis_transactions = None
@@ -881,10 +879,10 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
             ledger_manager = context.injector.inject(BaseMultipleLedgerManager)
             write_ledger = context.injector.inject(BaseLedger)
             available_write_ledgers = await ledger_manager.get_write_ledgers()
-            LOGGER.debug("available write_ledgers = %s", available_write_ledgers)
-            LOGGER.debug("write_ledger = %s", write_ledger)
+            LOGGER.debug("available write_ledgers = {available_write_ledgers}")
+            LOGGER.debug("write_ledger = {write_ledger}")
             pool = write_ledger.pool
-            LOGGER.debug("write_ledger pool = %s", pool)
+            LOGGER.debug("write_ledger pool = {pool}")
 
             genesis_transactions = pool.genesis_txns
 

--- a/acapy_agent/tails/indy_tails_server.py
+++ b/acapy_agent/tails/indy_tails_server.py
@@ -47,10 +47,10 @@ class IndyTailsServer(BaseTailsServer):
             ledger_manager = context.injector.inject(BaseMultipleLedgerManager)
             write_ledger = context.injector.inject(BaseLedger)
             available_write_ledgers = await ledger_manager.get_write_ledgers()
-            LOGGER.debug("available write_ledgers = %s", available_write_ledgers)
-            LOGGER.debug("write_ledger = %s", write_ledger)
+            LOGGER.debug(f"available write_ledgers = {available_write_ledgers}")
+            LOGGER.debug(f"write_ledger = {write_ledger}")
             pool = write_ledger.pool
-            LOGGER.debug("write_ledger pool = %s", pool)
+            LOGGER.debug(f"write_ledger pool = {pool}")
 
             genesis_transactions = pool.genesis_txns
 

--- a/acapy_agent/transport/inbound/manager.py
+++ b/acapy_agent/transport/inbound/manager.py
@@ -208,7 +208,7 @@ class InboundTransportManager:
                         break
 
         if accepted:
-            LOGGER.debug("Returned message to socket %s", session.session_id)
+            LOGGER.debug(f"Returned message to socket {session.session_id}")
         return accepted
 
     def return_undelivered(self, outbound: OutboundMessage) -> bool:

--- a/acapy_agent/transport/inbound/session.py
+++ b/acapy_agent/transport/inbound/session.py
@@ -299,7 +299,7 @@ class InboundSession:
                     try:
                         response = await self.encode_outbound(self.response_buffer)
                     except WireFormatError as e:
-                        LOGGER.warning("Error encoding direct response: %s", str(e))
+                        LOGGER.warning(f"Error encoding direct response: {str(e)}")
                         self.clear_response()
                 if response:
                     return response

--- a/acapy_agent/transport/inbound/ws.py
+++ b/acapy_agent/transport/inbound/ws.py
@@ -113,7 +113,7 @@ class WsTransport(BaseInboundTransport):
 
                 if inbound.done():
                     msg: WSMessage = inbound.result()
-                    LOGGER.info("Websocket received message: %s", msg.data)
+                    LOGGER.info(f"Websocket received message: {msg.data}")
                     if msg.type in (WSMsgType.TEXT, WSMsgType.BINARY):
                         try:
                             await session.receive(msg.data)
@@ -121,15 +121,11 @@ class WsTransport(BaseInboundTransport):
                             await ws.close(1003)  # unsupported data error
                     elif msg.type == WSMsgType.ERROR:
                         LOGGER.error(
-                            "Websocket connection closed with exception: %s",
-                            ws.exception(),
+                            f"Websocket connection closed with exception: {ws.exception()}"
                         )
                     else:
                         LOGGER.error(
-                            "Unexpected Websocket message type received: %s: %s, %s",
-                            msg.type,
-                            msg.data,
-                            msg.extra,
+                            f"Unexpected Websocket message type received: {msg.type}: {msg.data}, {msg.extra}"
                         )
                     if not ws.closed:
                         inbound = loop.create_task(ws.receive())

--- a/acapy_agent/transport/inbound/ws.py
+++ b/acapy_agent/transport/inbound/ws.py
@@ -133,7 +133,7 @@ class WsTransport(BaseInboundTransport):
                 if outbound.done() and not ws.closed:
                     # response would be None if session was closed
                     response = outbound.result()
-                    LOGGER.debug("Sending outbound websocket message %s", response)
+                    LOGGER.debug(f"Sending outbound websocket message {response}")
                     if isinstance(response, bytes):
                         await ws.send_bytes(response)
                     else:

--- a/acapy_agent/transport/outbound/http.py
+++ b/acapy_agent/transport/outbound/http.py
@@ -74,7 +74,7 @@ class HttpTransport(BaseOutboundTransport):
         else:
             headers["Content-Type"] = "application/json"
         self.logger.debug(
-            "Posting to %s; Data: %s; Headers: %s", endpoint, payload, headers
+            f"Posting to {endpoint}; Data: {payload}; Headers: {headers}"
         )
         async with self.client_session.post(
             endpoint, data=payload, headers=headers

--- a/acapy_agent/transport/outbound/manager.py
+++ b/acapy_agent/transport/outbound/manager.py
@@ -345,8 +345,7 @@ class OutboundTransportManager:
                 if queued.state == QueuedOutboundMessage.STATE_DONE:
                     if queued.error:
                         LOGGER.exception(
-                            "Outbound message could not be delivered to %s",
-                            queued.endpoint,
+                            f"Outbound message could not be delivered to {queued.endpoint}",
                             exc_info=queued.error,
                         )
                         if self.handle_not_delivered and queued.message:
@@ -476,13 +475,10 @@ class OutboundTransportManager:
         if retry:
             LOGGER.debug(
                 (
-                    ">>> Error when posting to: %s; "
-                    "Error: %s; "
-                    "Payload: %s; Re-queue failed message ..."
-                ),
-                queued.endpoint,
-                queued.error,
-                queued.payload,
+                    f">>> Error when posting to: {queued.endpoint}; "
+                    f"Error: {queued.error}; "
+                    f"Payload: {queued.payload}; Re-queue failed message ..."
+                )
             )
         else:
             err_msg = ">>> Outbound message failed to deliver, NOT Re-queued."

--- a/acapy_agent/transport/outbound/ws.py
+++ b/acapy_agent/transport/outbound/ws.py
@@ -49,7 +49,7 @@ class WsTransport(BaseOutboundTransport):
         """
         # aiohttp should automatically handle websocket sessions
         async with self.client_session.ws_connect(endpoint, headers=metadata) as ws:
-            self.logger.debug("Sending outbound websocket message %s", payload)
+            self.logger.debug(f"Sending outbound websocket message {payload}")
             if isinstance(payload, bytes):
                 await ws.send_bytes(payload)
             else:

--- a/acapy_agent/transport/v2_pack_format.py
+++ b/acapy_agent/transport/v2_pack_format.py
@@ -80,7 +80,7 @@ class V2PackWireFormat(BaseWireFormat):
         # handle transport decorator
         receipt.direct_response_mode = message_dict.get("return_route")
 
-        LOGGER.debug("Expanded message: %s", message_dict)
+        LOGGER.debug(f"Expanded message: {message_dict}")
 
         return message_dict, receipt
 

--- a/acapy_agent/utils/classloader.py
+++ b/acapy_agent/utils/classloader.py
@@ -73,7 +73,7 @@ class ClassLoader:
         try:
             return import_module(mod_path, package)
         except ModuleNotFoundError as e:
-            LOGGER.warning("Module %s not found during import", full_path)
+            LOGGER.warning(f"Module {full_path} not found during import")
             raise ModuleLoadError(f"Unable to import module {full_path}: {str(e)}") from e
 
     @classmethod
@@ -106,7 +106,7 @@ class ClassLoader:
             mod_path = default_module
         else:
             LOGGER.warning(
-                "Cannot resolve class name %s with no default module", class_name
+                f"Cannot resolve class name {class_name} with no default module"
             )
             raise ClassNotFoundError(
                 f"Cannot resolve class name with no default module: {class_name}"
@@ -115,24 +115,24 @@ class ClassLoader:
         mod = cls.load_module(mod_path, package)
         if not mod:
             LOGGER.warning(
-                "Module %s not found when loading class %s", mod_path, class_name
+                f"Module {mod_path} not found when loading class {class_name}"
             )
             raise ClassNotFoundError(f"Module '{mod_path}' not found")
 
         resolved = getattr(mod, class_name, None)
         if not resolved:
-            LOGGER.warning("Class %s not found in module %s", class_name, mod_path)
+            LOGGER.warning(f"Class {class_name} not found in module {mod_path}")
             raise ClassNotFoundError(
                 f"Class '{class_name}' not defined in module: {mod_path}"
             )
         if not isinstance(resolved, type):
             LOGGER.warning(
-                "Resolved attribute %s in module %s is not a class", class_name, mod_path
+                "Resolved attribute {class_name} in module {mod_path} is not a class"
             )
             raise ClassNotFoundError(
                 f"Resolved value is not a class: {mod_path}.{class_name}"
             )
-        LOGGER.debug("Successfully loaded class %s from module %s", class_name, mod_path)
+        LOGGER.debug("Successfully loaded class {class_name} from module {mod_path}")
         return resolved
 
     @classmethod
@@ -158,9 +158,7 @@ class ClassLoader:
         mod = cls.load_module(mod_path, package)
         if not mod:
             LOGGER.warning(
-                "Module %s not found when loading subclass of %s",
-                mod_path,
-                base_class.__name__,
+                f"Module {mod_path} not found when loading subclass of {base_class.__name__}"
             )
             raise ClassNotFoundError(f"Module '{mod_path}' not found")
 
@@ -173,9 +171,7 @@ class ClassLoader:
             )
         except StopIteration:
             LOGGER.debug(
-                "No subclass of %s found in module %s",
-                base_class.__name__,
-                mod_path,
+                f"No subclass of {base_class.__name__} found in module {mod_path}"
             )
             raise ClassNotFoundError(
                 f"Could not resolve a class that inherits from {base_class}"
@@ -185,22 +181,22 @@ class ClassLoader:
     @classmethod
     def scan_subpackages(cls, package: str) -> Sequence[str]:
         """Return a list of sub-packages defined under a named package."""
-        LOGGER.debug("Scanning subpackages under package %s", package)
+        LOGGER.debug(f"Scanning subpackages under package {package}")
         if "." in package:
             package, sub_pkg = package.split(".", 1)
-            LOGGER.debug("Extracted main package: %s, sub-package: %s", package, sub_pkg)
+            LOGGER.debug(f"Extracted main package: {package}, sub-package: {sub_pkg}")
         else:
             sub_pkg = "."
-            LOGGER.debug("No sub-package provided, defaulting to %s", sub_pkg)
+            LOGGER.debug(f"No sub-package provided, defaulting to {sub_pkg}")
 
         try:
             package_path = resources.files(package)
         except FileNotFoundError:
-            LOGGER.warning("Package %s not found during subpackage scan", package)
+            LOGGER.warning(f"Package {package} not found during subpackage scan")
             raise ModuleLoadError(f"Undefined package {package}")
 
         if not (package_path / sub_pkg).is_dir():
-            LOGGER.warning("Sub-package %s is not a directory under %s", sub_pkg, package)
+            LOGGER.warning(f"Sub-package {sub_pkg} is not a directory under {package}")
             raise ModuleLoadError(f"Undefined package {package}")
 
         found = []
@@ -210,7 +206,7 @@ class ClassLoader:
             if (item / "__init__.py").exists():
                 subpackage = f"{package}.{joiner}{item.name}"
                 found.append(subpackage)
-        LOGGER.debug("%d sub-packages found under %s: %s", len(found), package, found)
+        LOGGER.debug(f"{len(found)} sub-packages found under {package}: {found}")
         return found
 
 

--- a/acapy_agent/utils/classloader.py
+++ b/acapy_agent/utils/classloader.py
@@ -127,12 +127,12 @@ class ClassLoader:
             )
         if not isinstance(resolved, type):
             LOGGER.warning(
-                "Resolved attribute {class_name} in module {mod_path} is not a class"
+                f"Resolved attribute {class_name} in module {mod_path} is not a class"
             )
             raise ClassNotFoundError(
                 f"Resolved value is not a class: {mod_path}.{class_name}"
             )
-        LOGGER.debug("Successfully loaded class {class_name} from module {mod_path}")
+        LOGGER.debug(f"Successfully loaded class {class_name} from module {mod_path}")
         return resolved
 
     @classmethod

--- a/acapy_agent/utils/http.py
+++ b/acapy_agent/utils/http.py
@@ -191,7 +191,7 @@ async def put_file(
                         if parsed_to.hostname != parsed_from.hostname:
                             raise PutError("Redirect denied: hostname mismatch")
                         url = to_url
-                        LOGGER.info("Upload redirect: %s", to_url)
+                        LOGGER.info(f"Upload redirect: {to_url}")
                     elif (response.status < 200 or response.status >= 300) and (
                         response.status != HTTPConflict.status_code
                     ):
@@ -203,7 +203,7 @@ async def put_file(
                         return await (response.json() if json else response.text())
             except (ClientError, asyncio.TimeoutError) as e:
                 if isinstance(e, ClientError):
-                    LOGGER.warning("Upload error: %s", e)
+                    LOGGER.warning(f"Upload error: {e}")
                 else:
                     LOGGER.warning("Upload error: request timed out")
                 if attempt.final:

--- a/acapy_agent/utils/multi_ledger.py
+++ b/acapy_agent/utils/multi_ledger.py
@@ -28,8 +28,7 @@ def get_write_ledger_config_for_profile(settings: BaseSettings) -> dict:
             non_prod_write_ledger_pool[ledger_id] = ledger_config
         else:
             LOGGER.warning(
-                "Ledger config %s is not a write ledger nor a read-only ledger",
-                ledger_id,
+                f"Ledger config {ledger_id} is not a write ledger nor a read-only ledger",
             )
 
     write_ledger = settings.get("ledger.write_ledger")

--- a/acapy_agent/utils/task_queue.py
+++ b/acapy_agent/utils/task_queue.py
@@ -343,7 +343,7 @@ class TaskQueue:
         if exc_info:
             self.total_failed += 1
             if not task_complete and not self._trace_fn:
-                LOGGER.exception("Error running task %s", ident or "", exc_info=exc_info)
+                LOGGER.exception(f"Error running task {ident or ""}", exc_info=exc_info)
         else:
             self.total_done += 1
         if task_complete or self._trace_fn:
@@ -354,7 +354,7 @@ class TaskQueue:
                 if self._trace_fn:
                     self._trace_fn(completed)
             except Exception:
-                LOGGER.exception("Error finalizing task %s", completed)
+                LOGGER.exception(f"Error finalizing task {completed}")
         try:
             self.active_tasks.remove(task)
         except ValueError:

--- a/acapy_agent/utils/tracing.py
+++ b/acapy_agent/utils/tracing.py
@@ -238,7 +238,7 @@ def trace_event(
             elif context["trace.target"] == TRACE_LOG_TARGET:
                 # write to standard log file
                 LOGGER.setLevel(logging.INFO)
-                LOGGER.info(" %s %s", context["trace.tag"], event_str)
+                LOGGER.info(f" {context["trace.tag"]} {event_str}")
             else:
                 # should be an http endpoint
                 _ = requests.post(
@@ -251,10 +251,7 @@ def trace_event(
             if raise_errors:
                 raise
             LOGGER.error(
-                "Error logging trace target: %s tag: %s event: %s",
-                context.get("trace.target"),
-                context.get("trace.tag"),
-                event_str,
+                f"Error logging trace target: {context.get("trace.target")} tag: {context.get("trace.tag")} event: {event_str}"
             )
             LOGGER.exception(e)
 

--- a/acapy_agent/vc/ld_proofs/document_downloader.py
+++ b/acapy_agent/vc/ld_proofs/document_downloader.py
@@ -74,10 +74,10 @@ class StaticCacheJsonLdDownloader:
         cached = self.cache.get(url)
 
         if cached is not None:
-            logger.info("Local cache hit for context: %s", url)
+            logger.info("Local cache hit for context: {url}")
             return cached
 
-        logger.debug("Context %s not in static cache, resolving from URL.", url)
+        logger.debug("Context {url} not in static cache, resolving from URL.")
         return self._live_load(url, options)
 
     def _live_load(self, url: str, options: Optional[Dict] = None):

--- a/acapy_agent/vc/ld_proofs/document_downloader.py
+++ b/acapy_agent/vc/ld_proofs/document_downloader.py
@@ -74,10 +74,10 @@ class StaticCacheJsonLdDownloader:
         cached = self.cache.get(url)
 
         if cached is not None:
-            logger.info("Local cache hit for context: {url}")
+            logger.info(f"Local cache hit for context: {url}")
             return cached
 
-        logger.debug("Context {url} not in static cache, resolving from URL.")
+        logger.debug(f"Context {url} not in static cache, resolving from URL.")
         return self._live_load(url, options)
 
     def _live_load(self, url: str, options: Optional[Dict] = None):

--- a/acapy_agent/vc/vc_di/prove.py
+++ b/acapy_agent/vc/vc_di/prove.py
@@ -314,7 +314,7 @@ async def prepare_data_for_presentation(
                 # issuer_id = field["filter"]["const"]
                 pass
             else:
-                LOGGER.info("... skipping: %s", path)
+                LOGGER.info(f"... skipping: {path}")
 
     return anoncreds_proofrequest, w3c_creds_metadata
 

--- a/acapy_agent/wallet/anoncreds_upgrade.py
+++ b/acapy_agent/wallet/anoncreds_upgrade.py
@@ -609,7 +609,7 @@ async def upgrade_wallet_to_anoncreds_if_requested(
             return
 
         try:
-            LOGGER.info("Upgrade in process for wallet: %s", profile.name)
+            LOGGER.info(f"Upgrade in process for wallet: {profile.name}")
             await convert_records_to_anoncreds(profile)
             await finish_upgrade_by_updating_profile_or_shutting_down(
                 profile, is_subwallet
@@ -675,14 +675,12 @@ async def finish_upgrade_by_updating_profile_or_shutting_down(
         await upgrade_subwallet(profile)
         await finish_upgrade(profile)
         LOGGER.info(
-            "Upgrade of subwallet %s has completed. Profile is now askar-anoncreds",
-            profile.settings.get("wallet.name"),
+            f"Upgrade of subwallet {profile.settings.get("wallet.name")} has completed. Profile is now askar-anoncreds"
         )
     else:
         await finish_upgrade(profile)
         LOGGER.info(
-            "Upgrade of base wallet %s to anoncreds has completed. Shutting down agent.",
-            profile.settings.get("wallet.name"),
+            f"Upgrade of base wallet {profile.settings.get("wallet.name")} to anoncreds has completed. Shutting down agent."
         )
         asyncio.get_event_loop().stop()
 
@@ -692,7 +690,7 @@ async def check_upgrade_completion_loop(profile: Profile, is_subwallet=False):
     async with profile.session() as session:
         while True:
             storage = session.inject(BaseStorage)
-            LOGGER.debug("Checking upgrade completion for wallet: %s", profile.name)
+            LOGGER.debug(f"Checking upgrade completion for wallet: {profile.name}")
             try:
                 upgrading_record = await storage.find_record(
                     RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
@@ -704,14 +702,12 @@ async def check_upgrade_completion_loop(profile: Profile, is_subwallet=False):
                         await upgrade_subwallet(profile)
                         await finish_upgrade(profile)
                         LOGGER.info(
-                            "Upgrade of subwallet %s has completed. "
+                            f"Upgrade of subwallet {profile.settings.get("wallet.name")} has completed. "
                             "Profile is now askar-anoncreds",
-                            profile.settings.get("wallet.name"),
                         )
                         return
                     LOGGER.info(
-                        "Upgrade complete for wallet: %s, shutting down agent.",
-                        profile.name,
+                        f"Upgrade complete for wallet: {profile.name}, shutting down agent.",
                     )
                     # Shut down agent if base wallet
                     asyncio.get_event_loop().stop()

--- a/acapy_agent/wallet/default_verification_key_strategy.py
+++ b/acapy_agent/wallet/default_verification_key_strategy.py
@@ -207,13 +207,9 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
         if len(suitable_methods) > 1:
             LOGGER.info(
                 (
-                    "More than 1 verification method matched for did %s with proof "
-                    "type %s and purpose %s; returning the first: %s"
-                ),
-                did,
-                proof_type,
-                proof_purpose,
-                suitable_methods[0].id,
+                    f"More than 1 verification method matched for did {did} with proof "
+                    f"type {proof_type} and purpose {proof_purpose}; returning the first: {suitable_methods[0].id}"
+                )
             )
 
         return suitable_methods[0].id

--- a/acapy_agent/wallet/routes.py
+++ b/acapy_agent/wallet/routes.py
@@ -865,7 +865,7 @@ async def promote_wallet_public_did(
 
         async with ledger:
             if not await ledger.get_key_for_did(did):
-                LOGGER.info("Cannot promote DID {did}; it is not posted to the ledger")
+                LOGGER.info(f"Cannot promote DID {did}; it is not posted to the ledger")
                 raise LookupError(f"DID {did} is not posted to the ledger")
 
         is_author_profile = (

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1229,7 +1229,7 @@ class DemoAgent:
                 "DELETE", path, data, text, params, headers=headers
             )
             EVENT_LOGGER.debug(
-                "Response from DELETE {path} received: \n{repr_json(response)}"
+                f"Response from DELETE {path} received: \n{repr_json(response)}"
             )
             return response
         except ClientError as e:

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1032,11 +1032,7 @@ class DemoAgent:
             method = getattr(self, handler, None)
             if method:
                 EVENT_LOGGER.debug(
-                    "Agent called controller webhook: %s%s%s%s",
-                    handler,
-                    f"\nPOST {self.webhook_url}/topic/{topic}/",
-                    (f" for wallet: {wallet_id}" if wallet_id else ""),
-                    (f" with payload: \n{repr_json(payload)}\n" if payload else ""),
+                    f"Agent called controller webhook: {handler}{f"\nPOST {self.webhook_url}/topic/{topic}/"}{(f" for wallet: {wallet_id}" if wallet_id else "")}{(f" with payload: \n{repr_json(payload)}\n" if payload else "")}"
                 )
                 asyncio.get_event_loop().create_task(method(payload))
             else:
@@ -1108,16 +1104,14 @@ class DemoAgent:
         if not self.multitenant:
             raise Exception("Error can't call agency admin unless in multitenant mode")
         try:
-            EVENT_LOGGER.debug("Controller GET %s request to Agent", path)
+            EVENT_LOGGER.debug(f"Controller GET {path} request to Agent")
             if not headers:
                 headers = {}
             response = await self.admin_request(
                 "GET", path, None, text, params, headers=headers
             )
             EVENT_LOGGER.debug(
-                "Response from GET %s received: \n%s",
-                path,
-                repr_json(response),
+                f"Response from GET {path} received: \n{repr_json(response)}"
             )
             return response
         except ClientError as e:
@@ -1128,7 +1122,7 @@ class DemoAgent:
         self, path, text=False, params=None, headers=None
     ) -> ClientResponse:
         try:
-            EVENT_LOGGER.debug("Controller GET %s request to Agent", path)
+            EVENT_LOGGER.debug(f"Controller GET {path} request to Agent")
             if self.multitenant:
                 if not headers:
                     headers = {}
@@ -1137,9 +1131,7 @@ class DemoAgent:
                 "GET", path, None, text, params, headers=headers
             )
             EVENT_LOGGER.debug(
-                "Response from GET %s received: \n%s",
-                path,
-                repr_json(response),
+                f"Response from GET {path} received: \n{repr_json(response)}"
             )
             return response
         except ClientError as e:
@@ -1153,9 +1145,7 @@ class DemoAgent:
             raise Exception("Error can't call agency admin unless in multitenant mode")
         try:
             EVENT_LOGGER.debug(
-                "Controller POST %s request to Agent%s",
-                path,
-                (" with data: \n{}".format(repr_json(data)) if data else ""),
+                f"Controller POST {path} request to Agent{(" with data: \n{}".format(repr_json(data)) if data else "")}"
             )
             if not headers:
                 headers = {}
@@ -1163,9 +1153,7 @@ class DemoAgent:
                 "POST", path, data, text, params, headers=headers
             )
             EVENT_LOGGER.debug(
-                "Response from POST %s received: \n%s",
-                path,
-                repr_json(response),
+                f"Response from POST {path} received: \n{repr_json(response)}"
             )
             return response
         except ClientError as e:
@@ -1177,9 +1165,7 @@ class DemoAgent:
     ) -> ClientResponse:
         try:
             EVENT_LOGGER.debug(
-                "Controller POST %s request to Agent%s",
-                path,
-                (" with data: \n{}".format(repr_json(data)) if data else ""),
+                f"Controller POST {path} request to Agent{(" with data: \n{}".format(repr_json(data)) if data else "")}"
             )
             if self.multitenant:
                 if not headers:
@@ -1189,9 +1175,7 @@ class DemoAgent:
                 "POST", path, data, text, params, headers=headers
             )
             EVENT_LOGGER.debug(
-                "Response from POST %s received: \n%s",
-                path,
-                repr_json(response),
+                f"Response from POST {path} received: \n{repr_json(response)}"
             )
             return response
         except ClientError as e:
@@ -1235,9 +1219,7 @@ class DemoAgent:
     ) -> ClientResponse:
         try:
             EVENT_LOGGER.debug(
-                "Controller DELETE %s request to Agent%s",
-                path,
-                (" with data: \n{}".format(repr_json(data)) if data else ""),
+                f"Controller DELETE {path} request to Agent{(" with data: \n{}".format(repr_json(data)) if data else "")}"
             )
             if self.multitenant:
                 if not headers:
@@ -1247,9 +1229,7 @@ class DemoAgent:
                 "DELETE", path, data, text, params, headers=headers
             )
             EVENT_LOGGER.debug(
-                "Response from DELETE %s received: \n%s",
-                path,
-                repr_json(response),
+                "Response from DELETE {path} received: \n{repr_json(response)}"
             )
             return response
         except ClientError as e:


### PR DESCRIPTION
## Summary

When utilizing a custom config.yaml file to setup a custom logging format class, string interpolation using the "%s" syntax does not seem to work. However, the f'' string syntax does. This pull request aims to modernize logging output syntax to use the f'' string syntax to fix this logging problem. 

Other benefits include: 
- More Readable
- Consistent Log style (Currently some are f-string, and some are % syntax. 

Drawbacks:
- Some will say f string interpolation in logging is bad as there is a (negligible) performance reduction. 

This problem may also be solvable through a pylint configuration, but I have not explored that avenue as this solution has other readability/consistency benefits. 