### PR TITLE
fix: backport DIF holder presentation signing to 1.6 LTS

### DIFF
--- a/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/pres_exch_handler.py
@@ -210,7 +210,10 @@ class DIFPresExchHandler:
                 if not issuer_id:
                     for cred_subject_id in cred.subject_ids:
                         if not cred_subject_id.startswith("urn:"):
-                            did_info = await self._did_info_for_did(cred_subject_id)
+                            try:
+                                did_info = await self._did_info_for_did(cred_subject_id)
+                            except WalletError:
+                                continue
                             if did_info.key_type == reqd_key_type:
                                 issuer_id = cred_subject_id
                                 filtered_creds_list.append(cred.cred_value)
@@ -1284,39 +1287,36 @@ class DIFPresExchHandler:
             submission_property = PresentationSubmission(
                 id=str(uuid4()), definition_id=pd.id, descriptor_maps=descriptor_maps
             )
-            if self.is_holder or is_holder_override:
+            if self.pres_signing_did:
+                issuer_id = self.pres_signing_did
+                vp = await create_presentation(credentials=applicable_creds_list)
+            elif self.is_holder or is_holder_override:
                 (
                     issuer_id,
                     filtered_creds_list,
                 ) = await self.get_sign_key_credential_subject_id(
                     applicable_creds=applicable_creds
                 )
-                if not issuer_id and len(filtered_creds_list) == 0:
+                if not issuer_id:
+                    raise DIFPresExchError(
+                        "Unable to determine a local signing DID for the presentation"
+                    )
+                applicable_creds_list = filtered_creds_list
+                vp = await create_presentation(credentials=applicable_creds_list)
+            else:
+                (
+                    issuer_id,
+                    filtered_creds_list,
+                ) = await self.get_sign_key_credential_subject_id(
+                    applicable_creds=applicable_creds
+                )
+                if not issuer_id:
                     vp = await create_presentation(credentials=applicable_creds_list)
                     vp = self.__add_dif_fields_to_vp(vp, submission_property)
                     result_vp.append(vp)
                     continue
                 else:
                     applicable_creds_list = filtered_creds_list
-                    vp = await create_presentation(credentials=applicable_creds_list)
-            else:
-                if not self.pres_signing_did:
-                    (
-                        issuer_id,
-                        filtered_creds_list,
-                    ) = await self.get_sign_key_credential_subject_id(
-                        applicable_creds=applicable_creds
-                    )
-                    if not issuer_id:
-                        vp = await create_presentation(credentials=applicable_creds_list)
-                        vp = self.__add_dif_fields_to_vp(vp, submission_property)
-                        result_vp.append(vp)
-                        continue
-                    else:
-                        applicable_creds_list = filtered_creds_list
-                        vp = await create_presentation(credentials=applicable_creds_list)
-                else:
-                    issuer_id = self.pres_signing_did
                     vp = await create_presentation(credentials=applicable_creds_list)
             vp["presentation_submission"] = submission_property.serialize()
             if self.proof_type is BbsBlsSignature2020.signature_type:

--- a/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/acapy_agent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -2365,6 +2365,182 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
                 assert SECURITY_CONTEXT_BBS_URL in vp_single["@context"]
 
     @pytest.mark.ursa_bbs_signatures
+    async def test_create_vp_explicit_signing_did_in_holder_mode(self):
+        signing_did = "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
+        dif_pres_exch_handler = DIFPresExchHandler(
+            self.profile,
+            pres_signing_did=signing_did,
+            proof_type=BbsBlsSignature2020.signature_type,
+        )
+        cred_list, pd_list = await self.setup_tuple(self.profile)
+        requirement = mock.MagicMock(nested_req=None)
+        with (
+            mock.patch.object(
+                DIFPresExchHandler,
+                "make_requirement",
+                mock.CoroutineMock(return_value=requirement),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "apply_requirements",
+                mock.CoroutineMock(),
+            ) as mock_apply_req,
+            mock.patch.object(
+                DIFPresExchHandler,
+                "merge",
+                mock.CoroutineMock(),
+            ) as mock_merge,
+            mock.patch.object(
+                DIFPresExchHandler,
+                "get_sign_key_credential_subject_id",
+                mock.CoroutineMock(),
+            ) as mock_sign_key_cred_subject,
+            mock.patch.object(
+                DIFPresExchHandler,
+                "_get_issue_suite",
+                mock.CoroutineMock(),
+            ),
+            mock.patch.object(
+                test_module,
+                "create_presentation",
+                mock.CoroutineMock(),
+            ) as mock_create_vp,
+            mock.patch.object(
+                test_module,
+                "sign_presentation",
+                mock.CoroutineMock(),
+            ) as mock_sign_vp,
+        ):
+            mock_apply_req.return_value = mock.MagicMock()
+            mock_merge.return_value = (cred_list, {})
+            mock_create_vp.return_value = {
+                "test": "1",
+                "@context": ["test"],
+                "type": ["VerifiablePresentation"],
+            }
+            mock_sign_vp.return_value = {"test": "1"}
+            dif_pres_exch_handler.is_holder = True
+
+            vp = await dif_pres_exch_handler.create_vp(
+                cred_list,
+                pd=pd_list[0][0],
+                challenge="3fa85f64-5717-4562-b3fc-2c963f66afa7",
+                is_holder_override=True,
+            )
+
+            mock_sign_key_cred_subject.assert_not_awaited()
+            mock_sign_vp.assert_awaited_once()
+            assert vp["test"] == "1"
+
+    async def test_create_vp_auto_detects_local_ed25519_did(self):
+        signing_did = "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
+        dif_pres_exch_handler = DIFPresExchHandler(self.profile)
+        cred_list, pd_list = await self.setup_tuple(self.profile)
+        credential = deepcopy(cred_list[0])
+        credential.subject_ids = {"did:key:z6Mknot-local", signing_did}
+        did_info = DIDInfo(
+            did=signing_did,
+            verkey="verkey",
+            metadata={},
+            method=KEY,
+            key_type=ED25519,
+        )
+
+        async def did_info_for_did(did):
+            if did == "did:key:z6Mknot-local":
+                raise WalletNotFoundError()
+            return did_info
+
+        requirement = mock.MagicMock(nested_req=None)
+        with (
+            mock.patch.object(
+                DIFPresExchHandler,
+                "_did_info_for_did",
+                mock.CoroutineMock(side_effect=did_info_for_did),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "make_requirement",
+                mock.CoroutineMock(return_value=requirement),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "apply_requirements",
+                mock.CoroutineMock(return_value=mock.MagicMock()),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "merge",
+                mock.CoroutineMock(return_value=([credential], {})),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "_get_issue_suite",
+                mock.CoroutineMock(),
+            ),
+            mock.patch.object(
+                test_module,
+                "create_presentation",
+                mock.CoroutineMock(
+                    return_value={
+                        "@context": ["test"],
+                        "type": ["VerifiablePresentation"],
+                    }
+                ),
+            ),
+            mock.patch.object(
+                test_module,
+                "sign_presentation",
+                mock.CoroutineMock(return_value={"proof": {"type": "test"}}),
+            ) as mock_sign_vp,
+        ):
+            dif_pres_exch_handler.is_holder = True
+            vp = await dif_pres_exch_handler.create_vp(
+                [credential],
+                pd=pd_list[0][0],
+                challenge="3fa85f64-5717-4562-b3fc-2c963f66afa7",
+                is_holder_override=True,
+            )
+
+            mock_sign_vp.assert_awaited_once()
+            assert vp["proof"]["type"] == "test"
+
+    async def test_create_vp_holder_without_signing_did_fails(self):
+        dif_pres_exch_handler = DIFPresExchHandler(self.profile)
+        cred_list, pd_list = await self.setup_tuple(self.profile)
+        requirement = mock.MagicMock(nested_req=None)
+        with (
+            mock.patch.object(
+                DIFPresExchHandler,
+                "make_requirement",
+                mock.CoroutineMock(return_value=requirement),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "apply_requirements",
+                mock.CoroutineMock(return_value=mock.MagicMock()),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "merge",
+                mock.CoroutineMock(return_value=(cred_list, {})),
+            ),
+            mock.patch.object(
+                DIFPresExchHandler,
+                "get_sign_key_credential_subject_id",
+                mock.CoroutineMock(return_value=(None, [])),
+            ),
+        ):
+            dif_pres_exch_handler.is_holder = True
+            with pytest.raises(DIFPresExchError, match="local signing DID"):
+                await dif_pres_exch_handler.create_vp(
+                    cred_list,
+                    pd=pd_list[0][0],
+                    challenge="3fa85f64-5717-4562-b3fc-2c963f66afa7",
+                    is_holder_override=True,
+                )
+
+    @pytest.mark.ursa_bbs_signatures
     async def test_create_vp_no_issuer_with_bbs_suite(self):
         dif_pres_exch_handler = DIFPresExchHandler(
             self.profile, proof_type=BbsBlsSignature2020.signature_type
@@ -3224,18 +3400,17 @@ class TestPresExchangeHandler(IsolatedAsyncioTestCase):
         assert tmp_vp.get("proof")
 
     @pytest.mark.ursa_bbs_signatures
-    async def test_is_holder_signature_suite_mismatch(self):
+    async def test_is_holder_signature_suite_mismatch_fails(self):
         dif_pres_exch_handler = DIFPresExchHandler(
             self.profile, proof_type=BbsBlsSignature2020.signature_type
         )
         cred_list, _ = await self.setup_tuple(self.profile)
-        tmp_vp = await dif_pres_exch_handler.create_vp(
-            credentials=cred_list,
-            pd=is_holder_pd,
-            challenge="1f44d55f-f161-4938-a659-f8026467f126",
-        )
-        assert len(tmp_vp.get("verifiableCredential")) == 6
-        assert not tmp_vp.get("proof")
+        with pytest.raises(DIFPresExchError, match="local signing DID"):
+            await dif_pres_exch_handler.create_vp(
+                credentials=cred_list,
+                pd=is_holder_pd,
+                challenge="1f44d55f-f161-4938-a659-f8026467f126",
+            )
 
     @pytest.mark.ursa_bbs_signatures
     async def test_is_holder_subject_mismatch(self):

--- a/acapy_agent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -144,6 +144,7 @@ class DIFPresFormatHandler(V20PresFormatHandler):
             DIFPresFormatHandler.format
         )
 
+        issuer_id = None
         pres_definition = None
         limit_record_ids = None
         reveal_doc_frame = None
@@ -161,7 +162,6 @@ class DIFPresFormatHandler(V20PresFormatHandler):
             pres_definition = PresentationDefinition.deserialize(
                 proof_request.get("presentation_definition")
             )
-            issuer_id = None
         if "options" in proof_request:
             challenge = proof_request["options"].get("challenge")
             domain = proof_request["options"].get("domain")

--- a/acapy_agent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/acapy_agent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -575,17 +575,27 @@ class TestDIFFormatHandler(IsolatedAsyncioTestCase):
             error_msg="error",
         )
 
-        with mock.patch.object(
-            DIFPresExchHandler,
-            "create_vp",
-            mock.CoroutineMock(),
-        ) as mock_create_vp:
+        with (
+            mock.patch.object(
+                DIFPresExchHandler,
+                "__init__",
+                return_value=None,
+            ) as mock_handler_init,
+            mock.patch.object(
+                DIFPresExchHandler,
+                "create_vp",
+                mock.CoroutineMock(),
+            ) as mock_create_vp,
+        ):
             mock_create_vp.return_value = DIF_PRES
-            output = await self.handler.create_pres(record, {})
+            output = await self.handler.create_pres(
+                record, {"dif": {"issuer_id": TEST_DID_KEY}}
+            )
             assert isinstance(output[0], V20PresFormat) and isinstance(
                 output[1], AttachDecorator
             )
             assert output[1].data.json_ == DIF_PRES
+            assert mock_handler_init.call_args.kwargs["pres_signing_did"] == TEST_DID_KEY
 
     async def test_create_pres_pd_schema_uri(self):
         dif_pres_req = deepcopy(DIF_PRES_REQUEST_B)


### PR DESCRIPTION
Backports #4196 to `1.6.lts`, as requested in https://github.com/openwallet-foundation/acapy/pull/4196#issuecomment-5531736939.

Preserves an explicit `issuer_id` when reusing the requested presentation definition, honors an explicit `pres_signing_did` in holder mode, and skips non-local subject DIDs during local signing-key discovery. Holder mode now raises `DIFPresExchError` when no local signing DID is available, instead of returning an unsigned presentation.

The four-file patch is identical to the net change in merge commit c148063f307ba33a41402ed1b73e241c07dd55c4 (matching stable patch ID), including the corrected regression tests. No dependency or unrelated main-branch changes are included.

Validation on Python 3.13, using this LTS branch's locked dependencies 
