### PR TITLE
Fix anoncreds upgrade failure in-memory in-progress check

### DIFF
--- a/acapy_agent/wallet/anoncreds_upgrade.py
+++ b/acapy_agent/wallet/anoncreds_upgrade.py
@@ -580,6 +580,7 @@ async def retry_converting_records(
     async def fail_upgrade():
         async with profile.session() as session:
             storage = session.inject(BaseStorage)
+            UpgradeInProgressSingleton().remove_wallet(profile.name)
             await storage.delete_record(upgrading_record)
 
     try:
@@ -597,7 +598,8 @@ async def retry_converting_records(
         else:
             LOGGER.error(
                 f"Failed to upgrade wallet: {profile.name} after 5 retries. "
-                "Try fixing any connection issues and re-running the update"
+                "Try fixing any connection issues or repairing the wallet and re-running "
+                "the update"
             )
             await fail_upgrade()
 

--- a/acapy_agent/wallet/tests/test_anoncreds_upgrade.py
+++ b/acapy_agent/wallet/tests/test_anoncreds_upgrade.py
@@ -27,6 +27,7 @@ from ...storage.type import (
 from ...tests import mock
 from ...utils.testing import create_test_profile
 from .. import anoncreds_upgrade
+from ..singletons import UpgradeInProgressSingleton
 
 
 class TestAnonCredsUpgrade(IsolatedAsyncioTestCase):
@@ -361,11 +362,15 @@ class TestAnonCredsUpgrade(IsolatedAsyncioTestCase):
                         Exception("Error"),
                     ]
                 )
+                # Add wallet to upgrade in progress singleton
+                UpgradeInProgressSingleton().set_wallet(self.profile.name)
                 await anoncreds_upgrade.upgrade_wallet_to_anoncreds_if_requested(
                     self.profile
                 )
                 assert mock_rollback.called
                 assert not mock_commit.called
+                # Verify wallet has been removed from singleton
+                assert self.profile.name not in UpgradeInProgressSingleton().wallets
                 # Upgrading record should not be deleted
                 with self.assertRaises(Exception):
                     await storage.find_record(


### PR DESCRIPTION
We were upgrading a traction tenant that was in a corrupted state and failed. The in memory, in progress check was never set off which caused the api endpoints for this tenant to be stuck with 503 errors until pods were restarted.

