### PR TITLE
fix(ci): use correct python version per LTS release when tagging images

### DIFF
--- a/.github/lts-versions.txt
+++ b/.github/lts-versions.txt
@@ -1,12 +1,8 @@
 # LTS Version Patterns
 # Each line represents a version pattern that should be treated as LTS
-# Use major.minor format (e.g., 1.2 for versions 1.2.x)
+# Format: major.minor:python_version (e.g., 1.2:3.12 for versions 1.2.x built with Python 3.12)
 # Lines starting with # are comments and will be ignored
 # Empty lines are ignored
 
-# Example: Uncomment the lines below to enable LTS for specific versions
-1.3
-1.6
-
-# For testing purposes (remove in production):
-# 0.0
+1.3:3.12
+1.6:3.13

--- a/.github/workflows/tag-recreate-lts.yml
+++ b/.github/workflows/tag-recreate-lts.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       lts_tag: ${{ steps.set_outputs.outputs.lts_tag }}
       release_tag: ${{ steps.set_outputs.outputs.release_tag }}
+      python_version: ${{ steps.set_outputs.outputs.python_version }}
 
     steps:
       - name: Checkout repository
@@ -94,24 +95,36 @@ jobs:
           fi
           
           # Read LTS versions from config file (remove comments and empty lines)
-          LTS_VERSIONS=$(grep -v '^#' .github/lts-versions.txt | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
+          # Format: major.minor:python_version
+          LTS_ENTRIES=$(grep -v '^#' .github/lts-versions.txt | grep -v '^$')
           
-          if [ -z "$LTS_VERSIONS" ]; then
+          if [ -z "$LTS_ENTRIES" ]; then
             echo "No LTS versions configured in .github/lts-versions.txt"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           
-          echo "Configured LTS versions: $LTS_VERSIONS"
+          echo "Configured LTS entries: $LTS_ENTRIES"
           echo "Checking release: $RELEASE_TAG"
           
           # Extract major.minor from release tag
           SHORT_TAG=$(echo "$RELEASE_TAG" | cut -d. -f1,2)
           
-          # Check if it matches any LTS version pattern
-          if echo "$SHORT_TAG" | grep -qE "^($LTS_VERSIONS)$"; then
-            echo "Release $RELEASE_TAG matches LTS version $SHORT_TAG"
+          # Check if it matches any LTS version pattern and extract python version
+          PYTHON_VERSION=""
+          while IFS= read -r entry; do
+            LTS_VER=$(echo "$entry" | cut -d: -f1)
+            PY_VER=$(echo "$entry" | cut -d: -f2)
+            if [ "$SHORT_TAG" == "$LTS_VER" ]; then
+              PYTHON_VERSION="$PY_VER"
+              break
+            fi
+          done <<< "$LTS_ENTRIES"
+          
+          if [ -n "$PYTHON_VERSION" ]; then
+            echo "Release $RELEASE_TAG matches LTS version $SHORT_TAG (python $PYTHON_VERSION)"
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "python_version=$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
           else
             echo "Release $RELEASE_TAG (version $SHORT_TAG) is not configured as LTS"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -219,6 +232,7 @@ jobs:
         run: |
           echo "lts_tag=${{ steps.vars.outputs.LTS_TAG }}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${{ steps.set_release_tag.outputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          echo "python_version=${{ steps.check_lts.outputs.python_version }}" >> "$GITHUB_OUTPUT"
           echo "Set job outputs for downstream job"
   
   tag-lts-images:
@@ -232,7 +246,6 @@ jobs:
       packages: write
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
         image-name: ["acapy-agent", "acapy-agent-bbs"]
     
     steps:
@@ -249,8 +262,8 @@ jobs:
 
       - name: Tag Images with LTS
         env:
-          SOURCE_TAG: py${{ matrix.python-version }}-${{ needs.recreate-lts-release.outputs.release_tag }}
-          LTS_TAG: py${{ matrix.python-version }}-${{ needs.recreate-lts-release.outputs.lts_tag }}
+          SOURCE_TAG: py${{ needs.recreate-lts-release.outputs.python_version }}-${{ needs.recreate-lts-release.outputs.release_tag }}
+          LTS_TAG: py${{ needs.recreate-lts-release.outputs.python_version }}-${{ needs.recreate-lts-release.outputs.lts_tag }}
           IMAGE_NAME: ghcr.io/${{ steps.lower.outputs.owner }}/${{ matrix.image-name }}
         run: |
           echo "Tagging \"$IMAGE_NAME:$SOURCE_TAG\" with \"$LTS_TAG\""


### PR DESCRIPTION
## Description

Follow-up to #4149 - somehow I managed to not commit the relevant changes in that PR, these are the updates switching the matrix strategy for a deterministic base image based on the versions file.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have added/updated tests where applicable
- [x] I have updated documentation if needed

