### PR TITLE
1.6.lts fix: Add ruff check to GHA for this branch, updates to files failing ruff format check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 1.6.lts
 
 jobs:
   lint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         additional_dependencies: ['@commitlint/config-conventional']
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ensure this is synced with pyproject.toml
-    rev: v0.14.0
+    rev: v0.15.0
     hooks:
       # Run the linter
       - id: ruff

--- a/acapy_agent/admin/tests/test_route_auth_coverage.py
+++ b/acapy_agent/admin/tests/test_route_auth_coverage.py
@@ -82,9 +82,7 @@ def _collect():
                 route = (
                     path_arg.value if isinstance(path_arg, ast.Constant) else "<dynamic>"
                 )
-                registrations.append(
-                    (handler.id, node.func.attr.upper(), route, path)
-                )
+                registrations.append((handler.id, node.func.attr.upper(), route, path))
 
     return registrations, defs_by_name
 


### PR DESCRIPTION
Updates the workflow to invoke the ruff format check to include the lts branch, and makes code changes to the 1 file on the branch that fail the ruff format check. Also updates the pre-commit check to use the same version of ruff (0.15.0) as the format.yml GHA merge workflow.



Signed-off-by: Stephen Curran <swcurran@gmail.com>
