### PR TITLE
feat: full JSONPath support via jsonpath_ng.ext with a safety guard

### DIFF
--- a/acapy_agent/protocols/present_proof/dif/jsonpath_guard.py
+++ b/acapy_agent/protocols/present_proof/dif/jsonpath_guard.py
@@ -1,0 +1,57 @@
+"""Whitelist validator for JSONPath expressions in DIF field paths.
+
+Presentation requests are only secured at the DIDComm connection level —
+nothing validates the *content* of an incoming request. Since ACA-Py parses
+each field's JSONPath with ``jsonpath_ng.ext``, an untrusted sender could
+include a malformed or function-extension-based expression (``sub()``,
+``str()``, ``sorted()``, ``search()``, ``match()``, regex via ``=~``) that
+either crashes the whole presentation or evaluates logic we never intended
+to support.
+
+Rather than trying to detect "is this expression malicious," this module
+does the safer inverse: only expressions matching a fixed, narrow, known-safe
+grammar are accepted. Anything else — malicious or merely unsupported — is
+rejected the same way, before it ever reaches the real parser.
+"""
+
+import re
+
+_NAME = r"[A-Za-z_][A-Za-z0-9_-]*"
+_LITERAL = r"(?:-?\d+(?:\.\d+)?|'[^']*'|\"[^\"]*\"|true|false)"
+_OP = r"(?:<=|>=|==|!=|<|>)"
+_EXISTS = rf"@\.{_NAME}"
+_COND = rf"@\.{_NAME}\s*{_OP}\s*{_LITERAL}"
+_ONE_COND = rf"(?:{_COND}|{_EXISTS})"
+_FILTER = rf"\?\({_ONE_COND}(?:\s*&\s*{_ONE_COND})?\)"
+_SCRIPT_LEN = r"\(@\.length\s*-\s*\d+\)"
+_INDEX = r"-?\d+"
+_SLICE = r"-?\d*:-?\d*(?::-?\d*)?"
+_UNION = r"-?\d+(?:,\s*-?\d+)+"
+_BRACKET = rf"\[(?:\*|{_INDEX}|{_SLICE}|{_UNION}|{_FILTER}|{_SCRIPT_LEN})\]"
+_SEGMENT = rf"(?:\.\.(?:{_NAME}|\*)|\.(?:{_NAME}|\*)|{_BRACKET})"
+
+SAFE_JSONPATH_RE = re.compile(rf"^\$?{_SEGMENT}*$")
+
+MAX_PATH_LENGTH = 200
+MAX_SEGMENTS = 12
+
+
+def is_safe_jsonpath(path: str) -> bool:
+    """Return True if ``path`` matches the supported, known-safe JSONPath grammar.
+
+    Supports: child access, wildcard (``*``/``.*``), recursive descent
+    (``..name``/``..*``), index (``[n]``), slice (``[n:m]``), union
+    (``[n,m]``), the ``@.length-N`` script subscript, and filter expressions
+    (``[?(...)]``) limited to bare-existence or single-comparison conditions,
+    optionally joined by one ``&``.
+
+    Deliberately excludes: function-extension calls (``sub``, ``str``,
+    ``sorted``, ``search``, ``match``, ``filter``), the ``=~`` regex operator,
+    ``&&``, and anything else outside this grammar — including expressions
+    that are merely unsupported rather than actively malicious.
+    """
+    if not path or len(path) > MAX_PATH_LENGTH:
+        return False
+    if path.count(".") + path.count("[") > MAX_SEGMENTS * 2:
+        return False
+    return bool(SAFE_JSONPATH_RE.match(path))

--- a/acapy_agent/protocols/present_proof/dif/pres_exch.py
+++ b/acapy_agent/protocols/present_proof/dif/pres_exch.py
@@ -18,6 +18,13 @@ from ....vc.vc_ld.models.presentation import (
     VerifiablePresentation,
     VerifiablePresentationSchema,
 )
+from .jsonpath_guard import is_safe_jsonpath
+
+
+def _validate_path(path: str):
+    """Reject a field path outside the supported, known-safe JSONPath grammar."""
+    if not is_safe_jsonpath(path):
+        raise ValidationError(f"Unsupported or unsafe JSONPath expression: {path!r}")
 
 
 class ClaimFormat(BaseModel):
@@ -427,7 +434,11 @@ class DIFFieldSchema(BaseModelSchema):
 
     id = fields.Str(required=False, metadata={"description": "ID"})
     paths = fields.List(
-        fields.Str(required=False, metadata={"description": "Path"}),
+        fields.Str(
+            required=False,
+            validate=_validate_path,
+            metadata={"description": "Path"},
+        ),
         required=False,
         data_key="path",
     )

--- a/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 from dateutil import tz
 from dateutil.parser import ParserError
 from dateutil.parser import parse as dateutil_parser
-from jsonpath_ng import parse
+from jsonpath_ng.ext import parse
 from pyld import jsonld
 from pyld.jsonld import JsonLdProcessor
 from unflatten import unflatten

--- a/acapy_agent/protocols/present_proof/dif/tests/test_jsonpath_guard.py
+++ b/acapy_agent/protocols/present_proof/dif/tests/test_jsonpath_guard.py
@@ -1,0 +1,46 @@
+"""Tests for the JSONPath whitelist guard."""
+
+from unittest import TestCase
+
+from ..jsonpath_guard import MAX_PATH_LENGTH, is_safe_jsonpath
+
+VALID_PATHS = [
+    "$.credentialSubject.store.book[*].author",
+    "$.credentialSubject..author",
+    "$.credentialSubject.store.*",
+    "$.credentialSubject.store..price",
+    "$.credentialSubject.store.book[2]",
+    "$.credentialSubject.store.book[-1:]",
+    "$.credentialSubject.store.book[0,1]",
+    "$.credentialSubject.store.book[:2]",
+    "$.credentialSubject.store.book[?(@.isbn)].author",
+    "$.credentialSubject.store.book[?(@.price<10)].author",
+    "$.credentialSubject.store.book[?(@.price==8.95)].author",
+    "$.credentialSubject.store.book[?(@.price<30 & @.category=='fiction')].author",
+    "$.credentialSubject..*",
+    "$.credentialSubject.store.bicycle[?(@.color=='blue')].price",
+    "$.credentialSubject.store.book[(@.length-1)]",
+]
+
+MALICIOUS_OR_UNSUPPORTED_PATHS = [
+    "$.credentialSubject.store.book[?(sub(@.author,'.*','x')=='x')].title",
+    "$.credentialSubject..*[?(@.ssn =~ '^[0-9]{3}-[0-9]{2}-[0-9]{4}$')]",
+    '$.credentialSubject.store.book[?(@.price<30 && @.category=="fiction")].author',
+    "$.credentialSubject.store.book[?(__import__('os').system('id'))]",
+    "$.credentialSubject.store.book[?(str(@.price).length()>2)]",
+    "." * (MAX_PATH_LENGTH * 2),
+    "",
+    None,
+]
+
+
+class TestJsonPathGuard(TestCase):
+    """Whitelist behavior for DIF field paths."""
+
+    def test_valid_paths_are_accepted(self):
+        for path in VALID_PATHS:
+            assert is_safe_jsonpath(path), f"expected valid: {path!r}"
+
+    def test_malicious_or_unsupported_paths_are_rejected(self):
+        for path in MALICIOUS_OR_UNSUPPORTED_PATHS:
+            assert not is_safe_jsonpath(path), f"expected rejected: {path!r}"

--- a/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch.py
+++ b/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch.py
@@ -7,6 +7,7 @@ from .....messaging.models.base import BaseModelError
 from ..pres_exch import (
     ClaimFormat,
     Constraints,
+    DIFField,
     DIFHolder,
     Filter,
     SchemasInputDescriptorFilter,
@@ -433,3 +434,42 @@ class TestPresExchSchemas(TestCase):
         assert deser_schema_filter.uri_groups[0][0].uri == test_schema_list[0].get("uri")
         assert deser_schema_filter.uri_groups[0][1].uri == test_schema_list[1].get("uri")
         assert isinstance(deser_schema_filter, SchemasInputDescriptorFilter)
+
+    def test_dif_field_accepts_supported_jsonpath(self):
+        field_json = """
+            {
+                "path": ["$.credentialSubject.store.book[?(@.price<30 & @.category=='fiction')].author"]
+            }
+        """
+        deser_field = DIFField.deserialize(field_json)
+        assert isinstance(deser_field, DIFField)
+        assert deser_field.paths == [
+            "$.credentialSubject.store.book[?(@.price<30 & @.category=='fiction')].author"
+        ]
+
+    def test_dif_field_rejects_function_extension_jsonpath(self):
+        field_json = """
+            {
+                "path": ["$.credentialSubject.store.book[?(sub(@.author,'.*','x')=='x')].title"]
+            }
+        """
+        with self.assertRaises(BaseModelError):
+            DIFField.deserialize(field_json)
+
+    def test_dif_field_rejects_double_ampersand_jsonpath(self):
+        field_json = """
+            {
+                "path": ["$.credentialSubject.store.book[?(@.price<30 && @.category==\\"fiction\\")].author"]
+            }
+        """
+        with self.assertRaises(BaseModelError):
+            DIFField.deserialize(field_json)
+
+    def test_dif_field_rejects_regex_extension_jsonpath(self):
+        field_json = """
+            {
+                "path": ["$.credentialSubject..*[?(@.ssn =~ '^[0-9]{3}-[0-9]{2}-[0-9]{4}$')]"]
+            }
+        """
+        with self.assertRaises(BaseModelError):
+            DIFField.deserialize(field_json)


### PR DESCRIPTION
## Description

Same change as #4199, retargeted to `main` per @swcurran's request there ([comment](https://github.com/openwallet-foundation/acapy/pull/4199#issuecomment-5527157789)) so it can be cherry-picked to `1.6.lts` afterward instead of the other way around.

DIF field paths (`constraints.fields[].path`) are parsed with `jsonpath_ng`'s **base** grammar, which supports only 9 of the 14 example expressions in the DIF Presentation Exchange spec's own [JSONPath syntax table](https://identity.foundation/presentation-exchange/#jsonpath-syntax-definition) — filter expressions (`[?(...)]`) are a `jsonpath_ng.ext`-only feature and currently fail with `JsonPathLexerError: Unexpected character: ?`.

**This PR:**

1. Switches `pres_exch_handler.py` to `jsonpath_ng.ext.parse`, adding support for existence filters (`[?(@.isbn)]`), numeric/exact-match comparisons (`[?(@.price<10)]`, `[?(@.price==8.95)]`), and single-`&` compound conditions (`[?(@.price<30 & @.category=='fiction')]`). No new dependency — `jsonpath-ng` already ships the `.ext` module under the version already pinned in `pyproject.toml` (`^1.8.0`).

2. **Adds a whitelist validator** (`jsonpath_guard.is_safe_jsonpath`), wired into `DIFFieldSchema.paths`, because `jsonpath_ng.ext` also enables a materially larger attack surface than the base grammar — and presentation requests are only authenticated at the DIDComm connection level, with **no validation of content** once received.

### Why the safety guard is necessary, specifically

Per the DIF Presentation Exchange spec's own Security Considerations section:

> *"This specification recommends avoiding use of JSONPath's regular expression and function extension features if other approaches can achieve the same goal... If use is necessary, implementations should use proper security and execution time guards, e.g., through sandboxed execution with a timeout."*

`jsonpath_ng.ext` is exactly the "function extension" surface this warns about — it adds callable functions (`sub`, `str`, `sorted`, `search`, `match`) and a regex-match operator (`=~`) to the filter grammar. Two concrete, exploitable gaps result from enabling it without any content validation:

- **Unbounded processing / DoS surface.** A connected-but-untrusted party can submit a `path` invoking `search`/`match`/`=~` with a pathological regex, or an oversized/deeply-nested expression, and there is currently no size, complexity, or execution-time bound on what gets parsed and evaluated.
- **Unhandled-exception propagation.** `filter_by_field()` only catches `KeyError` around `parse(path)`, not `JsonPathParserError`. Any malformed expression in *any single field* — malicious or just a typo — propagates uncaught through `filter_constraints → apply_requirements → create_vp`, failing presentation creation for the **entire** request, including fields marked `"optional": true`.

Rather than trying to detect malicious intent in an expression, `jsonpath_guard.is_safe_jsonpath()` takes the DIF spec's recommended approach directly: define the narrow, known-safe grammar we actually support, and reject anything outside it, before it reaches the real parser at all.

### Testing

- New `tests/test_jsonpath_guard.py`: unit tests covering all 14 example expressions from the DIF spec's JSONPath table, plus representative malicious payloads (function-extension calls, `=~`, `&&`, code-shaped content, oversized input).
- Extended `tests/test_pres_exch.py`: schema-level tests confirming `DIFField.deserialize()` accepts a supported filter expression and rejects `sub()`, `&&`, and `=~` variants with a `BaseModelError`.
- Verified against every JSONPath expression already used across `acapy_agent/protocols/present_proof/`'s existing tests (69 distinct expressions) — none are rejected by the new validator.
- Fixed a `ruff format` violation in `test_jsonpath_guard.py` (quote style) that was flagged by CI on #4199; `ruff format --check .` and `ruff check` pass locally on the full tree.

### Out of scope (noted for maintainers, not addressed here)

- `Filter.pattern` (a separate, freeform regex field used for value matching) has its own regex-DoS risk independent of JSONPath and isn't touched by this PR.
- Structural/volume limits (field count per descriptor, `SubmissionRequirements.from_nested` recursion depth) are a different class of risk from expression *content* and are better suited to their own PR.

## Related Issue

Supersedes/retargets #4199 (which was opened against `1.6.lts`). Once this merges to `main`, I'll close #4199 or update it to be a cherry-pick.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Chore / maintenance

## Checklist

- [ ] I have read the Contributing Guide
- [x] My changes follow the existing code style
- [x] I have added/updated tests where applicable
- [ ] I have updated documentation if needed