### PR TITLE
Add citizenship context to document downloader

### DIFF
--- a/acapy_agent/vc/ld_proofs/document_downloader.py
+++ b/acapy_agent/vc/ld_proofs/document_downloader.py
@@ -50,6 +50,7 @@ class StaticCacheJsonLdDownloader:
         "https://identity.foundation/presentation-exchange/submission/v1": (
             "dif-presentation-exchange-submission-v1.jsonld"
         ),
+        "https://w3id.org/citizenship/v1": "citizenship_v1_context.jsonld",
     }
 
     def __init__(

--- a/acapy_agent/vc/ld_proofs/resources/citizenship_v1_context.jsonld
+++ b/acapy_agent/vc/ld_proofs/resources/citizenship_v1_context.jsonld
@@ -1,0 +1,57 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "name": "http://schema.org/name",
+        "description": "http://schema.org/description",
+        "identifier": "http://schema.org/identifier",
+        "image": {
+            "@id": "http://schema.org/image",
+            "@type": "@id"
+        },
+        "PermanentResidentCard": {
+            "@id": "https://w3id.org/citizenship#PermanentResidentCard",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "description": "http://schema.org/description",
+                "name": "http://schema.org/name",
+                "identifier": "http://schema.org/identifier",
+                "image": {
+                    "@id": "http://schema.org/image",
+                    "@type": "@id"
+                }
+            }
+        },
+        "PermanentResident": {
+            "@id": "https://w3id.org/citizenship#PermanentResident",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "ctzn": "https://w3id.org/citizenship#",
+                "schema": "http://schema.org/",
+                "xsd": "http://www.w3.org/2001/XMLSchema#",
+                "birthCountry": "ctzn:birthCountry",
+                "birthDate": {
+                    "@id": "schema:birthDate",
+                    "@type": "xsd:dateTime"
+                },
+                "commuterClassification": "ctzn:commuterClassification",
+                "familyName": "schema:familyName",
+                "gender": "schema:gender",
+                "givenName": "schema:givenName",
+                "lprCategory": "ctzn:lprCategory",
+                "lprNumber": "ctzn:lprNumber",
+                "residentSince": {
+                    "@id": "ctzn:residentSince",
+                    "@type": "xsd:dateTime"
+                }
+            }
+        },
+        "Person": "http://schema.org/Person"
+    }
+}


### PR DESCRIPTION
This context URI is used in integration tests and is currently experiencing some timeout issues. Adding it to the document downloader.

See #4026 
https://github.com/openwallet-foundation/acapy/actions/runs/21196680028/job/61047096003?pr=4026