### PR TITLE
fix: support JsonWebKey VMs in JWT verify via jwk_to_multikey

### DIFF
--- a/acapy_agent/admin/tests/test_route_auth_coverage.py
+++ b/acapy_agent/admin/tests/test_route_auth_coverage.py
@@ -82,9 +82,7 @@ def _collect():
                 route = (
                     path_arg.value if isinstance(path_arg, ast.Constant) else "<dynamic>"
                 )
-                registrations.append(
-                    (handler.id, node.func.attr.upper(), route, path)
-                )
+                registrations.append((handler.id, node.func.attr.upper(), route, path))
 
     return registrations, defs_by_name
 

--- a/acapy_agent/wallet/keys/manager.py
+++ b/acapy_agent/wallet/keys/manager.py
@@ -74,6 +74,9 @@ def jwk_to_multikey(jwk: Mapping) -> str:
 
     Supports OKP/Ed25519, OKP/X25519, and EC/P-256 — the curves used by
     ACA-Py JWT signing (EdDSA / ES256) and MultikeyManager.
+
+    Private key material (``d``) is ignored so this helper always treats the
+    input as a public key.
     """
     if not isinstance(jwk, Mapping):
         raise MultikeyManagerError("JWK must be a mapping.")
@@ -85,8 +88,11 @@ def jwk_to_multikey(jwk: Mapping) -> str:
             f"kty={jwk.get('kty')}, crv={jwk.get('crv')}."
         )
 
+    # Only pass public members to Askar.
+    public_jwk = {key: value for key, value in jwk.items() if key != "d"}
+
     try:
-        public_bytes = Key.from_jwk(dict(jwk)).get_public_bytes()
+        public_bytes = Key.from_jwk(public_jwk).get_public_bytes()
     except Exception as err:
         raise MultikeyManagerError(f"Unable to parse JWK: {err}") from err
 

--- a/acapy_agent/wallet/keys/manager.py
+++ b/acapy_agent/wallet/keys/manager.py
@@ -1,7 +1,9 @@
 """Multikey class."""
 
 import logging
+from typing import Mapping
 
+from aries_askar import Key
 from pydid import VerificationMethod
 
 from ...core.profile import ProfileSession
@@ -42,6 +44,13 @@ ALG_MAPPINGS = {
     },
 }
 
+# JWK kty/crv pairs supported for Multikey conversion (aligned with JWT algs).
+JWK_TO_ALG = {
+    ("OKP", "Ed25519"): "ed25519",
+    ("OKP", "X25519"): "x25519",
+    ("EC", "P-256"): "p256",
+}
+
 
 def multikey_to_verkey(multikey: str):
     """Transform multikey to verkey."""
@@ -58,6 +67,30 @@ def verkey_to_multikey(verkey: str, alg: str):
     prefixed_key_hex = f"{prefix_hex}{b58_to_bytes(verkey).hex()}"
 
     return multibase.encode(bytes.fromhex(prefixed_key_hex), "base58btc")
+
+
+def jwk_to_multikey(jwk: Mapping) -> str:
+    """Transform a public JWK to multikey.
+
+    Supports OKP/Ed25519, OKP/X25519, and EC/P-256 — the curves used by
+    ACA-Py JWT signing (EdDSA / ES256) and MultikeyManager.
+    """
+    if not isinstance(jwk, Mapping):
+        raise MultikeyManagerError("JWK must be a mapping.")
+
+    alg = JWK_TO_ALG.get((jwk.get("kty"), jwk.get("crv")))
+    if not alg:
+        raise MultikeyManagerError(
+            "Unsupported JWK for multikey conversion: "
+            f"kty={jwk.get('kty')}, crv={jwk.get('crv')}."
+        )
+
+    try:
+        public_bytes = Key.from_jwk(dict(jwk)).get_public_bytes()
+    except Exception as err:
+        raise MultikeyManagerError(f"Unable to parse JWK: {err}") from err
+
+    return verkey_to_multikey(bytes_to_b58(public_bytes), alg=alg)
 
 
 def key_type_from_multikey(multikey: str) -> KeyType:
@@ -90,7 +123,14 @@ def multikey_from_verification_method(verification_method: VerificationMethod) -
         multikey = verkey_to_multikey(
             verification_method.public_key_base58, alg="bls12381g2"
         )
-    # TODO address JsonWebKey based verification methods
+
+    elif verification_method.type in ("JsonWebKey2020", "JsonWebKey"):
+        jwk = verification_method.public_key_jwk
+        if not jwk:
+            raise MultikeyManagerError(
+                f"{verification_method.type} verification method missing publicKeyJwk."
+            )
+        multikey = jwk_to_multikey(jwk)
 
     else:
         raise MultikeyManagerError("Unknown verification method type.")

--- a/acapy_agent/wallet/keys/tests/test_key_operations.py
+++ b/acapy_agent/wallet/keys/tests/test_key_operations.py
@@ -1,7 +1,7 @@
 """Test MultikeypManager."""
 
 import json
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, mock
 
 import base58
 from aries_askar import Key, KeyAlg
@@ -17,7 +17,6 @@ from acapy_agent.wallet.keys.manager import (
     multikey_to_verkey,
     verkey_to_multikey,
 )
-from acapy_agent.wallet.util import bytes_to_b64
 
 
 class TestKeyOperations(IsolatedAsyncioTestCase):
@@ -114,7 +113,10 @@ class TestKeyOperations(IsolatedAsyncioTestCase):
             )
             jwk = json.loads(askar_key.get_jwk_public())
             assert jwk_to_multikey(jwk) == expected_multikey
-            assert jwk_to_multikey(jwk) == created["multikey"]
+
+            # Private material must be ignored for public conversion.
+            jwk_with_d = {**jwk, "d": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
+            assert jwk_to_multikey(jwk_with_d) == expected_multikey
 
     async def test_jwk_to_multikey_unsupported(self):
         with self.assertRaises(MultikeyManagerError):
@@ -156,18 +158,8 @@ class TestKeyOperations(IsolatedAsyncioTestCase):
             assert multikey_from_verification_method(vm) == created["multikey"]
 
     async def test_multikey_from_json_web_key_missing_jwk(self):
-        vm = JsonWebKey2020.deserialize(
-            {
-                "id": "did:web:example.com#key-01-jwk",
-                "type": "JsonWebKey2020",
-                "controller": "did:web:example.com",
-                "publicKeyJwk": {
-                    "kty": "OKP",
-                    "crv": "Ed25519",
-                    "x": bytes_to_b64(b"\x00" * 32, True),
-                },
-            }
-        )
-        object.__setattr__(vm, "public_key_jwk", None)
+        vm = mock.MagicMock(spec=VerificationMethod)
+        vm.type = "JsonWebKey2020"
+        vm.public_key_jwk = None
         with self.assertRaises(MultikeyManagerError):
             multikey_from_verification_method(vm)

--- a/acapy_agent/wallet/keys/tests/test_key_operations.py
+++ b/acapy_agent/wallet/keys/tests/test_key_operations.py
@@ -1,14 +1,23 @@
 """Test MultikeypManager."""
 
+import json
 from unittest import IsolatedAsyncioTestCase
+
+import base58
+from aries_askar import Key, KeyAlg
+from pydid.verification_method import JsonWebKey2020, VerificationMethod
 
 from acapy_agent.utils.testing import create_test_profile
 from acapy_agent.wallet.key_type import KeyTypes
 from acapy_agent.wallet.keys.manager import (
     MultikeyManager,
+    MultikeyManagerError,
+    jwk_to_multikey,
+    multikey_from_verification_method,
     multikey_to_verkey,
     verkey_to_multikey,
 )
+from acapy_agent.wallet.util import bytes_to_b64
 
 
 class TestKeyOperations(IsolatedAsyncioTestCase):
@@ -89,3 +98,76 @@ class TestKeyOperations(IsolatedAsyncioTestCase):
         ]:
             assert multikey_to_verkey(multikey) == verkey
             assert verkey_to_multikey(verkey, alg=alg) == multikey
+
+    async def test_jwk_to_multikey_ed25519_and_p256(self):
+        for alg, key_alg, expected_multikey in [
+            (self.ed25519_alg, KeyAlg.ED25519, self.ed25519_multikey),
+            (self.p256_alg, KeyAlg.P256, self.p256_multikey),
+        ]:
+            async with self.profile.session() as session:
+                created = await MultikeyManager(session=session).create(
+                    seed=self.seed, alg=alg
+                )
+
+            askar_key = Key.from_public_bytes(
+                key_alg, base58.b58decode(multikey_to_verkey(created["multikey"]))
+            )
+            jwk = json.loads(askar_key.get_jwk_public())
+            assert jwk_to_multikey(jwk) == expected_multikey
+            assert jwk_to_multikey(jwk) == created["multikey"]
+
+    async def test_jwk_to_multikey_unsupported(self):
+        with self.assertRaises(MultikeyManagerError):
+            jwk_to_multikey({"kty": "EC", "crv": "secp256k1", "x": "x", "y": "y"})
+        with self.assertRaises(MultikeyManagerError):
+            jwk_to_multikey("not-a-jwk")
+
+    async def test_multikey_from_json_web_key_verification_method(self):
+        async with self.profile.session() as session:
+            created = await MultikeyManager(session=session).create(
+                seed=self.seed, alg=self.ed25519_alg
+            )
+
+        askar_key = Key.from_public_bytes(
+            KeyAlg.ED25519,
+            base58.b58decode(multikey_to_verkey(created["multikey"])),
+        )
+        jwk = json.loads(askar_key.get_jwk_public())
+
+        for vm_type in ("JsonWebKey2020", "JsonWebKey"):
+            if vm_type == "JsonWebKey2020":
+                vm = JsonWebKey2020.deserialize(
+                    {
+                        "id": "did:web:example.com#key-01-jwk",
+                        "type": vm_type,
+                        "controller": "did:web:example.com",
+                        "publicKeyJwk": jwk,
+                    }
+                )
+            else:
+                vm = VerificationMethod.deserialize(
+                    {
+                        "id": "did:web:example.com#key-01-jwk",
+                        "type": vm_type,
+                        "controller": "did:web:example.com",
+                        "publicKeyJwk": jwk,
+                    }
+                )
+            assert multikey_from_verification_method(vm) == created["multikey"]
+
+    async def test_multikey_from_json_web_key_missing_jwk(self):
+        vm = JsonWebKey2020.deserialize(
+            {
+                "id": "did:web:example.com#key-01-jwk",
+                "type": "JsonWebKey2020",
+                "controller": "did:web:example.com",
+                "publicKeyJwk": {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": bytes_to_b64(b"\x00" * 32, True),
+                },
+            }
+        )
+        object.__setattr__(vm, "public_key_jwk", None)
+        with self.assertRaises(MultikeyManagerError):
+            multikey_from_verification_method(vm)

--- a/acapy_agent/wallet/tests/test_jwt.py
+++ b/acapy_agent/wallet/tests/test_jwt.py
@@ -1,7 +1,10 @@
+import json
 from typing import Tuple
 from unittest import IsolatedAsyncioTestCase
 
+import base58
 import pytest
+from aries_askar import Key, KeyAlg
 
 from acapy_agent.resolver.default.key import KeyDIDResolver
 
@@ -10,6 +13,7 @@ from ...resolver.tests.test_did_resolver import MockResolver
 from ...utils.testing import create_test_profile
 from ...wallet.did_method import KEY, DIDMethods
 from ...wallet.key_type import ED25519, P256, KeyType, KeyTypes
+from ...wallet.keys.manager import MultikeyManager, multikey_to_verkey
 from ..base import BaseWallet
 from ..default_verification_key_strategy import (
     BaseVerificationKeyStrategy,
@@ -187,3 +191,52 @@ class TestJWT(IsolatedAsyncioTestCase):
 
             with pytest.raises(Exception):
                 await jwt_verify(self.profile, signed)
+
+    async def test_sign_and_verify_with_json_web_key_verification_method(self):
+        """JWT verify must accept JsonWebKey2020 publicKeyJwk VMs (e.g. #key-01-jwk)."""
+        async with self.profile.session() as session:
+            created = await MultikeyManager(session=session).create(
+                seed=self.seed, alg="ed25519"
+            )
+            multikey = created["multikey"]
+            await MultikeyManager(session=session).update(
+                multikey, "did:web:example.com#key-01-jwk"
+            )
+
+        askar_key = Key.from_public_bytes(
+            KeyAlg.ED25519, base58.b58decode(multikey_to_verkey(multikey))
+        )
+        jwk = json.loads(askar_key.get_jwk_public())
+        vm_id = "did:web:example.com#key-01-jwk"
+        did_doc = {
+            "@context": [
+                "https://www.w3.org/ns/did/v1",
+                "https://w3id.org/security/suites/jws-2020/v1",
+            ],
+            "id": "did:web:example.com",
+            "verificationMethod": [
+                {
+                    "id": vm_id,
+                    "type": "JsonWebKey2020",
+                    "controller": "did:web:example.com",
+                    "publicKeyJwk": jwk,
+                }
+            ],
+            "assertionMethod": [vm_id],
+            "authentication": [vm_id],
+        }
+        resolver = DIDResolver()
+        resolver.register_resolver(
+            MockResolver(
+                ["web"],
+                resolved=did_doc,
+                native=True,
+            )
+        )
+        self.profile.context.injector.bind_instance(DIDResolver, resolver)
+
+        signed = await jwt_sign(self.profile, {}, {"hello": "world"}, None, vm_id)
+        result = await jwt_verify(self.profile, signed)
+        assert result.valid
+        assert result.kid == vm_id
+        assert result.payload == {"hello": "world"}

--- a/acapy_agent/wallet/tests/test_jwt.py
+++ b/acapy_agent/wallet/tests/test_jwt.py
@@ -194,49 +194,54 @@ class TestJWT(IsolatedAsyncioTestCase):
 
     async def test_sign_and_verify_with_json_web_key_verification_method(self):
         """JWT verify must accept JsonWebKey2020 publicKeyJwk VMs (e.g. #key-01-jwk)."""
-        async with self.profile.session() as session:
-            created = await MultikeyManager(session=session).create(
-                seed=self.seed, alg="ed25519"
-            )
-            multikey = created["multikey"]
-            await MultikeyManager(session=session).update(
-                multikey, "did:web:example.com#key-01-jwk"
-            )
+        for alg, key_alg in [
+            ("ed25519", KeyAlg.ED25519),
+            ("p256", KeyAlg.P256),
+        ]:
+            with self.subTest(alg=alg):
+                vm_id = f"did:web:example.com#key-01-{alg}-jwk"
+                async with self.profile.session() as session:
+                    created = await MultikeyManager(session=session).create(
+                        seed=self.seed, alg=alg
+                    )
+                    multikey = created["multikey"]
+                    await MultikeyManager(session=session).update(multikey, vm_id)
 
-        askar_key = Key.from_public_bytes(
-            KeyAlg.ED25519, base58.b58decode(multikey_to_verkey(multikey))
-        )
-        jwk = json.loads(askar_key.get_jwk_public())
-        vm_id = "did:web:example.com#key-01-jwk"
-        did_doc = {
-            "@context": [
-                "https://www.w3.org/ns/did/v1",
-                "https://w3id.org/security/suites/jws-2020/v1",
-            ],
-            "id": "did:web:example.com",
-            "verificationMethod": [
-                {
-                    "id": vm_id,
-                    "type": "JsonWebKey2020",
-                    "controller": "did:web:example.com",
-                    "publicKeyJwk": jwk,
+                askar_key = Key.from_public_bytes(
+                    key_alg, base58.b58decode(multikey_to_verkey(multikey))
+                )
+                jwk = json.loads(askar_key.get_jwk_public())
+                did_doc = {
+                    "@context": [
+                        "https://www.w3.org/ns/did/v1",
+                        "https://w3id.org/security/suites/jws-2020/v1",
+                    ],
+                    "id": "did:web:example.com",
+                    "verificationMethod": [
+                        {
+                            "id": vm_id,
+                            "type": "JsonWebKey2020",
+                            "controller": "did:web:example.com",
+                            "publicKeyJwk": jwk,
+                        }
+                    ],
+                    "assertionMethod": [vm_id],
+                    "authentication": [vm_id],
                 }
-            ],
-            "assertionMethod": [vm_id],
-            "authentication": [vm_id],
-        }
-        resolver = DIDResolver()
-        resolver.register_resolver(
-            MockResolver(
-                ["web"],
-                resolved=did_doc,
-                native=True,
-            )
-        )
-        self.profile.context.injector.bind_instance(DIDResolver, resolver)
+                resolver = DIDResolver()
+                resolver.register_resolver(
+                    MockResolver(
+                        ["web"],
+                        resolved=did_doc,
+                        native=True,
+                    )
+                )
+                self.profile.context.injector.bind_instance(DIDResolver, resolver)
 
-        signed = await jwt_sign(self.profile, {}, {"hello": "world"}, None, vm_id)
-        result = await jwt_verify(self.profile, signed)
-        assert result.valid
-        assert result.kid == vm_id
-        assert result.payload == {"hello": "world"}
+                signed = await jwt_sign(
+                    self.profile, {}, {"hello": "world", "alg": alg}, None, vm_id
+                )
+                result = await jwt_verify(self.profile, signed)
+                assert result.valid
+                assert result.kid == vm_id
+                assert result.payload == {"hello": "world", "alg": alg}


### PR DESCRIPTION
## Description

Add `jwk_to_multikey()` and wire it into `multikey_from_verification_method` for `JsonWebKey2020` / `JsonWebKey` verification methods.

This unblocks `/wallet/jwt/verify` when the JWT `kid` is a DID URL whose verification method uses `publicKeyJwk` (e.g. `did:web:…#key-01-jwk`), instead of failing on the previous TODO for JsonWebKey VMs.

Supported JWK curves: OKP/Ed25519, OKP/X25519, EC/P-256 (aligned with JWT EdDSA / ES256).

## Related Issue

Supports JWT verification against JWK verification methods used by Traction / `did:web` documents.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have added/updated tests where applicable
- [ ] I have updated documentation if needed


Made with [Cursor](https://cursor.com)