### PR TITLE
Update bcvrin test genesis url

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -9,7 +9,7 @@ inputs:
   IN_LEDGER_URL:
     description: "URL to the von network ledger browser"
     required: false
-    default: "http://test.bcovrin.vonx.io"
+    default: "https://test.bcovrin.vonx.io"
   IN_PUBLIC_TAILS_URL:
     description: "URL to the tails server"
     required: false
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: run-integration-tests-acapy
       # to run with external ledger and tails server run as follows (and remove the ledger and tails actions from the workflow):
-      # run: LEDGER_URL=http://test.bcovrin.vonx.io PUBLIC_TAILS_URL=https://tails.vonx.io ./run_bdd ${{ inputs.TEST_SCOPE }}
+      # run: LEDGER_URL=https://test.bcovrin.vonx.io PUBLIC_TAILS_URL=https://tails.vonx.io ./run_bdd ${{ inputs.TEST_SCOPE }}
       run: ./run_bdd ${{ inputs.TEST_SCOPE }}
       shell: bash
       env:

--- a/demo/docker-agent/README.md
+++ b/demo/docker-agent/README.md
@@ -47,7 +47,7 @@ For this example, we will connect to [this endorser service](https://github.com/
 
 Make sure you start the endorser service on the same ledger as your author, and make sure the endorser has a public DID with ENDORSER role.
 
-For example start the endorser service as `LEDGER_URL=http://test.bcovrin.vonx.io TAILS_SERVER_URL=https://tails-test.vonx.io ./manage start --logs` and then make sure the Author agent is started with `--genesis_url http://test.bcovrin.vonx.io/genesis`.
+For example start the endorser service as `LEDGER_URL=https://test.bcovrin.vonx.io TAILS_SERVER_URL=https://tails-test.vonx.io ./manage start --logs` and then make sure the Author agent is started with `--genesis_url https://test.bcovrin.vonx.io/genesis`.
 
 ### Connecting the Author to the Endorser
 

--- a/demo/docker-agent/ngrok-wait.sh
+++ b/demo/docker-agent/ngrok-wait.sh
@@ -27,7 +27,7 @@ exec aca-py start \
     --auto-provision \
     --inbound-transport http '0.0.0.0' 8001 \
     --outbound-transport http \
-    --genesis-url "http://test.bcovrin.vonx.io/genesis" \
+    --genesis-url "https://test.bcovrin.vonx.io/genesis" \
     --endpoint "${ACAPY_ENDPOINT}" \
     --auto-ping-connection \
     --monitor-ping \

--- a/demo/docker-test/docker-compose-agent.yml
+++ b/demo/docker-test/docker-compose-agent.yml
@@ -19,7 +19,7 @@ services:
         --inbound-transport http '0.0.0.0' 8001 \
         --endpoint 'http://host.docker.internal:8001' \
         --outbound-transport http \
-        --genesis-url 'http://test.bcovrin.vonx.io/genesis' \
+        --genesis-url 'https://test.bcovrin.vonx.io/genesis' \
         --auto-accept-invites \
         --auto-accept-requests \
         --auto-ping-connection \

--- a/demo/docker/ledgers.yaml
+++ b/demo/docker/ledgers.yaml
@@ -15,7 +15,7 @@
   genesis_url: 'https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis'
 - id: BCovrinTest
   is_production: true
-  genesis_url: 'http://test.bcovrin.vonx.io/genesis'
+  genesis_url: 'https://test.bcovrin.vonx.io/genesis'
 - id: CANdyDev
   is_production: true
   genesis_url: 'https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/dev/pool_transactions_genesis'

--- a/demo/elk-stack/README.md
+++ b/demo/elk-stack/README.md
@@ -28,11 +28,11 @@ We can run demos to see agent tracing events and attach them to the `elknet` net
 Assuming the elk stack is running from above... from your demos directory, in two separate bash shells, startup the demo as follows:
 
 ```bash
-DOCKER_NET=elknet TRACE_TARGET_URL=logstash:9700 LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --trace-http
+DOCKER_NET=elknet TRACE_TARGET_URL=logstash:9700 LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --trace-http
 ```
 
 ```bash
-DOCKER_NET=elknet TRACE_TARGET_URL=logstash:9700 LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo alice --trace-http
+DOCKER_NET=elknet TRACE_TARGET_URL=logstash:9700 LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo alice --trace-http
 ```
 
 And run the demo scenarios as you wish.

--- a/demo/multi-demo/ngrok-wait.sh
+++ b/demo/multi-demo/ngrok-wait.sh
@@ -30,7 +30,7 @@ exec aca-py start \
     --auto-provision \
     --inbound-transport http '0.0.0.0' 8001 \
     --outbound-transport http \
-    --genesis-url "http://test.bcovrin.vonx.io/genesis" \
+    --genesis-url "https://test.bcovrin.vonx.io/genesis" \
     --endpoint "${ACAPY_ENDPOINT}" \
     --auto-ping-connection \
     --monitor-ping \

--- a/demo/multi_ledger_config.yml
+++ b/demo/multi_ledger_config.yml
@@ -4,7 +4,7 @@
 - id: bcovrinTest
   is_production: true
   is_write: true
-  genesis_url: 'http://test.bcovrin.vonx.io/genesis'
+  genesis_url: 'https://test.bcovrin.vonx.io/genesis'
 - id: greenlightTest
   is_production: true
   genesis_url: 'http://dev.greenlight.bcovrin.vonx.io/genesis'

--- a/demo/multi_ledger_config_bdd.yml
+++ b/demo/multi_ledger_config_bdd.yml
@@ -5,7 +5,7 @@
 - id: bcovrinTest
   is_production: true
 #  is_write: true
-  genesis_url: 'http://test.bcovrin.vonx.io/genesis'
+  genesis_url: 'https://test.bcovrin.vonx.io/genesis'
 - id: greenlightTest
   is_production: true
   genesis_url: 'http://dev.greenlight.bcovrin.vonx.io/genesis'

--- a/demo/run_bdd
+++ b/demo/run_bdd
@@ -191,7 +191,7 @@ fi
 if ! [ -z "$POSTGRES" ]; then
   DOCKER_ENV="${DOCKER_ENV} -e POSTGRES=1 -e RUST_BACKTRACE=1"
 fi
-# e.g. LEDGER_URL=http://test.bcovrin.vonx.io
+# e.g. LEDGER_URL=https://test.bcovrin.vonx.io
 if ! [ -z "$LEDGER_URL" ]; then
   GENESIS_URL="${LEDGER_URL}/genesis"
   DOCKER_ENV="${DOCKER_ENV} -e LEDGER_URL=${LEDGER_URL}"

--- a/docs/demo/ACA-Py-Workshop.md
+++ b/docs/demo/ACA-Py-Workshop.md
@@ -38,7 +38,7 @@ for developers, such as experimenting with the Traction/ACA-Py
 [Traction]: https://digital.gov.bc.ca/digital-trust/technical-resources/traction/
 [ACA-Py]: https://aca-py.org
 [Traction Sandbox]: https://traction-sandbox-tenant-ui.apps.silver.devops.gov.bc.ca/
-[BCovrin Test Ledger]: http://test.bcovrin.vonx.io/
+[BCovrin Test Ledger]: https://test.bcovrin.vonx.io/
 [Traction Sandbox Workshop FAQ and Questions]: https://github.com/bcgov/traction/issues/927
 
 Jump in!
@@ -106,7 +106,7 @@ BCovrin (pronounced “Be Sovereign”) Test network. For those new to AnonCreds
     2. Click “Add Schema From Ledger” and fill in the `Schema Id` with the value `H7W22uhD4ueQdGaGeiCgaM:2:student id:1.0.0`.
         1. By doing this, you (as the issuer) will be using a previously
         published schema. [Click
-        here](http://test.bcovrin.vonx.io/browse/domain?page=1&query=H7W22uhD4ueQdGaGeiCgaM&txn_type=101)
+        here](https://test.bcovrin.vonx.io/browse/domain?page=1&query=H7W22uhD4ueQdGaGeiCgaM&txn_type=101)
         to see the schema on the ledger.
     3. To see the details about your schema, hit the Expand (`>`) link, and then
        the subsequent `>` to “View Raw Content."

--- a/docs/demo/AcmeDemoWorkshop.md
+++ b/docs/demo/AcmeDemoWorkshop.md
@@ -22,13 +22,13 @@ cd acapy/demo
 In one shell run Faber:
 
 ```bash
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber
 ```
 
 ... and in the second shell run Alice:
 
 ```bash
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo alice
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo alice
 ```
 
 When Faber has produced an invitation, copy it over to Alice.
@@ -38,7 +38,7 @@ Then, in the Faber shell, select option ```1``` to issue a credential to Alice. 
 Then, in the Faber shell, enter ```X``` to exit the controller, and then run the Acme controller:
 
 ```bash
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo acme
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo acme
 ```
 
 In the Alice shell, select option ```4``` (to enter a new invitation) and then copy over Acme's invitation once it's available.

--- a/docs/demo/AliceGetsAPhone.md
+++ b/docs/demo/AliceGetsAPhone.md
@@ -206,7 +206,7 @@ If you are running in a _local bash shell_, navigate to the `demo` directory in
 your fork/clone of the ACA-Py repository and run:
 
 ```bash
-TAILS_NETWORK=docker_tails-server LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --revocation --events
+TAILS_NETWORK=docker_tails-server LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --revocation --events
 ```
 
 The `TAILS_NETWORK` parameter lets the demo script know how to connect to the tails server (which should be running in a separate shell on the same machine).
@@ -217,7 +217,7 @@ If you are running in _Play with Docker_, navigate to the `demo` folder in the
 clone of ACA-Py and run the following:
 
 ```bash
-PUBLIC_TAILS_URL=https://c4f7fbb85911.ngrok.io LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --revocation --events
+PUBLIC_TAILS_URL=https://c4f7fbb85911.ngrok.io LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --revocation --events
 ```
 
 The `PUBLIC_TAILS_URL` parameter lets the demo script know how to connect to the tails server. This can be running in another PWD session, or even on your local machine - the ngrok endpoint is public and will map to the correct location.
@@ -284,7 +284,7 @@ Note that this will use the ngrok endpoint if you are running locally, or your P
 
 When running locally, use the `AGENT_ENDPOINT` environment variable to run the demo so that it puts the public hostname in the QR code:
 ```bash
-AGENT_ENDPOINT=https://abc123.ngrok.io LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber
+AGENT_ENDPOINT=https://abc123.ngrok.io LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber
 ```
 See the Connectionless Proof Request section below for a more complete ngrok configuration that also supports the revocation option.
 

--- a/docs/demo/AliceWantsAJsonCredential.md
+++ b/docs/demo/AliceWantsAJsonCredential.md
@@ -16,13 +16,13 @@ cd acapy/demo
 Open up a second shell (so you have 2 shells open in the `demo` directory) and in one shell:
 
 ```bash
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --did-exchange --aip 20 --cred-type json-ld
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --did-exchange --aip 20 --cred-type json-ld
 ```
 
 ... and in the other:
 
 ```bash
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo alice
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo alice
 ```
 
 Note that you start the `faber` agent with AIP2.0 options.  (When you specify `--cred-type json-ld` faber will set aip to `20` automatically,

--- a/docs/demo/OpenAPIDemo.md
+++ b/docs/demo/OpenAPIDemo.md
@@ -49,11 +49,11 @@ What better way to learn about controllers than by actually being one yourself! 
 
 We will get started by opening three browser tabs that will be used throughout the lab. Two will be Swagger UIs for the Faber and Alice agent and one for the public ledger (showing the Hyperledger Indy ledger). As well, we'll keep the terminal sessions where we started the demos handy, as we'll be grabbing information from them as well.
 
-Let's start with the ledger browser. For this demo, we're going to use an open public ledger operated by the BC Government's VON Team. In your first browser tab, go to: [http://test.bcovrin.vonx.io](http://test.bcovrin.vonx.io). This will be called the "ledger tab" in the instructions below.
+Let's start with the ledger browser. For this demo, we're going to use an open public ledger operated by the BC Government's VON Team. In your first browser tab, go to: [https://test.bcovrin.vonx.io](https://test.bcovrin.vonx.io). This will be called the "ledger tab" in the instructions below.
 
 For the rest of the set up, you can choose to run the terminal sessions in your browser (no local resources needed), or you can run it in Docker on your local system. Your choice, each is covered in the next two sections.
 
-> Note: In the following, when we start the agents we use several special demo settings. The command we use is this: `LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --events --no-auto --bg`. In that:
+> Note: In the following, when we start the agents we use several special demo settings. The command we use is this: `LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --events --no-auto --bg`. In that:
 > 
 > - The `LEDGER_URL` environment variable informs the agent what ledger to use.
 > - The `--events` option indicates that we want the controller to display the webhook events from ACA-Py in the log displayed on the terminal.
@@ -71,7 +71,7 @@ In a browser, go to the [Play with Docker](https://labs.play-with-docker.com/) h
 ```bash
 git clone https://github.com/openwallet-foundation/acapy
 cd acapy/demo
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --events --no-auto --bg
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --events --no-auto --bg
 
 ```
 
@@ -99,7 +99,7 @@ Now to start Alice's agent. Click the "+Add a new instance" button again to open
 ```bash
 git clone https://github.com/openwallet-foundation/acapy
 cd acapy/demo
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo alice --events --no-auto --bg
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo alice --events --no-auto --bg
 
 ```
 
@@ -137,7 +137,7 @@ In the first terminal window, clone the ACA-Py repo, change into the demo folder
 ```bash
 git clone https://github.com/openwallet-foundation/acapy
 cd acapy/demo
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --events --no-auto --bg
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --events --no-auto --bg
 
 ```
 
@@ -163,7 +163,7 @@ If all goes well, the agent will show a message indicating it is running. Use th
 To start Alice's agent, open up a second terminal window and in it, change to the same `demo` directory as where Faber's agent was started above. Once there, start Alice's agent:
 
 ``` bash
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo alice --events --no-auto --bg
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo alice --events --no-auto --bg
 
 ```
 
@@ -404,7 +404,7 @@ You can confirm the schema and credential definition were published by going bac
     <img src="collateral/C-1-Faber-DID-Public.png" alt="Faber Public DID">
 </details>
 
-On the ledger browser of the [BCovrin ledger](http://test.bcovrin.vonx.io), click the `Domain` page, refresh, and paste the Faber public DID into the `Filter:` field:
+On the ledger browser of the [BCovrin ledger](https://test.bcovrin.vonx.io), click the `Domain` page, refresh, and paste the Faber public DID into the `Filter:` field:
 
 <details>
     <summary>Show me a screenshot</summary>

--- a/docs/demo/PostmanDemo.md
+++ b/docs/demo/PostmanDemo.md
@@ -57,7 +57,7 @@ Each collection consists of a series of requests which can be configured indepen
 Make sure you have a demo agent available. You can use the following command to deploy one:
 
 ```bash
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --bg
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber --bg
 ```
 
 When running for the first time, please allow some time for the images to build.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -42,7 +42,7 @@ In your browser, go to the docker playground service [Play with Docker](https://
 ```bash
 git clone https://github.com/openwallet-foundation/acapy
 cd acapy/demo
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber
 ```
 
 Now to start Alice's agent. Click the "+Add a new instance" button again to open another terminal session. Run the following commands to start Alice's agent:
@@ -50,7 +50,7 @@ Now to start Alice's agent. Click the "+Add a new instance" button again to open
 ```bash
 git clone https://github.com/openwallet-foundation/acapy
 cd acapy/demo
-LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo alice
+LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo alice
 ```
 
 Alice's agent is now running.

--- a/docs/features/KanonStorage.md
+++ b/docs/features/KanonStorage.md
@@ -101,7 +101,7 @@ aca-py start \
   --wallet-name veridid.agent.kanon.issuer.normalized \
   --wallet-key kms.storage.secret \
   --preserve-exchange-records \
-  --genesis-url http://test.bcovrin.vonx.io/genesis \
+  --genesis-url https://test.bcovrin.vonx.io/genesis \
   --tails-server-base-url http://tails-server.digicred.services:6543 \
   --trace-target log \
   --trace-tag acapy.events \
@@ -143,7 +143,7 @@ aca-py start \
   --multitenant-admin \
   --admin-api-key <YOUR_ADMIN_API_KEY> \
   --preserve-exchange-records \
-  --genesis-url http://test.bcovrin.vonx.io/genesis \
+  --genesis-url https://test.bcovrin.vonx.io/genesis \
   --tails-server-base-url http://tails-server.digicred.services:6543 \
   --trace-target log \
   --trace-tag acapy.events \

--- a/docs/features/Multiledger.md
+++ b/docs/features/Multiledger.md
@@ -35,7 +35,7 @@ If `--genesis-transactions-list` is specified, then `--genesis-url, --genesis-fi
 - id: bcovrinTest
   is_production: true
   is_write: true
-  genesis_url: "http://test.bcovrin.vonx.io/genesis"
+  genesis_url: "https://test.bcovrin.vonx.io/genesis"
 ```
 
 ```yaml
@@ -45,13 +45,13 @@ If `--genesis-transactions-list` is specified, then `--genesis-url, --genesis-fi
 - id: bcovrinTest
   is_production: true
   is_write: true
-  genesis_url: "http://test.bcovrin.vonx.io/genesis"
+  genesis_url: "https://test.bcovrin.vonx.io/genesis"
   endorser_did: "9QPa6tHvBHttLg6U4xvviv"
   endorser_alias: "endorser_test"
 - id: greenlightDev
   is_production: true
   is_write: true
-  genesis_url: "http://test.bcovrin.vonx.io/genesis"
+  genesis_url: "https://test.bcovrin.vonx.io/genesis"
 ```
 
 Note: `is_write` property means that the ledger is write configurable. With reference to the above config example, both `bcovrinTest` and (the no longer available -- in the above its pointing to BCovrin Test as well) `greenlightDev` ledgers are write configurable. By default, on startup `bcovrinTest` will be the write ledger as it is the topmost write configurable production ledger, [more details](#write-requests) regarding the selection rule. Using `PUT /ledger/{ledger_id}/set-write-ledger` endpoint, either `greenlightDev` and `bcovrinTest` can be set as the write ledger.
@@ -66,10 +66,10 @@ Note: `is_write` property means that the ledger is write configurable. With refe
   genesis_url: "http://host.docker.internal:9000/genesis"
 - id: bcovrinTest
   is_production: true
-  genesis_url: "http://test.bcovrin.vonx.io/genesis"
+  genesis_url: "https://test.bcovrin.vonx.io/genesis"
 - id: greenlightDev
   is_production: true
-  genesis_url: "http://test.bcovrin.vonx.io/genesis"
+  genesis_url: "https://test.bcovrin.vonx.io/genesis"
 ```
 
 Note: For instance with regards to example config above, `localVON` will be the write ledger, as there are no production ledgers which are configurable it will choose the topmost write configurable non production ledger.

--- a/docs/features/devcontainer.md
+++ b/docs/features/devcontainer.md
@@ -167,7 +167,7 @@ For all the agents if you don't want to support revocation you need to remove or
 
 To run your ACA-Py code in debug mode, go to the `Run and Debug` view, select the agent(s) you want to start and click `Start Debugging (F5)`.
 
-This will start your source code as a running ACA-Py instance, all configuration is in the `*.yml` files. This is just a sample of a configuration. Note that we are not using a database and are joining to a local VON Network (by default, it would be `http://localhost:9000`). You could change this or another ledger such as `http://test.bcovrin.vonx.io`. These are purposefully, very simple configurations.
+This will start your source code as a running ACA-Py instance, all configuration is in the `*.yml` files. This is just a sample of a configuration. Note that we are not using a database and are joining to a local VON Network (by default, it would be `http://localhost:9000`). You could change this or another ledger such as `https://test.bcovrin.vonx.io`. These are purposefully, very simple configurations.
 
 For example, open `acapy_agent/admin/server.py` and set a breakpoint in `async def status_handler(self, request: web.BaseRequest):`, then call `GET /status` at `http://localhost:9061/api/doc#/server/get_status` in the Admin Console and hit your breakpoint.
 

--- a/docs/testing/Troubleshooting.md
+++ b/docs/testing/Troubleshooting.md
@@ -29,12 +29,12 @@ If that is the cause -- have you started your local ledger, and did it startup p
 - Is the von-network webserver (usually at `https:/localhost:9000`) accessible? If so, can you click on and see the Genesis File?
 - Do you even need a local ledger? If not, you can use a public sandbox ledger,
   such as the [BCovrin Test ledger], likely by just prefacing your ACA-Py
-  command with `LEDGER_URL=http://test.bcovrin.vonx.io`. For example,
+  command with `LEDGER_URL=https://test.bcovrin.vonx.io`. For example,
   when running the Alice-Faber demo in the [demo](../demo/README.md) folder, you can run (for
   example), the Faber agent using the command:
-  `LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber`
+  `LEDGER_URL=https://test.bcovrin.vonx.io ./run_demo faber`
 
-[BCovrin Test ledger]: http://test.bcovrin.vonx.io
+[BCovrin Test ledger]: https://test.bcovrin.vonx.io
 
 ### Any Firewalls
 

--- a/scenarios/examples/anoncreds_issuance_and_revocation/docker-compose.yml
+++ b/scenarios/examples/anoncreds_issuance_and_revocation/docker-compose.yml
@@ -12,7 +12,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name agency
         --wallet-key insecure
@@ -47,7 +47,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar-anoncreds
         --wallet-name holder_anoncreds
         --wallet-key insecure
@@ -75,7 +75,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name holder_indy
         --wallet-key insecure
@@ -114,7 +114,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/connectionless/docker-compose.yml
+++ b/scenarios/examples/connectionless/docker-compose.yml
@@ -14,7 +14,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -46,7 +46,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure
@@ -66,7 +66,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/did_indy_issuance_and_revocation/docker-compose.yml
+++ b/scenarios/examples/did_indy_issuance_and_revocation/docker-compose.yml
@@ -12,7 +12,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -43,7 +43,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure
@@ -79,7 +79,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/json_ld/docker-compose.yml
+++ b/scenarios/examples/json_ld/docker-compose.yml
@@ -10,7 +10,7 @@
         -e http://alice:3000
         --admin 0.0.0.0 3001 --admin-insecure-mode
         --log-level debug
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -35,7 +35,7 @@
         -e http://bob:3000
         --admin 0.0.0.0 3001 --admin-insecure-mode
         --log-level debug
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure

--- a/scenarios/examples/multitenancy/docker-compose.yml
+++ b/scenarios/examples/multitenancy/docker-compose.yml
@@ -12,7 +12,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name agency
         --wallet-key insecure
@@ -51,7 +51,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/multiuse_invitations/docker-compose.yml
+++ b/scenarios/examples/multiuse_invitations/docker-compose.yml
@@ -14,7 +14,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -46,7 +46,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure
@@ -66,7 +66,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/presenting_revoked_credential/docker-compose.yml
+++ b/scenarios/examples/presenting_revoked_credential/docker-compose.yml
@@ -12,7 +12,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -43,7 +43,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure
@@ -79,7 +79,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/restart_anoncreds_upgrade/docker-compose.yml
+++ b/scenarios/examples/restart_anoncreds_upgrade/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -67,7 +67,7 @@ services:
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob-askar
         --wallet-key insecure
@@ -106,7 +106,7 @@ services:
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar-anoncreds
         --wallet-name bob-anoncreds
         --wallet-key insecure
@@ -145,7 +145,7 @@ services:
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob-askar-anon
         --wallet-key insecure
@@ -174,7 +174,7 @@ services:
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/self_attested/docker-compose.yml
+++ b/scenarios/examples/self_attested/docker-compose.yml
@@ -12,7 +12,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -42,7 +42,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure
@@ -78,7 +78,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/simple/docker-compose.yml
+++ b/scenarios/examples/simple/docker-compose.yml
@@ -14,7 +14,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -47,7 +47,7 @@
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure
@@ -67,7 +67,7 @@
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0

--- a/scenarios/examples/simple_restart/docker-compose.yml
+++ b/scenarios/examples/simple_restart/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name alice
         --wallet-key insecure
@@ -66,7 +66,7 @@ services:
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name bob
         --wallet-key insecure
@@ -103,7 +103,7 @@ services:
         --admin 0.0.0.0 3001
         --admin-insecure-mode
         --tails-server-base-url http://tails:6543
-        --genesis-url http://test.bcovrin.vonx.io/genesis
+        --genesis-url https://test.bcovrin.vonx.io/genesis
         --wallet-type askar
         --wallet-name agency
         --wallet-key insecure
@@ -132,7 +132,7 @@ services:
     ports:
       - 6543:6543
     environment:
-      - GENESIS_URL=http://test.bcovrin.vonx.io/genesis
+      - GENESIS_URL=https://test.bcovrin.vonx.io/genesis
     command: >
       tails-server
       --host 0.0.0.0


### PR DESCRIPTION
BCovrin test genesis url has been promoted to https from http last week. This has cause many tests to fail, this pr will update all hard coded values of this url.