### PR TITLE
docs: warn that the subwallet token endpoint invalidates previous tokens

### DIFF
--- a/acapy_agent/multitenant/admin/routes.py
+++ b/acapy_agent/multitenant/admin/routes.py
@@ -579,12 +579,24 @@ async def wallet_update(request: web.BaseRequest):
     return web.json_response(result)
 
 
-@docs(tags=["multitenancy"], summary="Get auth token for a subwallet")
+@docs(
+    tags=["multitenancy"],
+    summary="Get auth token for a subwallet",
+    description=(
+        "Issue a new auth token for a subwallet. Issuing a new token invalidates "
+        "any token previously issued for the wallet: only the most recently "
+        "issued token is valid. Do not call this endpoint if another client may "
+        "still be using a previously issued token for the wallet."
+    ),
+)
 @request_schema(CreateWalletTokenRequestSchema)
 @response_schema(CreateWalletTokenResponseSchema(), 200, description="")
 @admin_authentication
 async def wallet_create_token(request: web.BaseRequest):
     """Request handler for creating an authorization token for a specific subwallet.
+
+    Issuing a new token invalidates any token previously issued for the wallet;
+    only the most recently issued token is valid.
 
     Args:
         request: aiohttp request object


### PR DESCRIPTION
## Description

The Swagger annotation for `POST /multitenancy/wallet/{wallet_id}/token` is only `summary="Get auth token for a subwallet"` — despite being a POST, it reads like an idempotent getter. The actual behavior (`create_auth_token` stores the new token's `iat` on the wallet record and `get_profile_for_token` rejects any token whose `iat` doesn't match, i.e. issuing a new token invalidates every previously issued token for the wallet) is documented only in `docs/features/Multitenancy.md` ("Method 2: Get tenant token"). Clients working from the API spec (Swagger UI / `swagger.json`) get no hint that the call is destructive.

This PR adds the warning to the endpoint's OpenAPI `description` and the handler docstring. Docs-only; no behavior change.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation if needed
