### PR TITLE
fix(ci): update python version in LTS image tagging to match publish workflow

### DIFF
--- a/.github/workflows/tag-recreate-lts.yml
+++ b/.github/workflows/tag-recreate-lts.yml
@@ -232,7 +232,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.12", "3.13"]
         image-name: ["acapy-agent", "acapy-agent-bbs"]
     
     steps:


### PR DESCRIPTION
The tag-lts-images job used only python 3.12 but since the 1.6 version the publish workflow also builds images with python 3.13, causing docker pull to fail when tagging LTS images for version 1.6.

## Description

<!-- Describe what this PR does and why -->

## Related Issue

Closes #4141 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have added/updated tests where applicable
- [x] I have updated documentation if needed

