### PR TITLE
1.6.lts - cherry pick 4206 and activate Integration tests on branch

### DIFF
--- a/.github/workflows/scenario-integration-tests.yml
+++ b/.github/workflows/scenario-integration-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - main
+      - 1.6.lts
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:

--- a/scenarios/examples/json_ld/example.py
+++ b/scenarios/examples/json_ld/example.py
@@ -160,11 +160,11 @@ async def main():
         pause_for_input()
 
         with section("Present example ED25519 credential"):
-            alice_pres_ex, bob_pres_ex = await jsonld_present_proof_v2(
-                alice,
+            bob_pres_ex, alice_pres_ex = await jsonld_present_proof_v2(
                 bob,
-                alice_conn.connection_id,
+                alice,
                 bob_conn.connection_id,
+                alice_conn.connection_id,
                 presentation_definition={
                     "input_descriptors": [
                         {
@@ -242,11 +242,11 @@ async def main():
         pause_for_input()
 
         with section("Present example P256 credential"):
-            alice_pres_ex, bob_pres_ex = await jsonld_present_proof_v2(
-                alice,
+            bob_pres_ex, alice_pres_ex = await jsonld_present_proof_v2(
                 bob,
-                alice_conn.connection_id,
+                alice,
                 bob_conn.connection_id,
+                alice_conn.connection_id,
                 presentation_definition={
                     "input_descriptors": [
                         {
@@ -328,11 +328,11 @@ async def main():
         pause_for_input()
 
         with section("Present ED25519 quick context credential"):
-            alice_pres_ex, bob_pres_ex = await jsonld_present_proof_v2(
-                alice,
+            bob_pres_ex, alice_pres_ex = await jsonld_present_proof_v2(
                 bob,
-                alice_conn.connection_id,
+                alice,
                 bob_conn.connection_id,
+                alice_conn.connection_id,
                 presentation_definition={
                     "input_descriptors": [
                         {
@@ -410,11 +410,11 @@ async def main():
         pause_for_input()
 
         with section("Present BBS+ Credential with SD"):
-            alice_pres_ex, bob_pres_ex = await jsonld_present_proof_v2(
-                alice,
+            bob_pres_ex, alice_pres_ex = await jsonld_present_proof_v2(
                 bob,
-                alice_conn.connection_id,
+                alice,
                 bob_conn.connection_id,
+                alice_conn.connection_id,
                 presentation_definition={
                     "input_descriptors": [
                         {

--- a/scenarios/poetry.lock
+++ b/scenarios/poetry.lock
@@ -1015,6 +1015,22 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.6"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pytest_rerunfailures-16.6-py3-none-any.whl", hash = "sha256:6af2d1ebd6e5cb79666ac408942cd6a0672a49fefd8523664770718560795e13"},
+    {file = "pytest_rerunfailures-16.6.tar.gz", hash = "sha256:29dbfee46f542073c888e0ed4e81c51e15b9096f49a299eb1a759629c601684a"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=8.2,<8.2.2 || >8.2.2"
+
+[[package]]
 name = "pywin32"
 version = "308"
 description = "Python for Window Extensions"
@@ -1266,4 +1282,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "4a9b989b9e5928e55e2271472e3759661bcbb7ccb68b3200ec1e20ecc2ad7bb7"
+content-hash = "cb4aeb1f1342096cbd54e0d9661157fdd64592bdb7648ade51ce35fcba9595bc"

--- a/scenarios/pyproject.toml
+++ b/scenarios/pyproject.toml
@@ -13,9 +13,13 @@ docker = "7.2.0"
 pytest = "^8.4.2"
 pytest-asyncio = "^0.26.0"
 pydantic = "^2.13.0"
+pytest-rerunfailures = "^16.6"
 
 [tool.pytest.ini_options]
 markers = "examples: test the examples"
+# Retry only on transient failures talking to the shared public test ledger
+# (test.bcovrin.vonx.io), not on genuine scenario/assertion failures.
+addopts = '--reruns 1 --reruns-delay 10 --only-rerun "(?i)(pool timeout|ledger request error)"'
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Cherry pick of [PR 44206](https://github.com/openwallet-foundation/acapy/pull/4206) to fix a JSON-LD integration tests, and to add in-run retrying for ledger timeouts.

Also updates the Integration Test workflow to trigger on this 1.6.lts branch, as without that the rest of the PR is kinda useless...



Signed-off-by: Stephen Curran <swcurran@gmail.com>
