### PR TITLE
1.3.lts docs: warn that the subwallet token endpoint invalidates previous tokens

### DIFF
--- a/acapy_agent/multitenant/admin/routes.py
+++ b/acapy_agent/multitenant/admin/routes.py
@@ -565,12 +565,24 @@ async def wallet_update(request: web.BaseRequest):
     return web.json_response(result)
 
 
-@docs(tags=["multitenancy"], summary="Get auth token for a subwallet")
+@docs(
+    tags=["multitenancy"],
+    summary="Get auth token for a subwallet",
+    description=(
+        "Issue a new auth token for a subwallet. Issuing a new token invalidates "
+        "any token previously issued for the wallet: only the most recently "
+        "issued token is valid. Do not call this endpoint if another client may "
+        "still be using a previously issued token for the wallet."
+    ),
+)
 @request_schema(CreateWalletTokenRequestSchema)
 @response_schema(CreateWalletTokenResponseSchema(), 200, description="")
 @admin_authentication
 async def wallet_create_token(request: web.BaseRequest):
     """Request handler for creating an authorization token for a specific subwallet.
+
+    Issuing a new token invalidates any token previously issued for the wallet;
+    only the most recently issued token is valid.
 
     Args:
         request: aiohttp request object


### PR DESCRIPTION
Backport of #4166 to `1.3.lts` (clean cherry-pick of 1a9b8d80, no conflicts).

Docs-only change to the subwallet token endpoint description in `acapy_agent/multitenant/admin/routes.py`; `acapy_agent/multitenant/admin/tests/test_routes.py` passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)