### PR TITLE
fix: fall back to default write ledger when persisted write_ledger is gone

### DIFF
--- a/acapy_agent/admin/tests/test_route_auth_coverage.py
+++ b/acapy_agent/admin/tests/test_route_auth_coverage.py
@@ -82,9 +82,7 @@ def _collect():
                 route = (
                     path_arg.value if isinstance(path_arg, ast.Constant) else "<dynamic>"
                 )
-                registrations.append(
-                    (handler.id, node.func.attr.upper(), route, path)
-                )
+                registrations.append((handler.id, node.func.attr.upper(), route, path))
 
     return registrations, defs_by_name
 

--- a/acapy_agent/utils/multi_ledger.py
+++ b/acapy_agent/utils/multi_ledger.py
@@ -39,13 +39,14 @@ def get_write_ledger_config_for_profile(settings: BaseSettings) -> dict:
         elif write_ledger in non_prod_write_ledger_pool:
             write_ledger_config = non_prod_write_ledger_pool.get(write_ledger)
         else:
-            error_message = (
-                "ledger.write_ledger in profile settings does not correspond to a "
-                "write configurable ledger provided with --genesis-transactions-list"
+            LOGGER.warning(
+                "ledger.write_ledger %s in profile settings does not correspond to "
+                "a write configurable ledger provided with "
+                "--genesis-transactions-list; falling back to the default "
+                "write ledger",
+                write_ledger,
             )
-            LOGGER.error(error_message)
-            raise ProfileError(error_message)
-    else:
+    if write_ledger_config is None:
         if len(prod_write_ledger_pool) >= 1:
             LOGGER.debug("Using first production write ledger")
             write_ledger_config = (list(prod_write_ledger_pool.values()))[0]

--- a/acapy_agent/utils/tests/test_multi_ledger.py
+++ b/acapy_agent/utils/tests/test_multi_ledger.py
@@ -1,0 +1,65 @@
+from unittest import TestCase
+
+from ...config.settings import Settings
+from ...core.error import ProfileError
+from ..multi_ledger import get_write_ledger_config_for_profile
+
+PROD_WRITE = {"id": "prod-write", "is_production": True, "is_write": True}
+PROD_READ_ONLY = {"id": "prod-read-only", "is_production": True, "read_only": True}
+NON_PROD_WRITE = {"id": "non-prod-write", "is_production": False, "is_write": True}
+NON_PROD_NEITHER = {"id": "non-prod-neither", "is_production": False}
+
+
+def make_settings(ledger_config_list, write_ledger=None) -> Settings:
+    settings = Settings({"ledger.ledger_config_list": ledger_config_list})
+    if write_ledger:
+        settings["ledger.write_ledger"] = write_ledger
+    return settings
+
+
+class TestGetWriteLedgerConfigForProfile(TestCase):
+    def test_write_ledger_in_prod_pool(self):
+        settings = make_settings([PROD_WRITE, NON_PROD_WRITE], write_ledger="prod-write")
+        assert get_write_ledger_config_for_profile(settings) == PROD_WRITE
+
+    def test_write_ledger_in_non_prod_pool(self):
+        settings = make_settings(
+            [PROD_WRITE, NON_PROD_WRITE], write_ledger="non-prod-write"
+        )
+        assert get_write_ledger_config_for_profile(settings) == NON_PROD_WRITE
+
+    def test_read_only_ledger_is_write_configurable(self):
+        settings = make_settings(
+            [PROD_WRITE, PROD_READ_ONLY], write_ledger="prod-read-only"
+        )
+        assert get_write_ledger_config_for_profile(settings) == PROD_READ_ONLY
+
+    def test_unconfigured_write_ledger_falls_back_to_prod_default(self):
+        # e.g. the ledger selected via set-write-ledger was later removed
+        # from --genesis-transactions-list
+        settings = make_settings(
+            [PROD_WRITE, NON_PROD_WRITE], write_ledger="decommissioned"
+        )
+        assert get_write_ledger_config_for_profile(settings) == PROD_WRITE
+
+    def test_unconfigured_write_ledger_falls_back_to_non_prod_default(self):
+        settings = make_settings([NON_PROD_WRITE], write_ledger="decommissioned")
+        assert get_write_ledger_config_for_profile(settings) == NON_PROD_WRITE
+
+    def test_no_write_ledger_uses_prod_default(self):
+        settings = make_settings([NON_PROD_WRITE, PROD_WRITE])
+        assert get_write_ledger_config_for_profile(settings) == PROD_WRITE
+
+    def test_no_write_ledger_uses_non_prod_default(self):
+        settings = make_settings([NON_PROD_NEITHER, NON_PROD_WRITE])
+        assert get_write_ledger_config_for_profile(settings) == NON_PROD_WRITE
+
+    def test_no_write_configurable_ledgers_raises(self):
+        settings = make_settings([NON_PROD_NEITHER])
+        with self.assertRaises(ProfileError):
+            get_write_ledger_config_for_profile(settings)
+
+    def test_unconfigured_write_ledger_no_default_raises(self):
+        settings = make_settings([NON_PROD_NEITHER], write_ledger="decommissioned")
+        with self.assertRaises(ProfileError):
+            get_write_ledger_config_for_profile(settings)


### PR DESCRIPTION
When a subwallet selects a write ledger via PUT /ledger/{id}/set-write-ledger, the choice is persisted into its wallet record settings. If that ledger is later removed from --genesis-transactions-list (or loses its is_write / read_only flags), get_write_ledger_config_for_profile raised ProfileError on every profile construction, leaving the tenant unusable and undeletable (remove_wallet builds the profile first) with no API path to amend the stale setting.

Treat the persisted value as a preference instead of an invariant: log a warning and fall back to the default write ledger selection. A configuration with no write-capable ledgers at all still raises ProfileError.

Adds unit tests for get_write_ledger_config_for_profile (previously uncovered).

Fixes #4193