### PR TITLE
[WIP] Prevent subwallet (tenant) endpoints from needing admin key

### DIFF
--- a/acapy_agent/multitenant/base.py
+++ b/acapy_agent/multitenant/base.py
@@ -281,9 +281,7 @@ class BaseMultitenantManager(ABC):
 
         """
 
-    async def create_auth_token(
-        self, wallet_record: WalletRecord, wallet_key: Optional[str] = None
-    ) -> str:
+    async def create_auth_token(self, wallet_record: WalletRecord) -> str:
         """Create JWT auth token for specified wallet record.
 
         Args:
@@ -305,10 +303,7 @@ class BaseMultitenantManager(ABC):
         jwt_secret = self._profile.settings.get("multitenant.jwt_secret")
 
         if wallet_record.requires_external_key:
-            if not wallet_key:
-                raise WalletKeyMissingError()
-
-            jwt_payload["wallet_key"] = wallet_key
+            jwt_payload["wallet_key"] = wallet_record.wallet_key
 
         token = jwt.encode(jwt_payload, jwt_secret, algorithm="HS256")
 


### PR DESCRIPTION
This is work-in-progress and tests will fail.

This is what I was thinking for the subwallet create token endpoint. There would be a sperate authorization for the subwallet to create the authentication token for using the api that would use the subwallet wallet key. For managed mode (currently the only available), the admin get wallet endpoints would supply the key, this way admin managed systems could still retrieve the key for the tenant. In an unmanaged system, the tenant would need to keep track of it's own wallet key and not lose it because the admin would not be able to retrieve it.

However, the problem I have with this approach is that we're using the wallet keys as an authorization key. I added a re-key feature for the tenant to try and alleviate some of the concern. But still this means a compromised key could be used to rekey and lock out a tenant. And then this same key is used for the wallet encryption.

Sooo, I'm still not exactly sure what to do about this. It seems like it more needs some fundamental oauth principals applied to this.