### PR TITLE
Add --debug-webhooks config to demo agents

### DIFF
--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -580,8 +580,7 @@ class DemoAgent:
             # turn on notifications if revocation is enabled
             result.append("--notify-revocation")
         # enable extended webhooks
-        if ACAPY_DEBUG_WEBHOOKS:
-            result.append("--debug-webhooks")
+        result.append("--debug-webhooks")
         # always enable notification webhooks
         result.append("--monitor-revocation-notification")
 


### PR DESCRIPTION
The demo agents use the `by_format` fields via webhooks for issuance and verification. The demo needs the --debug-webhooks configuration to operate correctly now that it's been removed from the default webhook payload.