### PR TITLE
Make ACA-Py 1.6 an LTS release

### DIFF
--- a/.github/lts-versions.txt
+++ b/.github/lts-versions.txt
@@ -6,6 +6,7 @@
 
 # Example: Uncomment the lines below to enable LTS for specific versions
 1.3
+1.6
 
 # For testing purposes (remove in production):
 # 0.0

--- a/.github/lts-versions.txt
+++ b/.github/lts-versions.txt
@@ -5,8 +5,6 @@
 # Empty lines are ignored
 
 # Example: Uncomment the lines below to enable LTS for specific versions
-0.12
-1.2
 1.3
 
 # For testing purposes (remove in production):

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -129,16 +129,18 @@ For the build test, the RTD Sphinx theme needs to be added to the docker image, 
    wait until it is merged. It's embarrassing when you have to do a whole new
    release just because you missed something silly...I know!
 
-10. If the release is a final release AND the latest release AND an LTS release,
-    update the LTS branch to point to `main`. Do this ONLY when the current
-    release version is both the latest release AND its version has been declared
-    an LTS release. Once a new version has been created that has NOT been
-    declared an LTS, the LTS branch will extend independent of main.
+10. Immediately after the PR is merged and if the release is a final release AND
+    the latest release AND an LTS release, update the LTS branch to point to
+    `main`. Do this ONLY when the current release version is both the latest
+    release AND its version has been declared an LTS release. Once a new version
+    has been created that has NOT been declared an LTS, the LTS branch will
+    extend independent of main.
 
-11. Immediately after it is merged, create a new GitHub tag representing the
-   version. The tag name and title of the release should be the
-   same as the version in
-   [pyproject.toml](https://github.com/openwallet-foundation/acapy/tree/main/pyproject.toml). Use the "Generate Release Notes" capability to get a sequential listing of
+11. Immediately after the PR is merged, create a new GitHub tag representing the
+   version. The tag name and title of the release should be the same as the
+   version in
+   [pyproject.toml](https://github.com/openwallet-foundation/acapy/tree/main/pyproject.toml).
+   Use the "Generate Release Notes" capability to get a sequential listing of
    the PRs in the release, to complement the manually curated Changelog. Verify
    on PyPi that the version is published.
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -129,14 +129,20 @@ For the build test, the RTD Sphinx theme needs to be added to the docker image, 
    wait until it is merged. It's embarrassing when you have to do a whole new
    release just because you missed something silly...I know!
 
-10. Immediately after it is merged, create a new GitHub tag representing the
-   version. The tag name and title of the release should be the same as the
-   version in [pyproject.toml](https://github.com/openwallet-foundation/acapy/tree/main/pyproject.toml). Use
-   the "Generate Release Notes" capability to get a sequential listing of the
-   PRs in the release, to complement the manually curated Changelog. Verify on
-   PyPi that the version is published.
+10. If the release is a final release AND the latest release AND an LTS release,
+    update the LTS branch to point to `main`. Do this ONLY when the current
+    release version is both the latest release AND its version has been declared
+    an LTS release. Once a new version has been created that has NOT been
+    declared an LTS, the LTS branch will extend independent of main.
 
-11. New images for the release are automatically published by the GitHubAction
+11. Immediately after it is merged, create a new GitHub tag representing the
+   version. The tag name and title of the release should be the
+   same as the version in
+   [pyproject.toml](https://github.com/openwallet-foundation/acapy/tree/main/pyproject.toml). Use the "Generate Release Notes" capability to get a sequential listing of
+   the PRs in the release, to complement the manually curated Changelog. Verify
+   on PyPi that the version is published.
+
+12. New images for the release are automatically published by the GitHubAction
    Workflow: [publish.yml]. The action is triggered when a release is tagged, so
    no manual action is needed. Images are published in the [OpenWallet
    Foundation Package Repository under
@@ -178,7 +184,7 @@ For the build test, the RTD Sphinx theme needs to be added to the docker image, 
 
 [publish.yml]: https://github.com/openwallet-foundation/acapy/blob/main/.github/workflows/publish.yml
 
-12. When a new release is tagged, create a new branch at the same commit with
+13. When a new release is tagged, create a new branch at the same commit with
     the branch name in the format `docs-v<version>`, for example, `docs-v1.6.0rc0`.
     The creation of the branch triggers the execution of the [publish-docs]
     GitHub Action which generates the documentation for the new release,
@@ -192,7 +198,7 @@ For the build test, the RTD Sphinx theme needs to be added to the docker image, 
 [Managing the ACA-Py Documentation Site]: Managing-ACA-Py-Doc-Site.md
 [https://aca-py.org]: https://aca-py.org
 
-13. Update the [ACA-Py Read The Docs site] by logging into Read The Docs
+14. Update the [ACA-Py Read The Docs site] by logging into Read The Docs
     administration site, building a new "latest" (main branch) and activating
     and building the new release by version ID. Appropriate permissions are
     required to publish the new documentation version.

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ the [LTS strategy](./LTS-Strategy.md).
 
 ### LTS Docker Images
 
-ACA-Py publishes Git tags in the format `x.y-lts` (e.g., `1.3-lts`) along with 
+ACA-Py publishes Git tags in the format `x.y-lts` (e.g., `1.6-lts`) along with 
 corresponding Docker images to the GitHub Container Registry (GHCR) for each LTS release. These 
 Docker images are tagged with a stable `-lts` suffix, making it easier for developers to rely on 
 a consistent and maintained version line.
 
-You can pull the latest LTS image for version `1.3` using the following image tag:
+You can pull the latest LTS image for version `1.6` using the following image tag:
 
 ```bash
-ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.3-lts
+ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.6-lts
 ```
 
 The `-lts` tags are kept up to date with the latest patch releases from the corresponding 
@@ -62,7 +62,8 @@ supported version within that release series.
 
 **Active LTS releases:**
 
-- Release [1.3](https://github.com/openwallet-foundation/acapy/releases/tag/1.3.1) **Current LTS Release**
+- Release [1.6](https://github.com/openwallet-foundation/acapy/blob/1.6.lts/CHANGELOG.md) **Current LTS Release**
+- Release [1.3](https://github.com/openwallet-foundation/acapy/blob/1.3.lts/CHANGELOG.md) **End of Life: January 2027**
 
 **Past LTS releases:**
 


### PR DESCRIPTION
Updates ACA-Py LTS releases to make 1.6 the current LTS and sets the end-of-life for the 1.3 LTS to January, 2027. Agreement to declare 1.6 the current LTS release was made at the ACA-Pug meeting on 2026.04.28.

Updated the publishing instructions (Publishing.md) to note how to handled the situation that we have now with the LTS version also being the current version. During such times, the LTS branch (e.g., 1.6.lts) must be updated to match the release commit on main for new releases until we have a new version (e.g., 1.7.0 or 2.0.0). That should trigger the LTS container to be built at the correct commit.

@esune -- please review updates to lts-versions.txt, and check if the proper LTS tagging was done. I'm guessing not because I didn't have the lts-versions.txt including 1.6 when I create the 1.6.lts branch.  Let's collaborate.
