### PR TITLE
fix: require binary wheels for sqlcipher3-wheels in Dockerfile

### DIFF
--- a/acapy_agent/admin/tests/test_route_auth_coverage.py
+++ b/acapy_agent/admin/tests/test_route_auth_coverage.py
@@ -82,9 +82,7 @@ def _collect():
                 route = (
                     path_arg.value if isinstance(path_arg, ast.Constant) else "<dynamic>"
                 )
-                registrations.append(
-                    (handler.id, node.func.attr.upper(), route, path)
-                )
+                registrations.append((handler.id, node.func.attr.upper(), route, path))
 
     return registrations, defs_by_name
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update && \
 WORKDIR /src
 
 COPY ./pyproject.toml ./poetry.lock ./
-# need to install pysqlcipher3 first to ensure build dependencies are available
-RUN pip install --no-cache-dir sqlcipher3-wheels==0.5.5 && \
+# need to install sqlcipher3-wheels first (binary-only) before poetry install
+RUN pip install --no-cache-dir --only-binary=:all: sqlcipher3-wheels==0.5.5 && \
     poetry install --no-root
 
 COPY ./acapy_agent ./acapy_agent


### PR DESCRIPTION
## Description

Require `--only-binary=:all:` when installing `sqlcipher3-wheels==0.5.5` in `docker/Dockerfile` so pip cannot fall back to an sdist and run setup scripts.

Verified in `python:3.13-slim-bookworm` that the pinned version installs the manylinux cp313 wheel and imports successfully.

## Related Issue

Addresses SonarQube Quality Gate failure on main:
https://github.com/openwallet-foundation/acapy/runs/93617250341

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Chore / maintenance

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation if needed


Made with [Cursor](https://cursor.com)