### PR TITLE
fix: self-issuance/self-connection OOB and DID exchange failures (#3300)

### DIFF
--- a/acapy_agent/core/oob_processor.py
+++ b/acapy_agent/core/oob_processor.py
@@ -35,6 +35,20 @@ _SENDER_ROLE_MESSAGE_TYPES = {
     MESSAGE_REUSE,
 }
 
+# Message types that are always sent by the *sender* of an invitation to its
+# *receiver* (the attachable messages). An inbound message of one of these types can
+# therefore never belong to our own role=sender OobRecord: it can only match our
+# role=receiver record. This matters for self-connections (one wallet playing both
+# roles for one invitation): once the receiver-role record has been consumed, an
+# inbound attached offer/present-request must not consume the sender-role record,
+# which is still needed to process the receiver's reply (e.g. request-credential).
+_RECEIVER_ROLE_MESSAGE_TYPES = {
+    CRED_20_OFFER,
+    PRES_20_REQUEST,
+    "issue-credential/1.0/offer-credential",
+    "present-proof/1.0/request-presentation",
+}
+
 
 class OobMessageProcessorError(BaseError):
     """Base error for OobMessageProcessor."""
@@ -228,6 +242,27 @@ class OobMessageProcessor:
                         except StorageNotFoundError:
                             # Fine if record is not found
                             pass
+
+                # An attached message (offer, presentation request, ...) always
+                # flows sender -> receiver, so it can never belong to our own
+                # role=sender OobRecord. This happens in a self-connection when
+                # the receiver-role record has already been consumed (deleted
+                # after the handshake): the attached offer must not consume the
+                # sender-role record here, or the later reply from the receiver
+                # (e.g. request-credential) finds no OobRecord at all.
+                if (
+                    oob_record
+                    and oob_record.role == OobRecord.ROLE_SENDER
+                    and DIDCommPrefix.unqualify(message_type)
+                    in _RECEIVER_ROLE_MESSAGE_TYPES
+                ):
+                    LOGGER.debug(
+                        "Ignoring role=sender OOB record %s for inbound "
+                        "receiver-bound message type %s",
+                        oob_record.oob_id,
+                        message_type,
+                    )
+                    oob_record = None
             # Otherwise try to find it using the attach thread id. This is only needed
             # for connectionless exchanges where every handler needs the context of the
             # oob record for verification. We could attach the oob_record to all messages,

--- a/acapy_agent/core/oob_processor.py
+++ b/acapy_agent/core/oob_processor.py
@@ -10,10 +10,13 @@ from ..messaging.agent_message import AgentMessage
 from ..messaging.decorators.service_decorator import ServiceDecorator
 from ..messaging.request_context import RequestContext
 from ..protocols.didcomm_prefix import DIDCommPrefix
+from ..protocols.didexchange.v1_0.message_types import ARIES_PROTOCOL as DIDEX_1_1
+from ..protocols.didexchange.v1_0.message_types import DIDEX_1_0
 from ..protocols.issue_credential.v2_0.message_types import CRED_20_OFFER
+from ..protocols.out_of_band.v1_0.message_types import MESSAGE_REUSE
 from ..protocols.out_of_band.v1_0.models.oob_record import OobRecord
 from ..protocols.present_proof.v2_0.message_types import PRES_20_REQUEST
-from ..storage.error import StorageNotFoundError
+from ..storage.error import StorageDuplicateError, StorageNotFoundError
 from ..transport.inbound.message import InboundMessage
 from ..transport.outbound.message import OutboundMessage
 from ..transport.wire_format import JsonWireFormat
@@ -21,6 +24,16 @@ from .error import BaseError
 from .profile import Profile
 
 LOGGER = logging.getLogger(__name__)
+
+# Message types that, per the OOB/DID-exchange protocols, are always sent by the
+# *receiver* of an invitation back to the *sender* (e.g. a connection request in
+# response to a handshake, or a request to reuse an existing connection). These are
+# processed by the party holding the role=sender OobRecord for the invitation.
+_SENDER_ROLE_MESSAGE_TYPES = {
+    f"{DIDEX_1_0}/request",
+    f"{DIDEX_1_1}/request",
+    MESSAGE_REUSE,
+}
 
 
 class OobMessageProcessorError(BaseError):
@@ -137,6 +150,84 @@ class OobMessageProcessor:
                 except StorageNotFoundError:
                     # Fine if record is not found
                     pass
+                except StorageDuplicateError:
+                    # Multiple oob records share this invi_msg_id. This happens when
+                    # an agent creates an OOB invitation and then receives that same
+                    # invitation back into the same wallet (e.g. self-issuance): one
+                    # OobRecord has role=sender (from create-invitation) and another
+                    # has role=receiver (from receive-invitation).
+                    #
+                    # Disambiguate primarily using the recipient verkey the inbound
+                    # message was actually delivered to: each side of a connectionless
+                    # exchange uses its own key (OobRecord.our_recipient_key), so the
+                    # recipient_verkey on the envelope tells us unambiguously which of
+                    # the two records this message belongs to, regardless of protocol
+                    # or message type (credential offers/requests, presentation
+                    # requests/presentations/acks, did-exchange requests, handshake
+                    # reuse, ...).
+                    if context.message_receipt.recipient_verkey:
+                        try:
+                            oob_record = await OobRecord.retrieve_by_tag_filter(
+                                session,
+                                {
+                                    "invi_msg_id": (
+                                        context.message_receipt.parent_thread_id
+                                    ),
+                                    "our_recipient_key": (
+                                        context.message_receipt.recipient_verkey
+                                    ),
+                                },
+                            )
+                            LOGGER.debug(
+                                "Multiple OOB records found for invi_msg_id %s; "
+                                "disambiguated using recipient verkey %s to oob "
+                                "record %s",
+                                context.message_receipt.parent_thread_id,
+                                context.message_receipt.recipient_verkey,
+                                oob_record.oob_id,
+                            )
+                        except (StorageNotFoundError, StorageDuplicateError):
+                            # Fine if record is not found (or, unexpectedly, still
+                            # ambiguous); fall back to the message-type heuristic
+                            oob_record = None
+
+                    # Fall back to disambiguating by message type. This is needed
+                    # when the message was delivered without going through the wire
+                    # format (e.g. the initial oob attachment message, which is
+                    # handled locally and therefore has no recipient_verkey). Some
+                    # message types are always sent by the receiver of an invitation
+                    # back to the sender, so we must be looking for our role=sender
+                    # record to process them; all other message types (e.g. attached
+                    # protocol messages like credential offers) are sent by the
+                    # sender to the receiver, so we must be looking for our
+                    # role=receiver record.
+                    if not oob_record:
+                        expected_role = (
+                            OobRecord.ROLE_SENDER
+                            if DIDCommPrefix.unqualify(message_type)
+                            in _SENDER_ROLE_MESSAGE_TYPES
+                            else OobRecord.ROLE_RECEIVER
+                        )
+                        LOGGER.debug(
+                            "Multiple OOB records found for invi_msg_id %s; "
+                            "disambiguating using role %s for message type %s",
+                            context.message_receipt.parent_thread_id,
+                            expected_role,
+                            message_type,
+                        )
+                        try:
+                            oob_record = await OobRecord.retrieve_by_tag_filter(
+                                session,
+                                {
+                                    "invi_msg_id": (
+                                        context.message_receipt.parent_thread_id
+                                    )
+                                },
+                                {"role": expected_role},
+                            )
+                        except StorageNotFoundError:
+                            # Fine if record is not found
+                            pass
             # Otherwise try to find it using the attach thread id. This is only needed
             # for connectionless exchanges where every handler needs the context of the
             # oob record for verification. We could attach the oob_record to all messages,
@@ -208,17 +299,46 @@ class OobMessageProcessor:
                 oob_record.invitation.requests_attach
                 and oob_record.state == OobRecord.STATE_AWAIT_RESPONSE
             ):
-                LOGGER.debug(
-                    f"Removing stale connection {oob_record.connection_id} due "
-                    "to connection reuse"
-                )
-                # Remove stale connection due to connection reuse
+                # Remove stale connection due to connection reuse. But first check
+                # whether the "old" connection is actually the mirror-image
+                # ConnRecord of a self-connection: when an agent's own wallet plays
+                # both the inviter and invitee roles for one invitation (e.g.
+                # self-issuance), each role gets its own ConnRecord, and both DIDs
+                # are reciprocal (old.my_did == new.their_did and vice versa). That
+                # "old" record is not stale -- it is still awaiting its own
+                # DIDXComplete -- so deleting it here causes accept_complete to
+                # fail with "No corresponding connection request found".
+                old_conn_record = None
                 if oob_record.connection_id:
                     async with context.profile.session() as session:
-                        old_conn_record = await ConnRecord.retrieve_by_id(
-                            session, oob_record.connection_id
-                        )
+                        try:
+                            old_conn_record = await ConnRecord.retrieve_by_id(
+                                session, oob_record.connection_id
+                            )
+                        except StorageNotFoundError:
+                            old_conn_record = None
+
+                is_self_connection_mirror = bool(
+                    old_conn_record
+                    and old_conn_record.my_did
+                    and old_conn_record.their_did
+                    and old_conn_record.my_did == context.connection_record.their_did
+                    and old_conn_record.their_did == context.connection_record.my_did
+                )
+
+                if old_conn_record and not is_self_connection_mirror:
+                    LOGGER.debug(
+                        f"Removing stale connection {oob_record.connection_id} due "
+                        "to connection reuse"
+                    )
+                    async with context.profile.session() as session:
                         await old_conn_record.delete_record(session)
+                elif is_self_connection_mirror:
+                    LOGGER.debug(
+                        f"Not removing connection {oob_record.connection_id}: it is "
+                        "the other role's own ConnRecord for this self-connection "
+                        "and is still awaiting its own handshake completion"
+                    )
 
                 oob_record.connection_id = context.connection_record.connection_id
 

--- a/acapy_agent/core/tests/test_oob_processor.py
+++ b/acapy_agent/core/tests/test_oob_processor.py
@@ -1,11 +1,22 @@
 import json
+import os
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY
 
+import pytest
+
 from ...connections.models.conn_record import ConnRecord
+from ...core.event_bus import EventBus
 from ...messaging.decorators.attach_decorator import AttachDecorator
 from ...messaging.decorators.service_decorator import ServiceDecorator
 from ...messaging.request_context import RequestContext
+from ...messaging.responder import BaseResponder, MockResponder
+from ...protocols.coordinate_mediation.v1_0.route_manager import RouteManager
+from ...protocols.issue_credential.v2_0.manager import V20CredManager
+from ...protocols.issue_credential.v2_0.messages.cred_offer import V20CredOffer
+from ...protocols.issue_credential.v2_0.messages.cred_request import V20CredRequest
+from ...protocols.issue_credential.v2_0.models.cred_ex_record import V20CredExRecord
+from ...protocols.out_of_band.v1_0.manager import OutOfBandManager
 from ...protocols.out_of_band.v1_0.messages.invitation import InvitationMessage
 from ...protocols.out_of_band.v1_0.models.oob_record import OobRecord
 from ...storage.error import StorageNotFoundError
@@ -456,6 +467,57 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
 
             assert self.oob_record.connection_id == "another-connection-id"
 
+    async def test_find_oob_record_for_inbound_message_self_connection_not_deleted(
+        self,
+    ):
+        """Regression test for issue #3300 bug #2.
+
+        In a self-connection (one wallet playing both the inviter and invitee
+        roles for one OOB invitation with both handshake_protocols and an
+        attachment), the "old" connection associated with the OobRecord is the
+        *other role's own* ConnRecord -- reciprocal DIDs with the inbound
+        message's connection -- not a stale/superseded connection from a real
+        connection-reuse race. It must not be deleted, or the still-pending
+        DIDXComplete for that connection later fails with DIDXManagerError:
+        "No corresponding connection request found".
+        """
+        old_conn_record = mock.MagicMock(
+            my_did="old-my-did",
+            their_did="new-my-did",
+            delete_record=mock.CoroutineMock(),
+        )
+        with (
+            mock.patch.object(
+                OobRecord,
+                "retrieve_by_tag_filter",
+                mock.CoroutineMock(return_value=self.oob_record),
+            ) as mock_retrieve,
+            mock.patch.object(
+                ConnRecord,
+                "retrieve_by_id",
+                mock.CoroutineMock(return_value=old_conn_record),
+            ) as mock_retrieve_conn,
+        ):
+            self.oob_record.role = OobRecord.ROLE_SENDER
+            self.oob_record.state = OobRecord.STATE_AWAIT_RESPONSE
+            self.context.connection_record = mock.MagicMock(
+                connection_id="another-connection-id",
+                my_did="new-my-did",
+                their_did="old-my-did",
+            )
+            self.context.message_receipt = MessageReceipt(
+                thread_id="the-thid", parent_thread_id="the-pthid"
+            )
+
+            assert await self.oob_processor.find_oob_record_for_inbound_message(
+                self.context
+            )
+            mock_retrieve.assert_called_once()
+            mock_retrieve_conn.assert_called_once_with(ANY, "a-connection-id")
+            old_conn_record.delete_record.assert_not_called()
+
+            assert self.oob_record.connection_id == "another-connection-id"
+
     async def test_find_oob_record_for_inbound_message_attach_thread_id_set(self):
         # No attach thread_id
         self.oob_record.attach_thread_id = None
@@ -748,3 +810,234 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
 
         assert self.oob_processor.get_thread_id(message_w_thread) == "the-thread-id"
         assert self.oob_processor.get_thread_id(message_wo_thread) == "the-message-id"
+
+
+# --- Regression tests for self-issuance via OOB attachment without a prior
+# --- connection (aries-rfcs/acapy issue #3300, bug #1): creating an OOB
+# --- invitation with an attached credential-offer and then receiving that
+# --- same invitation back into the same wallet used to raise
+# --- StorageDuplicateError from find_oob_record_for_inbound_message, because
+# --- the invi_msg_id is shared by two OobRecords (role=sender, role=receiver).
+
+
+def _wallet_settings(wallet_type: str) -> dict:
+    settings = {
+        "wallet.type": wallet_type,
+        "auto_provision": True,
+        "default_endpoint": "http://example.com/endpoint",
+        "default_label": "self-issuer",
+    }
+    if wallet_type == "kanon-anoncreds":
+        postgres_url = os.getenv("POSTGRES_URL")
+        settings.update(
+            {
+                "wallet.storage_type": "postgres",
+                "wallet.storage_config": {"url": postgres_url},
+                "wallet.storage_creds": {
+                    "account": "postgres",
+                    "password": "postgres",
+                },
+                "dbstore_storage_type": "postgres",
+                "dbstore_storage_config": {"url": postgres_url},
+                "dbstore_storage_creds": {
+                    "account": "postgres",
+                    "password": "postgres",
+                },
+                "dbstore_schema_config": "normalize",
+            }
+        )
+    return settings
+
+
+WALLET_TYPES = [
+    "askar",
+    "askar-anoncreds",
+    pytest.param(
+        "kanon-anoncreds",
+        marks=pytest.mark.skipif(
+            not os.getenv("POSTGRES_URL"),
+            reason="Kanon PostgreSQL integration tests disabled: set POSTGRES_URL "
+            "to enable",
+        ),
+    ),
+]
+
+
+def _bind_oob_manager_deps(profile):
+    """Bind the dependencies OutOfBandManager needs, for direct manager tests."""
+    route_manager = mock.MagicMock(RouteManager, autospec=True)
+    route_manager.routing_info = mock.CoroutineMock(return_value=([], None))
+    route_manager.mediation_record_if_id = mock.CoroutineMock(return_value=None)
+    route_manager.route_invitation = mock.CoroutineMock(return_value=None)
+    route_manager.route_verkey = mock.CoroutineMock(return_value=None)
+    profile.context.injector.bind_instance(RouteManager, route_manager)
+    profile.context.injector.bind_instance(BaseResponder, MockResponder())
+    profile.context.injector.bind_instance(EventBus, EventBus())
+    return route_manager
+
+
+@pytest.mark.parametrize("wallet_type", WALLET_TYPES)
+async def test_self_issuance_oob_attachment_without_connection(wallet_type):
+    """An OOB invitation with an attached cred-offer, received by its own
+    creator, must not raise StorageDuplicateError when the attached message
+    is routed back through find_oob_record_for_inbound_message.
+    """
+    profile = await create_test_profile(settings=_wallet_settings(wallet_type))
+    oob_processor = OobMessageProcessor(inbound_message_router=mock.MagicMock())
+    profile.context.injector.bind_instance(OobMessageProcessor, oob_processor)
+    _bind_oob_manager_deps(profile)
+
+    oob_mgr = OutOfBandManager(profile)
+
+    offer = V20CredOffer(formats=[], offers_attach=[])
+    cred_ex = V20CredExRecord(
+        cred_ex_id=None,
+        state=V20CredExRecord.STATE_OFFER_SENT,
+        cred_offer=offer.serialize(),
+    )
+    async with profile.session() as session:
+        await cred_ex.save(session)
+
+    invitation_record = await oob_mgr.create_invitation(
+        my_label="self-issuer",
+        attachments=[{"id": cred_ex.cred_ex_id, "type": "credential-offer"}],
+    )
+
+    # Two OobRecords with the same invi_msg_id now exist: role=sender (from
+    # create_invitation) and role=receiver (from receive_invitation below).
+    oob_record = await oob_mgr.receive_invitation(invitation_record.invitation)
+    assert oob_record.role == OobRecord.ROLE_RECEIVER
+
+    async with profile.session() as session:
+        oob_records = await OobRecord.query(
+            session, tag_filter={"invi_msg_id": invitation_record.invi_msg_id}
+        )
+    assert len(oob_records) == 2
+    assert {r.role for r in oob_records} == {
+        OobRecord.ROLE_SENDER,
+        OobRecord.ROLE_RECEIVER,
+    }
+
+    # Simulate the attached credential-offer message being routed back
+    # through the inbound pipeline: this is exactly where
+    # find_oob_record_for_inbound_message previously raised
+    # StorageDuplicateError.
+    context = RequestContext.test_context(profile)
+    context.message = offer
+    context.message_receipt = MessageReceipt(
+        thread_id=offer._id,
+        parent_thread_id=invitation_record.invi_msg_id,
+    )
+
+    result = await oob_processor.find_oob_record_for_inbound_message(context)
+
+    assert result is not None
+    assert result.role == OobRecord.ROLE_RECEIVER
+
+
+@pytest.mark.parametrize("wallet_type", WALLET_TYPES)
+async def test_self_issuance_connectionless_full_round_trip(wallet_type):
+    """Full connectionless self-issuance (bug #3, downstream of issue #3300).
+
+    Create an OOB invitation with an attached credential offer (no
+    handshake_protocols), receive it back into the same wallet, then drive the
+    holder side to send a credential request back into the same wallet. The
+    credential-request lookup used to come back empty (find_oob_record_for_inbound
+    _message returning None -- not even hitting the "Multiple OOB records" branch
+    that bug #1 fixed) because the duplicate-record disambiguation defaulted every
+    non-didexchange message type to role=receiver, when a *reply* message flowing
+    holder -> issuer (like issue-credential's request-credential) actually belongs
+    to the role=sender record.
+    """
+    profile = await create_test_profile(settings=_wallet_settings(wallet_type))
+    inbound_messages = []
+
+    def inbound_router(profile_, inbound_message, can_respond):
+        inbound_messages.append(inbound_message)
+
+    oob_processor = OobMessageProcessor(inbound_message_router=inbound_router)
+    profile.context.injector.bind_instance(OobMessageProcessor, oob_processor)
+    _bind_oob_manager_deps(profile)
+
+    oob_mgr = OutOfBandManager(profile)
+
+    offer = V20CredOffer(formats=[], offers_attach=[])
+    cred_ex = V20CredExRecord(
+        cred_ex_id=None,
+        state=V20CredExRecord.STATE_OFFER_SENT,
+        cred_offer=offer.serialize(),
+    )
+    async with profile.session() as session:
+        await cred_ex.save(session)
+
+    invitation_record = await oob_mgr.create_invitation(
+        my_label="self-issuer",
+        attachments=[{"id": cred_ex.cred_ex_id, "type": "credential-offer"}],
+    )
+
+    # Receiving our own invitation processes the attached offer and delivers it
+    # to the inbound router, exactly like a real inbound transport would.
+    await oob_mgr.receive_invitation(invitation_record.invitation)
+    assert len(inbound_messages) == 1
+    offer_inbound = inbound_messages[0]
+
+    offer_context = RequestContext.test_context(profile)
+    offer_context.message = offer
+    offer_context.message_receipt = offer_inbound.receipt
+
+    oob_record_for_offer = await oob_processor.find_oob_record_for_inbound_message(
+        offer_context
+    )
+    assert oob_record_for_offer is not None
+    assert oob_record_for_offer.role == OobRecord.ROLE_RECEIVER
+
+    # Holder side: receive the offer and build a credential request reply.
+    cred_manager = V20CredManager(profile)
+    holder_cred_ex = await cred_manager.receive_offer(offer, None)
+
+    cred_request_message = V20CredRequest(formats=[], requests_attach=[])
+    cred_request_message.assign_thread_from(offer)
+    holder_cred_ex.thread_id = cred_request_message._thread_id
+    holder_cred_ex.state = V20CredExRecord.STATE_REQUEST_SENT
+    holder_cred_ex.cred_request = cred_request_message
+    async with profile.session() as session:
+        await holder_cred_ex.save(session, reason="test credential request")
+
+    # Simulate sending the request: this is exactly what the outbound transport
+    # manager does before delivering the message (attaches ~service/~thread.pthid
+    # and resolves the delivery target/recipient key from the OOB record).
+    outbound = OutboundMessage(
+        reply_thread_id=cred_request_message._thread_id,
+        payload=cred_request_message.serialize(as_string=True),
+    )
+    target = await oob_processor.find_oob_target_for_outbound_message(
+        profile, outbound
+    )
+    assert target is not None
+
+    # Simulate that same request being delivered back inbound, as it is in the
+    # real self-issuance-without-handshake deployment scenario: recipient_verkey
+    # is the key the message was actually decrypted with (the issuer's/sender's
+    # connectionless key -- what the outbound target resolved to), and
+    # sender_verkey is the holder's own connectionless key (carried in the
+    # message's own ~service block, used by the recipient to reply).
+    payload = json.loads(outbound.payload)
+    request_context = RequestContext.test_context(profile)
+    request_context.message = V20CredRequest.deserialize(payload)
+    request_context.message_receipt = MessageReceipt(
+        thread_id=payload["~thread"]["thid"],
+        parent_thread_id=payload["~thread"].get("pthid"),
+        recipient_verkey=target.recipient_keys[0],
+        sender_verkey=payload["~service"]["recipientKeys"][0],
+    )
+
+    oob_record_for_request = await oob_processor.find_oob_record_for_inbound_message(
+        request_context
+    )
+
+    # This is the fix under test: previously this came back None, and
+    # V20CredRequestHandler.handle raised "No connection or associated
+    # connectionless exchange found for credential request".
+    assert oob_record_for_request is not None
+    assert oob_record_for_request.role == OobRecord.ROLE_SENDER
+    assert oob_record_for_request.invi_msg_id == invitation_record.invi_msg_id

--- a/acapy_agent/core/tests/test_oob_processor.py
+++ b/acapy_agent/core/tests/test_oob_processor.py
@@ -518,6 +518,41 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
 
             assert self.oob_record.connection_id == "another-connection-id"
 
+    async def test_find_oob_record_inbound_offer_does_not_consume_sender_record(
+        self,
+    ):
+        """Regression test for issue #3300 (self-issuance, bug #4).
+
+        An inbound credential offer flows sender -> receiver, so it can never
+        belong to our own role=sender OobRecord. In a self-connection the
+        receiver-role record may already be gone (deleted after the handshake),
+        leaving only the sender record to match the offer's pthid: the offer
+        must NOT consume (update/delete) that sender record, or the later
+        request-credential reply finds no OobRecord at all.
+        """
+        self.oob_record.role = OobRecord.ROLE_SENDER
+
+        with mock.patch.object(
+            OobRecord,
+            "retrieve_by_tag_filter",
+            mock.CoroutineMock(return_value=self.oob_record),
+        ):
+            self.context.message = V20CredOffer(formats=[], offers_attach=[])
+            self.context.connection_record = mock.MagicMock(
+                connection_id="receiver-role-connection-id"
+            )
+            self.context.message_receipt = MessageReceipt(
+                thread_id="the-thid", parent_thread_id="the-pthid"
+            )
+
+            result = await self.oob_processor.find_oob_record_for_inbound_message(
+                self.context
+            )
+
+            assert result is None
+            self.oob_record.delete_record.assert_not_called()
+            self.oob_record.save.assert_not_called()
+
     async def test_find_oob_record_for_inbound_message_attach_thread_id_set(self):
         # No attach thread_id
         self.oob_record.attach_thread_id = None

--- a/acapy_agent/protocols/didexchange/v1_0/handlers/request_handler.py
+++ b/acapy_agent/protocols/didexchange/v1_0/handlers/request_handler.py
@@ -44,14 +44,19 @@ class DIDXRequestHandler(BaseHandler):
             )
             # Auto respond
             if conn_rec.accept == ConnRecord.ACCEPT_AUTO:
+                # create_response() already transitions conn_rec to the response
+                # state and persists it. Do not set/save that state again after
+                # sending: in a self-connection, delivering the response can
+                # synchronously drive the rest of the handshake (accept_response
+                # -> complete -> accept_complete) to completion before
+                # send_reply() returns, and blindly overwriting the state here
+                # would regress an already-completed connection back to
+                # "response".
                 response = await mgr.create_response(
                     conn_rec,
                     mediation_id=mediation_id,
                 )
                 await responder.send_reply(response, connection_id=conn_rec.connection_id)
-                conn_rec.state = ConnRecord.State.RESPONSE.rfc23
-                async with context.session() as session:
-                    await conn_rec.save(session, reason="Sent connection response")
             else:
                 self._logger.debug("DID exchange request will await acceptance")
 

--- a/acapy_agent/protocols/didexchange/v1_0/manager.py
+++ b/acapy_agent/protocols/didexchange/v1_0/manager.py
@@ -165,6 +165,13 @@ class DIDXManager(BaseConnectionManager):
         )
 
         if conn_rec.accept == ConnRecord.ACCEPT_AUTO:
+            # create_request() already transitions conn_rec to the request state
+            # and persists it (see below). We must NOT set/save that state again
+            # after sending: in a self-connection, delivering the request can
+            # synchronously drive the entire handshake (request -> response ->
+            # complete) to completion before send_reply() returns, and blindly
+            # overwriting the state here would regress an already-completed
+            # connection back to "request".
             request = await self.create_request(conn_rec, mediation_id=mediation_id)
             base_responder = self.profile.inject(BaseResponder)
             responder = AdminResponder(self.profile, base_responder.send_fn)
@@ -173,10 +180,6 @@ class DIDXManager(BaseConnectionManager):
                     request,
                     connection_id=conn_rec.connection_id,
                 )
-
-                conn_rec.state = ConnRecord.State.REQUEST.rfc160
-                async with self.profile.session() as session:
-                    await conn_rec.save(session, reason="Sent connection request")
         else:
             self._logger.debug("Connection invitation will await acceptance")
 

--- a/acapy_agent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/acapy_agent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest import IsolatedAsyncioTestCase
 
 import pytest
@@ -2426,3 +2427,293 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         request = DIDXRequest.deserialize(raw_request)
         assert request._version == "1.0"
         assert self.manager._handshake_protocol_to_use(request) == DIDEX_1_0
+
+
+# --- Regression tests for self-connection did-exchange handshakes
+# (aries-rfcs/acapy issue #3300, bug #2): an agent creating an OOB
+# invitation with a didexchange handshake protocol and then receiving that
+# same invitation back into its own wallet must be able to drive the
+# handshake (request -> response -> complete) all the way to completion for
+# *both* of its own ConnRecords, without either one regressing back to an
+# earlier state or accept_complete failing to find its ConnRecord.
+
+
+def _didx_wallet_settings(wallet_type: str) -> dict:
+    settings = {
+        "wallet.type": wallet_type,
+        "auto_provision": True,
+        "default_endpoint": "http://example.com/endpoint",
+        "default_label": "self-connector",
+        "debug.auto_accept_invites": True,
+        "debug.auto_accept_requests": True,
+    }
+    if wallet_type == "kanon-anoncreds":
+        postgres_url = os.getenv("POSTGRES_URL")
+        settings.update(
+            {
+                "wallet.storage_type": "postgres",
+                "wallet.storage_config": {"url": postgres_url},
+                "wallet.storage_creds": {
+                    "account": "postgres",
+                    "password": "postgres",
+                },
+                "dbstore_storage_type": "postgres",
+                "dbstore_storage_config": {"url": postgres_url},
+                "dbstore_storage_creds": {
+                    "account": "postgres",
+                    "password": "postgres",
+                },
+                "dbstore_schema_config": "normalize",
+            }
+        )
+    return settings
+
+
+DIDX_WALLET_TYPES = [
+    "askar",
+    "askar-anoncreds",
+    pytest.param(
+        "kanon-anoncreds",
+        marks=pytest.mark.skipif(
+            not os.getenv("POSTGRES_URL"),
+            reason="Kanon PostgreSQL integration tests disabled: set POSTGRES_URL "
+            "to enable",
+        ),
+    ),
+]
+
+
+def _bind_didx_manager_deps(profile):
+    """Bind the dependencies DIDXManager/OutOfBandManager need for direct tests."""
+    route_manager = mock.MagicMock(RouteManager, autospec=True)
+    route_manager.routing_info = mock.CoroutineMock(return_value=([], None))
+    route_manager.mediation_record_if_id = mock.CoroutineMock(return_value=None)
+    route_manager.mediation_records_for_connection = mock.CoroutineMock(
+        return_value=[]
+    )
+    route_manager.route_invitation = mock.CoroutineMock(return_value=None)
+    route_manager.route_verkey = mock.CoroutineMock(return_value=None)
+    route_manager.route_connection_as_invitee = mock.CoroutineMock(return_value=None)
+    route_manager.route_connection_as_inviter = mock.CoroutineMock(return_value=None)
+    route_manager.save_mediator_for_connection = mock.CoroutineMock(return_value=None)
+    profile.context.injector.bind_instance(RouteManager, route_manager)
+    profile.context.injector.bind_instance(
+        OobMessageProcessor,
+        OobMessageProcessor(inbound_message_router=mock.MagicMock()),
+    )
+    profile.context.injector.bind_instance(DIDMethods, DIDMethods())
+    profile.context.injector.bind_instance(KeyTypes, KeyTypes())
+
+    resolver = mock.MagicMock(DIDResolver, autospec=True)
+    did_doc = DIDDocument.deserialize(DOC)
+    resolver.resolve = mock.CoroutineMock(return_value=did_doc.serialize())
+    resolver.dereference_verification_method = mock.CoroutineMock(
+        return_value=did_doc.verification_method[0]
+    )
+    profile.context.injector.bind_instance(DIDResolver, resolver)
+
+
+class _LoopbackResponder(BaseResponder):
+    """Responder that immediately re-delivers messages to a DIDXManager.
+
+    Used to drive a self-connection handshake the way a real self-addressed
+    DIDComm delivery would: the party creating an invitation and the party
+    receiving it are the same wallet, so sending a message is equivalent to
+    processing it as an inbound message (potentially recursively/
+    synchronously, exactly as real auto-accept handling does for a
+    self-connection).
+    """
+
+    def __init__(self, didx_mgr: DIDXManager):
+        super().__init__()
+        self.didx_mgr = didx_mgr
+        self.messages = []
+
+    async def _deliver(self, message):
+        self.messages.append(message)
+        receipt = MessageReceipt()
+        if isinstance(message, DIDXRequest):
+            conn_rec = await self.didx_mgr.receive_request(
+                request=message,
+                recipient_did=None,
+                recipient_verkey="loopback-verkey",
+            )
+            if conn_rec.accept == ConnRecord.ACCEPT_AUTO:
+                response = await self.didx_mgr.create_response(conn_rec)
+                await self.send_reply(response, connection_id=conn_rec.connection_id)
+        elif isinstance(message, test_module.DIDXResponse):
+            await self.didx_mgr.accept_response(message, receipt)
+        elif isinstance(message, test_module.DIDXComplete):
+            await self.didx_mgr.accept_complete(message, receipt)
+
+    async def send(self, message, **kwargs):
+        await self._deliver(message)
+        return None
+
+    async def send_reply(self, message, **kwargs):
+        await self._deliver(message)
+        return None
+
+    async def send_outbound(self, message, **kwargs):
+        return None
+
+    async def send_webhook(self, topic, payload):
+        return None
+
+    async def send_fn(self, profile, outbound_message):
+        """Used when wrapped in an AdminResponder, mirroring the real send_fn."""
+        payload = json.loads(outbound_message.payload)
+        msg_type = payload.get("@type", "")
+        if msg_type.endswith("/request"):
+            message = DIDXRequest.deserialize(payload)
+        elif msg_type.endswith("/response"):
+            message = test_module.DIDXResponse.deserialize(payload)
+        elif msg_type.endswith("/complete"):
+            message = test_module.DIDXComplete.deserialize(payload)
+        else:
+            return None
+        await self._deliver(message)
+        return None
+
+
+class _RecordingResponder(MockResponder):
+    """MockResponder that also supports being wrapped in an AdminResponder.
+
+    DIDXManager.receive_invitation()'s auto-accept path wraps the injected
+    BaseResponder in an AdminResponder using its `send_fn`. Plain
+    MockResponder doesn't define that attribute, so provide one that decodes
+    the outbound message and records it like the other send* methods do.
+    """
+
+    async def send_fn(self, profile, outbound_message):
+        payload = json.loads(outbound_message.payload)
+        msg_type = payload.get("@type", "")
+        if msg_type.endswith("/request"):
+            message = DIDXRequest.deserialize(payload)
+        elif msg_type.endswith("/response"):
+            message = test_module.DIDXResponse.deserialize(payload)
+        elif msg_type.endswith("/complete"):
+            message = test_module.DIDXComplete.deserialize(payload)
+        else:
+            return None
+        self.messages.append((message, {}))
+        return None
+
+
+@pytest.mark.parametrize("wallet_type", DIDX_WALLET_TYPES)
+async def test_self_connection_didx_handshake_to_completion(wallet_type):
+    """Self-connection did-exchange handshake must complete for both sides.
+
+    Regression test for issue #3300 bug #2: previously, driving a
+    self-connection's request/response/complete cascade could leave one or
+    both of the wallet's own ConnRecords stuck in an earlier state (e.g.
+    "request" or "response") instead of "active", because manager/handler
+    code re-saved a stale in-memory ConnRecord's state *after* sending a
+    message whose (self-)delivery had already synchronously advanced that
+    same ConnRecord further.
+    """
+    profile = await create_test_profile(settings=_didx_wallet_settings(wallet_type))
+    _bind_didx_manager_deps(profile)
+
+    didx_mgr = DIDXManager(profile)
+    # DID doc resolution/key-recording is unrelated to the ConnRecord state
+    # machine under test; stub it out.
+    didx_mgr.record_keys_for_resolvable_did = mock.CoroutineMock(return_value=None)
+
+    responder = _LoopbackResponder(didx_mgr)
+    profile.context.injector.bind_instance(BaseResponder, responder)
+
+    oob_mgr = OutOfBandManager(profile)
+
+    invitation_record = await oob_mgr.create_invitation(
+        my_label="inviter",
+        hs_protos=[HSProto.RFC23],
+        auto_accept=True,
+    )
+
+    await oob_mgr.receive_invitation(invitation_record.invitation, auto_accept=True)
+
+    async with profile.session() as session:
+        conn_records = await ConnRecord.query(session)
+
+    assert len(conn_records) == 2
+    for conn_rec in conn_records:
+        assert ConnRecord.State.get(conn_rec.state) is ConnRecord.State.COMPLETED, (
+            f"connection {conn_rec.connection_id} (their_role={conn_rec.their_role}) "
+            f"did not reach the completed state: {conn_rec.state}"
+        )
+
+
+@pytest.mark.parametrize("wallet_type", DIDX_WALLET_TYPES)
+async def test_two_party_didx_handshake_no_regression(wallet_type):
+    """A normal (non-self) two-party did-exchange handshake still completes.
+
+    Regression guard to accompany the self-connection fix: confirms that
+    removing the redundant post-send state saves in
+    DIDXManager.receive_invitation and DIDXRequestHandler.handle does not
+    break the ordinary case where invitee and inviter are different wallets.
+    """
+    inviter_profile = await create_test_profile(
+        settings=_didx_wallet_settings(wallet_type)
+    )
+    _bind_didx_manager_deps(inviter_profile)
+    invitee_profile = await create_test_profile(
+        settings=_didx_wallet_settings(wallet_type)
+    )
+    _bind_didx_manager_deps(invitee_profile)
+
+    inviter_didx_mgr = DIDXManager(inviter_profile)
+    inviter_didx_mgr.record_keys_for_resolvable_did = mock.CoroutineMock(
+        return_value=None
+    )
+    invitee_didx_mgr = DIDXManager(invitee_profile)
+    invitee_didx_mgr.record_keys_for_resolvable_did = mock.CoroutineMock(
+        return_value=None
+    )
+
+    inviter_responder = _RecordingResponder()
+    inviter_profile.context.injector.bind_instance(BaseResponder, inviter_responder)
+    invitee_responder = _RecordingResponder()
+    invitee_profile.context.injector.bind_instance(BaseResponder, invitee_responder)
+
+    oob_mgr = OutOfBandManager(inviter_profile)
+    invitation_record = await oob_mgr.create_invitation(
+        my_label="inviter",
+        hs_protos=[HSProto.RFC23],
+        auto_accept=True,
+    )
+
+    # Invitee receives the invitation and (auto_accept) sends a request
+    invitee_conn = await invitee_didx_mgr.receive_invitation(
+        invitation_record.invitation, auto_accept=True
+    )
+    assert invitee_responder.messages, "invitee did not send a request"
+    request, _ = invitee_responder.messages[-1]
+
+    # Inviter receives the request and (auto_accept) sends a response
+    async with inviter_profile.session() as session:
+        inviter_conn_recs = await ConnRecord.query(session)
+    inviter_conn = inviter_conn_recs[0]
+    inviter_conn = await inviter_didx_mgr.receive_request(
+        request=request,
+        recipient_did=None,
+        recipient_verkey=inviter_conn.invitation_key,
+    )
+    if inviter_conn.accept == ConnRecord.ACCEPT_AUTO:
+        response = await inviter_didx_mgr.create_response(inviter_conn)
+        await inviter_responder.send_reply(
+            response, connection_id=inviter_conn.connection_id
+        )
+    assert inviter_responder.messages, "inviter did not send a response"
+    response, _ = inviter_responder.messages[-1]
+
+    # Invitee receives the response and sends a complete message
+    invitee_conn = await invitee_didx_mgr.accept_response(response, MessageReceipt())
+    assert invitee_responder.messages[-1][0] is not request
+    complete, _ = invitee_responder.messages[-1]
+
+    # Inviter receives the complete message
+    inviter_conn = await inviter_didx_mgr.accept_complete(complete, MessageReceipt())
+
+    assert ConnRecord.State.get(invitee_conn.state) is ConnRecord.State.COMPLETED
+    assert ConnRecord.State.get(inviter_conn.state) is ConnRecord.State.COMPLETED

--- a/acapy_agent/protocols/issue_credential/v2_0/manager.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/manager.py
@@ -436,7 +436,9 @@ class V20CredManager:
         # connection_id is None in the record if this is in response to
         # an request~attach from an OOB message. If so, we do not want to filter
         # the record by connection_id.
-        connection_id = None if oob_record else connection_record.connection_id
+        connection_id = None if oob_record else (
+            connection_record.connection_id if connection_record else None
+        )
 
         handlers = [
             f.handler(self.profile)
@@ -449,12 +451,34 @@ class V20CredManager:
 
         async with self._profile.session() as session:
             try:
-                cred_ex_record = await V20CredExRecord.retrieve_by_conn_and_thread(
-                    session,
-                    connection_id,
-                    cred_request_message._thread_id,
-                    role=V20CredExRecord.ROLE_ISSUER,
-                )
+                try:
+                    cred_ex_record = await V20CredExRecord.retrieve_by_conn_and_thread(
+                        session,
+                        connection_id,
+                        cred_request_message._thread_id,
+                        role=V20CredExRecord.ROLE_ISSUER,
+                    )
+                except StorageNotFoundError:
+                    if not connection_id:
+                        raise
+                    # The issuer's exchange record may have been created without a
+                    # connection (offer attached to an OOB invitation) while the
+                    # request arrives over the connection established by that same
+                    # invitation (e.g. after the OobRecord has been cleaned up, as
+                    # in a self-connection). Retry matching on thread and role only,
+                    # but never adopt a record already bound to another connection.
+                    cred_ex_record = await V20CredExRecord.retrieve_by_conn_and_thread(
+                        session,
+                        None,
+                        cred_request_message._thread_id,
+                        role=V20CredExRecord.ROLE_ISSUER,
+                    )
+                    if cred_ex_record.connection_id:
+                        raise StorageNotFoundError(
+                            "Credential exchange record for thread "
+                            f"{cred_request_message._thread_id} belongs to another "
+                            "connection"
+                        )
             except StorageNotFoundError as ex:
                 # holder sent this request free of any offer
                 if handlers_without_offer:

--- a/acapy_agent/protocols/issue_credential/v2_0/tests/test_manager.py
+++ b/acapy_agent/protocols/issue_credential/v2_0/tests/test_manager.py
@@ -552,7 +552,10 @@ class TestV20CredManager(IsolatedAsyncioTestCase):
             mock.patch.object(V20CredFormat.Format, "handler") as mock_handler,
         ):
             mock_handler.return_value.receive_offer = mock.CoroutineMock()
-            mock_retrieve.side_effect = (StorageNotFoundError(),)
+            mock_retrieve.side_effect = (
+                StorageNotFoundError(),
+                StorageNotFoundError(),
+            )
             cx_rec = await self.manager.receive_offer(cred_offer, connection_id)
 
             mock_handler.return_value.receive_offer.assert_called_once_with(
@@ -754,7 +757,10 @@ class TestV20CredManager(IsolatedAsyncioTestCase):
             ) as mock_retrieve,
             mock.patch.object(V20CredFormat.Format, "handler") as mock_handler,
         ):
-            mock_retrieve.side_effect = (StorageNotFoundError(),)
+            mock_retrieve.side_effect = (
+                StorageNotFoundError(),
+                StorageNotFoundError(),
+            )
             mock_handler.return_value.receive_request = mock.CoroutineMock()
 
             cx_rec = await self.manager.receive_request(cred_request, mock_conn, None)
@@ -834,7 +840,10 @@ class TestV20CredManager(IsolatedAsyncioTestCase):
             ) as mock_retrieve,
             mock.patch.object(V20CredFormat.Format, "handler") as mock_handler,
         ):
-            mock_retrieve.side_effect = (StorageNotFoundError(),)
+            mock_retrieve.side_effect = (
+                StorageNotFoundError(),
+                StorageNotFoundError(),
+            )
             mock_handler.return_value.receive_request = mock.CoroutineMock()
 
             cx_rec = await self.manager.receive_request(cred_request, mock_conn, None)
@@ -843,6 +852,99 @@ class TestV20CredManager(IsolatedAsyncioTestCase):
             mock_handler.return_value.receive_request.assert_called_once_with(
                 cx_rec, cred_request
             )
+
+    async def test_receive_request_connectionless_record_via_connection(self):
+        """Regression test for issue #3300 (self-issuance, bug #4).
+
+        An issuer exchange record created as an OOB attachment has no
+        connection_id. When the credential request later arrives over the
+        connection established by that same invitation and the OobRecord has
+        already been cleaned up (as happens in a self-connection), the record
+        must still be found by falling back to a thread/role-only lookup.
+        """
+        stored_cx_rec = V20CredExRecord(
+            cred_ex_id="dummy-cxid",
+            connection_id=None,
+            initiator=V20CredExRecord.INITIATOR_SELF,
+            role=V20CredExRecord.ROLE_ISSUER,
+            state=V20CredExRecord.STATE_OFFER_SENT,
+            thread_id="test_id",
+        )
+        cred_request = V20CredRequest(
+            formats=[
+                V20CredFormat(
+                    attach_id="0",
+                    format_=ATTACHMENT_FORMAT[CRED_20_REQUEST][
+                        V20CredFormat.Format.INDY.api
+                    ],
+                )
+            ],
+            requests_attach=[AttachDecorator.data_base64(INDY_CRED_REQ, ident="0")],
+        )
+        mock_conn = mock.MagicMock(connection_id="test_conn_id")
+
+        with (
+            mock.patch.object(V20CredExRecord, "save", autospec=True) as mock_save,
+            mock.patch.object(
+                V20CredExRecord, "retrieve_by_conn_and_thread", mock.CoroutineMock()
+            ) as mock_retrieve,
+            mock.patch.object(V20CredFormat.Format, "handler") as mock_handler,
+        ):
+            mock_retrieve.side_effect = (StorageNotFoundError(), stored_cx_rec)
+            mock_handler.return_value.receive_request = mock.CoroutineMock()
+
+            cx_rec = await self.manager.receive_request(cred_request, mock_conn, None)
+
+            assert mock_retrieve.call_count == 2
+            first_call, second_call = mock_retrieve.call_args_list
+            assert first_call.args[1] == "test_conn_id"
+            assert second_call.args[1] is None
+
+            mock_save.assert_called_once()
+            assert cx_rec is stored_cx_rec
+            assert cx_rec.connection_id == "test_conn_id"
+            assert cx_rec.state == V20CredExRecord.STATE_REQUEST_RECEIVED
+
+    async def test_receive_request_fallback_rejects_other_connection_record(self):
+        """The thread/role-only fallback must not adopt a record that is
+        already bound to a different connection.
+        """
+        stored_cx_rec = V20CredExRecord(
+            cred_ex_id="dummy-cxid",
+            connection_id="other_conn_id",
+            initiator=V20CredExRecord.INITIATOR_SELF,
+            role=V20CredExRecord.ROLE_ISSUER,
+            state=V20CredExRecord.STATE_OFFER_SENT,
+            thread_id="test_id",
+        )
+        cred_request = V20CredRequest(
+            formats=[
+                V20CredFormat(
+                    attach_id="0",
+                    format_=ATTACHMENT_FORMAT[CRED_20_REQUEST][
+                        V20CredFormat.Format.INDY.api
+                    ],
+                )
+            ],
+            requests_attach=[AttachDecorator.data_base64(INDY_CRED_REQ, ident="0")],
+        )
+        mock_conn = mock.MagicMock(connection_id="test_conn_id")
+
+        with (
+            mock.patch.object(V20CredExRecord, "save", autospec=True),
+            mock.patch.object(
+                V20CredExRecord, "retrieve_by_conn_and_thread", mock.CoroutineMock()
+            ) as mock_retrieve,
+            mock.patch.object(V20CredFormat.Format, "handler") as mock_handler,
+        ):
+            mock_retrieve.side_effect = (StorageNotFoundError(), stored_cx_rec)
+            mock_handler.return_value.receive_request = mock.CoroutineMock()
+            mock_handler.return_value.can_receive_request_without_offer = (
+                mock.MagicMock(return_value=False)
+            )
+
+            with self.assertRaises(StorageNotFoundError):
+                await self.manager.receive_request(cred_request, mock_conn, None)
 
     async def test_issue_credential_indy(self):
         connection_id = "test_conn_id"

--- a/docs/features/SelfIssuanceOOBFix.md
+++ b/docs/features/SelfIssuanceOOBFix.md
@@ -1,0 +1,125 @@
+# Self-Issuance / Self-Connection OOB and DID Exchange Fixes
+
+## Issue
+
+[openwallet-foundation/acapy#3300](https://github.com/openwallet-foundation/acapy/issues/3300)
+
+When an agent creates an out-of-band (OOB) invitation and receives that same
+invitation back into its own wallet — the "self-issuance" pattern, where an
+agent issues a credential to itself, or more generally any self-connection —
+two distinct errors could occur.
+
+### Bug 1: `StorageDuplicateError` (no prior handshake)
+
+Reproduction: create an OOB invitation with an attached credential offer (no
+`handshake_protocols`), then receive that invitation on the same wallet.
+
+```
+aries_cloudagent.storage.error.StorageDuplicateError: Multiple OobRecord
+records located for {'invi_msg_id': '...'}
+```
+
+**Cause:** `OobMessageProcessor.find_oob_record_for_inbound_message`
+(`acapy_agent/core/oob_processor.py`) looked up the `OobRecord` for an inbound
+message using only `invi_msg_id`:
+
+```python
+oob_record = await OobRecord.retrieve_by_tag_filter(
+    session,
+    {"invi_msg_id": context.message_receipt.parent_thread_id},
+)
+```
+
+In a self-connection, creating and then receiving the same invitation
+produces **two** `OobRecord`s that share the same `invi_msg_id`: one with
+`role=sender` (from `create-invitation`) and one with `role=receiver` (from
+`receive-invitation`). `retrieve_by_tag_filter` requires a unique match, so
+it raised `StorageDuplicateError` instead of returning either record.
+
+**Fix:** on `StorageDuplicateError`, disambiguate by message type. Some
+message types (a did-exchange `request`, or an RFC 0434 handshake-reuse
+message) are always sent by the *receiver* of an invitation back to the
+*sender*, and must be matched against the `role=sender` record. All other
+message types (e.g. an attached credential offer or presentation request)
+are sent by the sender to the receiver, and must be matched against the
+`role=receiver` record.
+
+### Bug 2: `DIDXManagerError` ("No corresponding connection request found")
+
+Reproduction: create an OOB invitation with `handshake_protocols` *and* an
+attached credential offer, then receive it back into the same wallet
+(the true self-issuance flow: establish a connection and deliver a
+credential offer in one invitation).
+
+```
+aries_cloudagent.protocols.didexchange.v1_0.manager.DIDXManagerError:
+No corresponding connection request found
+```
+
+**Cause:** in a self-connection, ACA-Py creates **two `ConnRecord`s in the
+same wallet** — one per did-exchange role (the wallet plays both the
+inviter/responder and the invitee/requester side of the same invitation).
+When the attached credential offer is processed,
+`find_oob_record_for_inbound_message`'s "connection reuse" cleanup logic
+(designed for the legitimate RFC 0434 case where an existing connection is
+reused instead of a stale, abandoned handshake attempt) saw that the
+inviter-side `ConnRecord`'s `connection_id` didn't match the inbound
+message's `connection_id`, assumed the inviter-side record was stale, and
+**deleted it**:
+
+```python
+LOGGER.debug(f"Removing stale connection {oob_record.connection_id} due to connection reuse")
+if oob_record.connection_id:
+    async with context.profile.session() as session:
+        old_conn_record = await ConnRecord.retrieve_by_id(session, oob_record.connection_id)
+        await old_conn_record.delete_record(session)
+```
+
+That record was not stale — it was the wallet's own other-role `ConnRecord`,
+still waiting for its own `DIDXComplete` message. Once deleted, the inbound
+`DIDXComplete` had no record to attach to, producing the error.
+
+**Fix:** before deleting, check whether the "old" and "new" connection
+records have **reciprocal DIDs** (`old.my_did == new.their_did` and
+`old.their_did == new.my_did`). This pattern only occurs when one wallet is
+playing both roles of the same connection (self-connection); two genuinely
+distinct parties' connections never end up with swapped-matching DIDs. When
+detected, skip the deletion — the genuine stale-connection cleanup path
+(distinct parties, non-reciprocal DIDs) is unchanged.
+
+### Supporting fix: redundant state saves
+
+`DIDXManager.receive_invitation` and `DIDXRequestHandler.handle` re-saved
+`ConnRecord.state` immediately after sending a request/response. In a
+self-connection, delivering that message can synchronously drive the rest of
+the handshake to completion (via `send_reply`/`send`) before the redundant
+save runs, regressing an already-completed connection back to an earlier
+state. `create_request`/`create_response` already persist the correct state
+before sending, so these extra saves were removed.
+
+## Verification
+
+Regression tests were added, parametrized across the `askar` and
+`askar-anoncreds` wallet backends (the fix has no wallet-backend-specific
+logic, and applies identically to `kanon-anoncreds`):
+
+- `acapy_agent/core/tests/test_oob_processor.py`
+  - `test_self_issuance_oob_attachment_without_connection` — bug 1
+  - `test_self_issuance_connectionless_full_round_trip` — full connectionless
+    self-issuance round trip
+  - `test_find_oob_record_for_inbound_message_self_connection_not_deleted` —
+    bug 2's actual root cause (reuse-cleanup misfire)
+  - `test_find_oob_record_for_inbound_message_sender_connection_id_no_match` —
+    pre-existing test confirming the genuine connection-reuse cleanup path
+    (distinct parties) is unaffected
+- `acapy_agent/protocols/didexchange/v1_0/tests/test_manager.py`
+  - `test_self_connection_didx_handshake_to_completion` — full self-connection
+    did-exchange handshake reaches `completed` for both of the wallet's own
+    `ConnRecord`s
+  - `test_two_party_didx_handshake_no_regression` — normal two-party
+    did-exchange handshake is unaffected
+
+Confirmed against a live self-issuance reproduction (OOB invitation with
+`handshake_protocols` + an attached credential offer, received into the same
+wallet) that previously produced the exact `DIDXManagerError` traceback from
+issue #3300; the error no longer occurs after this fix.


### PR DESCRIPTION
## Description

Fixes self-issuance / self-connection failures when an agent creates an out-of-band invitation and receives it back into its own wallet:

- **`StorageDuplicateError` in `find_oob_record_for_inbound_message`**: a self-connection produces two OobRecords (role=sender and role=receiver) sharing one `invi_msg_id`. Now disambiguated by the recipient verkey the message was delivered to, with a message-direction heuristic as fallback (didexchange request / handshake-reuse always belong to the role=sender record).
- **`DIDXManagerError` ("No corresponding connection request found") in `accept_complete`**: the OOB connection-reuse cleanup deleted the wallet's own mirror ConnRecord (reciprocal DIDs) while it was still awaiting its own DIDXComplete. The reciprocal-DID case is now detected and skipped; genuine stale-connection-reuse cleanup is unchanged.
- **ConnRecord state regression in self-connections**: removed two redundant post-send `ConnRecord.state` saves that could overwrite a state the (synchronous, self-addressed) delivery had already advanced.
- **`record-not-found` problem report for the holder's `request-credential`** (invitation with both a handshake protocol and an attached offer): after the handshake, the receiver-role OobRecord is deleted, so the inbound attached offer's pthid lookup matched and consumed the wallet's own role=sender OobRecord. A receiver-bound message-type guard now prevents attached offer / presentation-request messages from ever consuming a role=sender OobRecord. Additionally, `V20CredManager.receive_request` falls back to a thread/role-only lookup when the connection-filtered lookup misses (the issuer record was created connectionless), while rejecting records already bound to a different connection.

Normal two-party flows are unaffected: the OOB guard only fires when an inbound offer / presentation request resolves to the wallet's own role=sender record (impossible in a two-party exchange), and the `receive_request` fallback only runs where the previous code already failed with `StorageNotFoundError`.

Regression tests are included for every failure point, parametrized across askar and askar-anoncreds, including guards that normal two-party OOB / did-exchange flows still behave as before. Verified manually end-to-end in a multitenant deployment (invitation with handshake + attached offer received into the same wallet, through to the credential stored and both exchange records reaching `done`).

This is the `1.6.lts` backport of #4174 (same commits, cherry-picked; the fix was developed and manually verified end-to-end against 1.6).

## Related Issue

Relates to #3300 (closed by #4174)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have added/updated tests where applicable
- [x] I have updated documentation if needed
