### PR TITLE
fix: complete stalled setup when activating a posted revocation registry

### DIFF
--- a/acapy_agent/revocation/indy.py
+++ b/acapy_agent/revocation/indy.py
@@ -7,6 +7,7 @@ from uuid_utils import uuid4
 
 from ..core.profile import Profile
 from ..ledger.base import BaseLedger
+from ..ledger.error import LedgerError
 from ..ledger.multiple_ledger.ledger_requests_executor import (
     GET_CRED_DEF,
     GET_REVOC_REG_DEF,
@@ -260,6 +261,7 @@ class IndyRevocation:
         except StorageNotFoundError:
             pass
 
+        posted_registries = []
         async with self._profile.session() as session:
             full_registries = await IssuerRevRegRecord.query_by_cred_def_id(
                 session, cred_def_id, None, IssuerRevRegRecord.STATE_FULL, 1
@@ -280,19 +282,30 @@ class IndyRevocation:
                     cred_def_id,
                     max_cred_num=any_registry.max_cred_num,
                 )
-            # if there is a posted registry, activate oldest
+            # if there is a posted registry, complete its setup and activate it
             else:
                 posted_registries = await IssuerRevRegRecord.query_by_cred_def_id(
                     session, cred_def_id, IssuerRevRegRecord.STATE_POSTED, None, None
                 )
-                if posted_registries:
-                    posted_registries = sorted(
-                        posted_registries, key=lambda r: r.created_at
-                    )
-                    await self._set_registry_status(
-                        revoc_reg_id=posted_registries[0].revoc_reg_id,
-                        state=IssuerRevRegRecord.STATE_ACTIVE,
-                    )
+
+        if posted_registries:
+            # A registry is only left posted when its setup stalled after the
+            # definition reached the ledger: the tails file upload and/or the
+            # initial accumulator entry are still outstanding. Complete those
+            # steps instead of activating with a bare state change, which would
+            # break every credential later issued against the registry
+            # (unresolvable tailsLocation, missing initial entry).
+            rec = min(posted_registries, key=lambda r: r.created_at)
+            try:
+                await rec.upload_tails_file(self._profile)
+                # publishing the initial entry transitions posted -> active
+                await rec.send_entry(self._profile)
+            except (RevocationError, LedgerError):
+                LOGGER.exception(
+                    "Setup of posted revocation registry %s could not be completed; "
+                    "not activating (will retry on next issuance attempt)",
+                    rec.revoc_reg_id,
+                )
         return None
 
     async def get_ledger_registry(self, revoc_reg_id: str) -> RevocationRegistry:

--- a/acapy_agent/revocation/tests/test_indy.py
+++ b/acapy_agent/revocation/tests/test_indy.py
@@ -318,11 +318,51 @@ class TestIndyRevocation(IsolatedAsyncioTestCase):
             ],
         ],
     )
+    @mock.patch.object(IssuerRevRegRecord, "upload_tails_file", mock.CoroutineMock())
+    @mock.patch.object(IssuerRevRegRecord, "send_entry", mock.CoroutineMock())
     async def test_get_or_create_active_registry_has_no_active_with_posted(self, *_):
         result = await self.revoc.get_or_create_active_registry("cred_def_id")
 
         assert not result
-        assert (
-            self.revoc._set_registry_status.call_args.kwargs["state"]
-            == IssuerRevRegRecord.STATE_ACTIVE
-        )
+        # the stalled setup pipeline is completed rather than bare-activated:
+        # the tails file is uploaded and the initial entry published (which
+        # transitions the record posted -> active)
+        IssuerRevRegRecord.upload_tails_file.assert_awaited_once()
+        IssuerRevRegRecord.send_entry.assert_awaited_once()
+        self.revoc._set_registry_status.assert_not_called()
+
+    @mock.patch(
+        "acapy_agent.revocation.indy.IndyRevocation.get_active_issuer_rev_reg_record",
+        mock.CoroutineMock(side_effect=StorageNotFoundError("No such record")),
+    )
+    @mock.patch(
+        "acapy_agent.revocation.indy.IndyRevocation._set_registry_status",
+        mock.CoroutineMock(return_value=None),
+    )
+    @mock.patch.object(
+        IssuerRevRegRecord,
+        "query_by_cred_def_id",
+        side_effect=[
+            [IssuerRevRegRecord(max_cred_num=3)],
+            [
+                IssuerRevRegRecord(
+                    revoc_reg_id="test-rev-reg-id",
+                    state=IssuerRevRegRecord.STATE_POSTED,
+                )
+            ],
+        ],
+    )
+    @mock.patch.object(
+        IssuerRevRegRecord,
+        "upload_tails_file",
+        mock.CoroutineMock(side_effect=RevocationError("tails server unavailable")),
+    )
+    @mock.patch.object(IssuerRevRegRecord, "send_entry", mock.CoroutineMock())
+    async def test_get_or_create_active_registry_posted_setup_incomplete(self, *_):
+        result = await self.revoc.get_or_create_active_registry("cred_def_id")
+
+        assert not result
+        # the registry must stay posted: activating it without a tails file
+        # on the server would break credentials issued against it
+        IssuerRevRegRecord.send_entry.assert_not_called()
+        self.revoc._set_registry_status.assert_not_called()


### PR DESCRIPTION
## Description

`IndyRevocation.get_or_create_active_registry` promoted the oldest `posted` registry to `active` with a bare wallet state change (`_set_registry_status`).

A registry is only ever left in a lasting `posted` state when its setup pipeline stalled between `send_def` and `send_entry` — most commonly a failed tails file upload (`on_revocation_registry_init_event`: `send_def` → `upload_tails_file` → `send_entry`). Promoting such a registry by flipping the wallet state skips the missed steps, so the "recovered" registry is broken:

- its ledger `tailsLocation` points at a file the tails server never received — holders get a 404 and can never build non-revocation proofs, and
- its initial accumulator entry (`REVOC_REG_ENTRY`) is missing from the ledger.

Every credential subsequently issued against it is silently unverifiable. If the agent's local tails copy was also lost (ephemeral storage), issuance instead wedges on `get_or_fetch_local_tails_path` until manual intervention.

This PR resumes the stalled pipeline instead of bare-flipping the state:

- `upload_tails_file()` — idempotent against the reference tails server, since `put_file` already treats HTTP 409 "already exists" as success — covers the case where the original failure happened after the upload;
- `send_entry()` — publishes the missed initial entry and itself performs the `posted -> active` transition (it also already contains the `fix_ledger_entry` correction path for entry conflicts).

If either step fails, the registry stays `posted`, an error is logged, and promotion is retried naturally on the next issuance attempt (callers already treat a `None` result as retry-after-delay). This is deliberately conservative: the worst case becomes "issuance paused with loud errors" instead of "broken credentials issued".

Note on endorser-mediated deployments: the promotion path has no endorser context, so the resume performs a direct ledger write; for endorser authors it will fail and leave the registry `posted`, which is no worse than the previous behavior (a broken activation).

**Tests**: reworked `test_get_or_create_active_registry_has_no_active_with_posted` to assert the missed steps run and no bare state change occurs; added `test_get_or_create_active_registry_posted_setup_incomplete` asserting that a registry whose setup cannot be completed is not activated. (The 3 `TestDeleteTails` failures reproduce on a pristine `main` checkout and are unrelated.)

**Backport request**: this code path ships in the 1.3 LTS line (observed on a 1.3.4 deployment; the function and the `put_file` 409 handling are identical on `1.3-lts`). We'd appreciate a backport to `1.3-lts` — happy to open that PR ourselves if preferred.

## Related Issue

N/A — full analysis included above.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have added/updated tests where applicable
- [ ] I have updated documentation if needed
